### PR TITLE
feat: M4 Module Packaging — PSGallery-ready module

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+    tags: ['v*']
 
 jobs:
   lint:
@@ -198,3 +199,67 @@ jobs:
             Write-Host "::error::$($result.FailedCount) test(s) failed"
             exit 1
           }
+
+  module-test:
+    name: Module Import Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test module manifest
+        shell: pwsh
+        run: |
+          $manifest = Test-ModuleManifest -Path ./CheckID.psd1
+          Write-Host "Module: $($manifest.Name) v$($manifest.Version)"
+          Write-Host "Exported functions: $($manifest.ExportedFunctions.Keys -join ', ')"
+          if ($manifest.ExportedFunctions.Count -ne 4) {
+            Write-Host "::error::Expected 4 exported functions, got $($manifest.ExportedFunctions.Count)"
+            exit 1
+          }
+
+      - name: Test module import and basic operations
+        shell: pwsh
+        run: |
+          Import-Module ./CheckID.psd1 -Force
+          $checks = Get-CheckRegistry
+          Write-Host "Loaded $($checks.Count) checks"
+          if ($checks.Count -lt 233) {
+            Write-Host "::error::Expected at least 233 checks"
+            exit 1
+          }
+          $check = Get-CheckById 'ENTRA-ADMIN-001'
+          if (-not $check) {
+            Write-Host "::error::Get-CheckById failed for ENTRA-ADMIN-001"
+            exit 1
+          }
+          Write-Host "Module import and basic operations OK"
+
+  publish:
+    name: Publish to PSGallery
+    runs-on: ubuntu-latest
+    needs: [lint, validate-data, registry-consistency, data-quality, test, module-test]
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate tag matches manifest version
+        shell: pwsh
+        run: |
+          $tag = '${{ github.ref_name }}' -replace '^v', ''
+          $manifest = Test-ModuleManifest -Path ./CheckID.psd1
+          if ($manifest.Version.ToString() -ne $tag) {
+            Write-Host "::error::Tag version ($tag) does not match manifest version ($($manifest.Version))"
+            exit 1
+          }
+          Write-Host "Tag v$tag matches manifest version"
+
+      - name: Publish module
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
+        run: |
+          if (-not $env:NUGET_API_KEY) {
+            Write-Host "::error::PSGALLERY_API_KEY secret not set"
+            exit 1
+          }
+          Publish-Module -Path . -NuGetApiKey $env:NUGET_API_KEY -Verbose

--- a/CheckID.psd1
+++ b/CheckID.psd1
@@ -1,0 +1,50 @@
+@{
+    # Module metadata
+    RootModule        = 'CheckID.psm1'
+    ModuleVersion     = '1.0.0'
+    GUID              = 'a3b7c4d5-1e2f-4a5b-8c9d-0e1f2a3b4c5d'
+    Author            = 'SelvageLabs'
+    CompanyName       = 'SelvageLabs'
+    Copyright         = '(c) SelvageLabs. All rights reserved. MIT License.'
+    Description       = 'Stable, unique identifiers for security configuration checks mapped across 14 compliance frameworks.'
+
+    # Requirements
+    PowerShellVersion = '7.0'
+
+    # Exported members
+    FunctionsToExport = @(
+        'Get-CheckRegistry'
+        'Get-CheckById'
+        'Search-Check'
+        'Test-CheckRegistryData'
+    )
+    CmdletsToExport   = @()
+    VariablesToExport  = @()
+    AliasesToExport    = @()
+
+    # Module data
+    FileList = @(
+        'CheckID.psd1'
+        'CheckID.psm1'
+        'data/registry.json'
+        'data/framework-titles.json'
+        'data/derived-mappings.json'
+        'data/framework-mappings.csv'
+        'data/check-id-mapping.csv'
+        'data/standalone-checks.json'
+        'data/frameworks/cis-m365-v6.json'
+        'data/frameworks/soc2-tsc.json'
+        'scripts/Import-ControlRegistry.ps1'
+        'scripts/Search-Registry.ps1'
+        'scripts/Test-RegistryData.ps1'
+    )
+
+    PrivateData = @{
+        PSData = @{
+            Tags         = @('Security', 'Compliance', 'CheckID', 'NIST', 'CIS', 'ISO27001', 'HIPAA', 'SOC2', 'FedRAMP', 'M365')
+            LicenseUri   = 'https://github.com/SelvageLabs/CheckID/blob/main/LICENSE'
+            ProjectUri   = 'https://github.com/SelvageLabs/CheckID'
+            ReleaseNotes = 'Initial module release. 233 checks across 14 compliance frameworks.'
+        }
+    }
+}

--- a/CheckID.psm1
+++ b/CheckID.psm1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+    CheckID PowerShell module — stable identifiers for security checks mapped
+    across compliance frameworks.
+.DESCRIPTION
+    Provides cmdlets to load, query, and validate the CheckID registry.
+    Wraps the existing script-based functionality into proper module exports.
+#>
+
+# Module-scoped registry cache
+$script:RegistryCache = $null
+$script:ModuleRoot = $PSScriptRoot
+
+function Get-CheckRegistry {
+    <#
+    .SYNOPSIS
+        Loads the CheckID registry and returns all checks.
+    .DESCRIPTION
+        Reads data/registry.json and returns the full check collection.
+        Results are cached for the session — call with -Force to reload.
+    .PARAMETER Force
+        Bypass the cache and reload from disk.
+    .OUTPUTS
+        PSCustomObject[] — array of check objects from registry.json.
+    .EXAMPLE
+        $checks = Get-CheckRegistry
+        $checks | Where-Object { $_.hasAutomatedCheck } | Measure-Object
+    #>
+    [CmdletBinding()]
+    param(
+        [switch]$Force
+    )
+
+    if ($script:RegistryCache -and -not $Force) {
+        return $script:RegistryCache
+    }
+
+    $registryPath = Join-Path $script:ModuleRoot 'data' 'registry.json'
+    if (-not (Test-Path $registryPath)) {
+        Write-Error "Registry not found: $registryPath"
+        return
+    }
+
+    $raw = Get-Content -Path $registryPath -Raw | ConvertFrom-Json
+    $script:RegistryCache = $raw.checks
+    return $script:RegistryCache
+}
+
+function Get-CheckById {
+    <#
+    .SYNOPSIS
+        Looks up a single check by its CheckId.
+    .PARAMETER CheckId
+        The CheckId to look up (e.g., ENTRA-ADMIN-001).
+    .OUTPUTS
+        PSCustomObject — the matching check, or $null if not found.
+    .EXAMPLE
+        Get-CheckById -CheckId ENTRA-ADMIN-001
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$CheckId
+    )
+
+    $checks = Get-CheckRegistry
+    return $checks | Where-Object { $_.checkId -eq $CheckId }
+}
+
+function Search-Check {
+    <#
+    .SYNOPSIS
+        Searches the CheckID registry by framework, control ID, or keyword.
+    .PARAMETER Framework
+        Filter to checks mapped to this framework key (e.g., hipaa, soc2).
+    .PARAMETER ControlId
+        Search for checks containing this control ID substring.
+    .PARAMETER Keyword
+        Search check names for this keyword (case-insensitive).
+    .OUTPUTS
+        PSCustomObject[] — matching check objects.
+    .EXAMPLE
+        Search-Check -Framework hipaa -Keyword 'password'
+    .EXAMPLE
+        Search-Check -ControlId 'AC-6'
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Framework,
+
+        [Parameter()]
+        [string]$ControlId,
+
+        [Parameter(Position = 0)]
+        [string]$Keyword
+    )
+
+    $checks = Get-CheckRegistry
+
+    if ($Framework) {
+        $checks = $checks | Where-Object {
+            $_.frameworks.PSObject.Properties.Name -contains $Framework
+        }
+    }
+
+    if ($ControlId) {
+        $checks = $checks | Where-Object {
+            $found = $false
+            foreach ($fwProp in $_.frameworks.PSObject.Properties) {
+                if ($Framework -and $fwProp.Name -ne $Framework) { continue }
+                if ($fwProp.Value.controlId -like "*$ControlId*") {
+                    $found = $true
+                    break
+                }
+            }
+            $found
+        }
+    }
+
+    if ($Keyword) {
+        $checks = $checks | Where-Object {
+            $_.name -like "*$Keyword*"
+        }
+    }
+
+    return @($checks)
+}
+
+function Test-CheckRegistryData {
+    <#
+    .SYNOPSIS
+        Runs data quality validation checks against the registry.
+    .DESCRIPTION
+        Wrapper around scripts/Test-RegistryData.ps1. Returns $true if all
+        checks pass, $false otherwise.
+    .OUTPUTS
+        Boolean — $true if all validation checks pass.
+    .EXAMPLE
+        if (-not (Test-CheckRegistryData)) { Write-Error "Registry validation failed" }
+    #>
+    [CmdletBinding()]
+    param()
+
+    $scriptPath = Join-Path $script:ModuleRoot 'scripts' 'Test-RegistryData.ps1'
+    if (-not (Test-Path $scriptPath)) {
+        Write-Error "Validation script not found: $scriptPath"
+        return $false
+    }
+
+    & $scriptPath -DataPath (Join-Path $script:ModuleRoot 'data')
+    return $LASTEXITCODE -eq 0
+}
+
+# Export module members
+Export-ModuleMember -Function @(
+    'Get-CheckRegistry'
+    'Get-CheckById'
+    'Search-Check'
+    'Test-CheckRegistryData'
+)

--- a/README.md
+++ b/README.md
@@ -17,13 +17,33 @@ CheckID starts with M365 but is designed to expand. The identifier format, regis
 
 ## Quick Start
 
-### Add as a git submodule
+### Install from PSGallery (recommended)
+
+```powershell
+Install-Module -Name CheckID -Scope CurrentUser
+```
+
+```powershell
+# Load all checks
+$checks = Get-CheckRegistry
+
+# Look up a specific check
+$check = Get-CheckById 'ENTRA-ADMIN-001'
+$check.name          # "Ensure that between two and four global admins are designated"
+$check.frameworks    # All framework mappings with titles
+
+# Search by framework, control ID, or keyword
+Search-Check -Framework 'hipaa' -Keyword 'password'
+Search-Check -ControlId 'AC-6'
+```
+
+### Add as a git submodule (legacy)
+
+> The submodule approach still works and will continue to be supported during the transition period. New projects should prefer `Install-Module`.
 
 ```bash
 git submodule add https://github.com/SelvageLabs/CheckID.git lib/CheckID
 ```
-
-### Load the registry in PowerShell
 
 ```powershell
 # Dot-source the loader
@@ -34,7 +54,7 @@ $registry = Import-ControlRegistry -ControlsPath ./lib/CheckID/data
 
 # Look up a specific check
 $check = $registry['ENTRA-ADMIN-001']
-$check.name          # "Ensure Administrative accounts are cloud-only"
+$check.name          # "Ensure that between two and four global admins are designated"
 $check.frameworks    # Hashtable of all framework mappings
 ```
 

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -24,10 +24,37 @@ for security framework reference data. CheckID's framework mappings are derived 
 
 ## Downstream Consumers
 
-These projects consume CheckID as a git submodule:
+These projects consume CheckID. All currently use git submodules; migration to the
+PSGallery module is in progress.
 
-| Project | Repository | Submodule Path | What They Use |
+| Project | Repository | Current Method | Target Method |
 |---------|-----------|---------------|--------------|
-| **M365-Assess** | [github.com/SelvageLabs/M365-Assess](https://github.com/SelvageLabs/M365-Assess) | `lib/CheckID/` | Full library (scripts + data) |
-| **Stitch-M365** | Private | `Engine/lib/CheckID/` | Full library (scripts + data) |
-| **Darn** | [github.com/SelvageLabs/Darn](https://github.com/SelvageLabs/Darn) | `lib/CheckID/` | Data only (`data/registry.json`) |
+| **M365-Assess** | [SelvageLabs/M365-Assess](https://github.com/SelvageLabs/M365-Assess) | Submodule (`lib/CheckID/`) | `Install-Module CheckID` |
+| **Stitch-M365** | Private | Submodule (`Engine/lib/CheckID/`) | `Install-Module CheckID` |
+| **Darn** | [SelvageLabs/Darn](https://github.com/SelvageLabs/Darn) | Submodule (`lib/CheckID/`) | `Install-Module CheckID` |
+
+### Migration: Submodule to PSGallery Module
+
+**For consumers migrating from git submodule to `Install-Module`:**
+
+1. Install the module: `Install-Module -Name CheckID -Scope CurrentUser`
+2. Replace dot-source imports:
+   ```powershell
+   # Before (submodule)
+   . ./lib/CheckID/scripts/Import-ControlRegistry.ps1
+   $registry = Import-ControlRegistry -ControlsPath ./lib/CheckID/data
+   $check = $registry['ENTRA-ADMIN-001']
+
+   # After (module)
+   Import-Module CheckID
+   $check = Get-CheckById 'ENTRA-ADMIN-001'
+   # Or load all checks:
+   $checks = Get-CheckRegistry
+   ```
+3. Replace script calls with module cmdlets:
+   - `Import-ControlRegistry` → `Get-CheckRegistry` / `Get-CheckById`
+   - `Search-Registry.ps1` → `Search-Check`
+   - `Test-RegistryData.ps1` → `Test-CheckRegistryData`
+4. Remove the submodule: `git submodule deinit lib/CheckID && git rm lib/CheckID`
+
+Both approaches work simultaneously during the transition period.

--- a/tests/module.Tests.ps1
+++ b/tests/module.Tests.ps1
@@ -1,0 +1,109 @@
+BeforeAll {
+    $modulePath = "$PSScriptRoot/../CheckID.psd1"
+    Import-Module $modulePath -Force
+}
+
+AfterAll {
+    Remove-Module CheckID -ErrorAction SilentlyContinue
+}
+
+Describe 'CheckID Module' {
+
+    It 'Loads successfully with correct version' {
+        $mod = Get-Module CheckID
+        $mod | Should -Not -BeNullOrEmpty
+        $mod.Version | Should -Be '1.0.0'
+    }
+
+    It 'Exports exactly the expected functions' {
+        $mod = Get-Module CheckID
+        $exported = $mod.ExportedFunctions.Keys | Sort-Object
+        $expected = @('Get-CheckById', 'Get-CheckRegistry', 'Search-Check', 'Test-CheckRegistryData') | Sort-Object
+        $exported | Should -Be $expected
+    }
+
+    It 'Does not export internal helpers' {
+        $mod = Get-Module CheckID
+        $mod.ExportedFunctions.Keys | Should -Not -Contain 'Resolve-FrameworkTitle'
+        $mod.ExportedFunctions.Keys | Should -Not -Contain 'Get-Soc2CriteriaFromNist'
+    }
+}
+
+Describe 'Get-CheckRegistry' {
+
+    It 'Returns all checks from the registry' {
+        $checks = Get-CheckRegistry
+        $checks.Count | Should -BeGreaterOrEqual 233
+    }
+
+    It 'Returns cached results on second call' {
+        $first = Get-CheckRegistry
+        $second = Get-CheckRegistry
+        $first.Count | Should -Be $second.Count
+    }
+
+    It 'Reloads from disk with -Force' {
+        $checks = Get-CheckRegistry -Force
+        $checks.Count | Should -BeGreaterOrEqual 233
+    }
+}
+
+Describe 'Get-CheckById' {
+
+    It 'Returns a check by exact CheckId' {
+        $check = Get-CheckById 'ENTRA-ADMIN-001'
+        $check | Should -Not -BeNullOrEmpty
+        $check.checkId | Should -Be 'ENTRA-ADMIN-001'
+    }
+
+    It 'Returns null for non-existent CheckId' {
+        $check = Get-CheckById 'DOES-NOT-EXIST-999'
+        $check | Should -BeNullOrEmpty
+    }
+}
+
+Describe 'Search-Check' {
+
+    It 'Filters by framework' {
+        $results = Search-Check -Framework 'stig'
+        $results.Count | Should -BeGreaterThan 0
+        foreach ($r in $results) {
+            $r.frameworks.PSObject.Properties.Name | Should -Contain 'stig'
+        }
+    }
+
+    It 'Searches by control ID' {
+        $results = Search-Check -ControlId 'AC-6'
+        $results.Count | Should -BeGreaterThan 0
+    }
+
+    It 'Searches by keyword' {
+        $results = Search-Check -Keyword 'MFA'
+        $results.Count | Should -BeGreaterThan 0
+        foreach ($r in $results) {
+            $r.name | Should -BeLike '*MFA*'
+        }
+    }
+
+    It 'Combines framework and keyword filters' {
+        $results = Search-Check -Framework 'hipaa' -Keyword 'password'
+        $results.Count | Should -BeGreaterThan 0
+    }
+}
+
+Describe 'Backwards Compatibility' {
+
+    It 'Import-ControlRegistry.ps1 still works via dot-source' {
+        . "$PSScriptRoot/../scripts/Import-ControlRegistry.ps1"
+        $registry = Import-ControlRegistry -ControlsPath "$PSScriptRoot/../data"
+        $registry | Should -Not -BeNullOrEmpty
+        $registry['ENTRA-ADMIN-001'] | Should -Not -BeNullOrEmpty
+        $registry['__cisReverseLookup'] | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Search-Registry.ps1 still works as standalone script' {
+        $results = & "$PSScriptRoot/../scripts/Search-Registry.ps1" -CheckId 'ENTRA-ADMIN-001' -AsObject
+        $results | Should -HaveCount 1
+        $results[0].checkId | Should -Be 'ENTRA-ADMIN-001'
+    }
+}


### PR DESCRIPTION
## Summary
- **Issue #21**: Create `CheckID.psd1` module manifest (v1.0.0, PowerShell 7.0+, PSGallery metadata)
- **Issue #22**: Create `CheckID.psm1` root module exporting 4 cmdlets:
  - `Get-CheckRegistry` — load all checks (with session cache)
  - `Get-CheckById` — single check lookup
  - `Search-Check` — search by framework, control ID, keyword
  - `Test-CheckRegistryData` — run data quality validation
- **Issue #23**: Migration guide in REFERENCES.md (submodule → Install-Module)
- **Issue #24**: PSGallery publish job in CI (tag-triggered `v*`, requires `PSGALLERY_API_KEY` secret)
- **Issue #25**: Backwards compatibility verified — dot-source and submodule patterns unchanged

42 tests: 20 registry integrity + 8 search + 14 module (including 2 backwards compat tests)

## Test plan
- [x] Module loads with correct version and 4 exported functions
- [x] All cmdlets work (Get-CheckRegistry, Get-CheckById, Search-Check)
- [x] Internal helpers not exported (Resolve-FrameworkTitle, Get-Soc2CriteriaFromNist)
- [x] Existing Import-ControlRegistry.ps1 dot-source pattern works
- [x] Existing Search-Registry.ps1 standalone script works
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)