### PR TITLE
docs: update SecFrame references and add SCF database

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ CheckID/
 1. **This is a shared library** -- M365-Assess, Stitch-M365, and Darn consume it via git submodule.
    After any change, consumers must bump their submodule pointer.
 2. **After modifying CSVs**, run `scripts/Build-Registry.ps1` to regenerate `data/registry.json`.
-3. **SecFrame is upstream** -- framework mapping data originates from `C:\git\SecFrame`. See REFERENCES.md.
+3. **SecFrame is upstream** -- framework mapping data originates from [SecFrame](https://github.com/SelvageLabs/SecFrame). See REFERENCES.md.
 4. **Do not add consumer-specific code** -- report generators, orchestrators, and collectors belong
    in their respective consumer repos, not here.
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -10,6 +10,8 @@ for security framework reference data. CheckID's framework mappings are derived 
 | `CIS/CIS_M365_to_NIST_to_FedRAMP_Crosswalk.csv` | CIS M365 to NIST 800-53 to FedRAMP mappings |
 | `SOC/tsc_to_nist_800-53.xlsx` | SOC 2 Trust Services Criteria to NIST 800-53 |
 | `SCF/secure-controls-framework-scf-2025-4.csv` | Master cross-framework mapping (80+ frameworks) |
+| `SCF/scf.db` | Normalized SQLite database (13 tables, 261 frameworks, 66K+ mappings) |
+| `SCF/checkid-framework-export.csv` | CheckID-compatible flat export from SCF database |
 | `NIST/csf-pf-to-sp800-53r5-mappings.xlsx` | NIST CSF 2.0 to NIST 800-53 R5 |
 
 ### Update Workflow


### PR DESCRIPTION
## Summary

- Fix hardcoded `C:\git\SecFrame` local path in CLAUDE.md → GitHub URL
- Add `SCF/scf.db` and `SCF/checkid-framework-export.csv` to upstream file table in REFERENCES.md

These files are now available in SecFrame (PR SelvageLabs/SecFrame#28) and will be used in M3 for framework expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)