### PR TITLE
Fix HIPAA encoding corruption and FileList gaps

### DIFF
--- a/CheckID.psd1
+++ b/CheckID.psd1
@@ -34,6 +34,8 @@
         'data/standalone-checks.json'
         'data/frameworks/cis-m365-v6.json'
         'data/frameworks/soc2-tsc.json'
+        'data/frameworks/nist-800-53-r5.json'
+        'data/frameworks/essential-eight.json'
         'scripts/Import-ControlRegistry.ps1'
         'scripts/Search-Registry.ps1'
         'scripts/Test-RegistryData.ps1'

--- a/data/registry.json
+++ b/data/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "dataVersion": "2026-03-15",
+  "dataVersion": "2026-03-17",
   "generatedFrom": "data/framework-mappings.csv + data/check-id-mapping.csv + data/standalone-checks.json",
   "checks": [
     {
@@ -13784,7 +13784,8 @@
           "controlId": "3.5.7"
         },
         "hipaa": {
-          "controlId": "┬º164.308(a)(5)(ii)(D)"
+          "controlId": "§164.308(a)(5)(ii)(D)",
+          "title": "Password Management"
         },
         "soc2": {
           "controlId": "CC6.1",
@@ -13918,7 +13919,8 @@
           "controlId": "3.1.8"
         },
         "hipaa": {
-          "controlId": "┬º164.312(a)(2)(i)"
+          "controlId": "§164.312(a)(2)(i)",
+          "title": "Unique User Identification"
         },
         "soc2": {
           "controlId": "CC6.1",
@@ -13968,7 +13970,8 @@
           "controlId": "3.4.6"
         },
         "hipaa": {
-          "controlId": "┬º164.312(a)(1)"
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
         },
         "soc2": {
           "controlId": "CC5;CC8.1",
@@ -14094,7 +14097,8 @@
           "controlId": "3.4.6"
         },
         "hipaa": {
-          "controlId": "┬º164.312(a)(1)"
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
         },
         "cisa-scuba": {
           "controlId": "MS.AAD.5.3v1"
@@ -14147,7 +14151,8 @@
           "controlId": "3.1.1;3.5.3"
         },
         "hipaa": {
-          "controlId": "┬º164.312(d);┬º164.312(a)(1)"
+          "controlId": "§164.312(d);§164.312(a)(1)",
+          "title": "Person or Entity Authentication; Access Control"
         },
         "cisa-scuba": {
           "controlId": "MS.AAD.1.1v1"
@@ -14200,7 +14205,8 @@
           "controlId": "3.1.1;3.1.2"
         },
         "hipaa": {
-          "controlId": "┬º164.312(a)(1)"
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
         },
         "soc2": {
           "controlId": "CC5;CC6.1",

--- a/data/standalone-checks.json
+++ b/data/standalone-checks.json
@@ -21,7 +21,7 @@
         "controlId": "3.1.1;3.5.3"
       },
       "hipaa": {
-        "controlId": "┬º164.312(d);┬º164.312(a)(1)"
+        "controlId": "§164.312(d);§164.312(a)(1)"
       },
       "cisa-scuba": {
         "controlId": "MS.AAD.1.1v1"
@@ -54,7 +54,7 @@
         "controlId": "3.4.6"
       },
       "hipaa": {
-        "controlId": "┬º164.312(a)(1)"
+        "controlId": "§164.312(a)(1)"
       },
       "cisa-scuba": {
         "controlId": "MS.AAD.5.3v1"
@@ -129,7 +129,7 @@
         "controlId": "3.1.1;3.1.2"
       },
       "hipaa": {
-        "controlId": "┬º164.312(a)(1)"
+        "controlId": "§164.312(a)(1)"
       },
       "soc2": {
         "controlId": "CC5;CC6.1",
@@ -159,7 +159,7 @@
         "controlId": "3.1.8"
       },
       "hipaa": {
-        "controlId": "┬º164.312(a)(2)(i)"
+        "controlId": "§164.312(a)(2)(i)"
       },
       "soc2": {
         "controlId": "CC6.1",
@@ -189,7 +189,7 @@
         "controlId": "3.5.7"
       },
       "hipaa": {
-        "controlId": "┬º164.308(a)(5)(ii)(D)"
+        "controlId": "§164.308(a)(5)(ii)(D)"
       },
       "soc2": {
         "controlId": "CC6.1",
@@ -273,7 +273,7 @@
         "controlId": "3.4.6"
       },
       "hipaa": {
-        "controlId": "┬º164.312(a)(1)"
+        "controlId": "§164.312(a)(1)"
       },
       "soc2": {
         "controlId": "CC5;CC8.1",

--- a/tests/registry-integrity.Tests.ps1
+++ b/tests/registry-integrity.Tests.ps1
@@ -175,11 +175,15 @@ Describe 'Control Registry Integrity' {
             $controlId = $check.frameworks.hipaa.controlId
             $controlId | Should -Not -BeNullOrEmpty `
                 -Because "$($check.checkId) has HIPAA mapping and needs a controlId"
-            # Detect garbled encoding: Â§ instead of §
+            # Detect garbled encoding: Â§ or ┬º instead of §
             $controlId | Should -Not -Match '\xC3\x82\xC2\xA7' `
                 -Because "$($check.checkId) HIPAA controlId must not contain double-encoded section symbol"
             $controlId | Should -Not -Match 'Â§' `
                 -Because "$($check.checkId) HIPAA controlId has garbled section symbol encoding"
+            $controlId | Should -Not -Match '┬º' `
+                -Because "$($check.checkId) HIPAA controlId has mojibake section symbol encoding"
+            $controlId | Should -Match '§' `
+                -Because "$($check.checkId) HIPAA controlId must contain the § section symbol"
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix mojibake `┬º` → `§` in `data/standalone-checks.json` (6 HIPAA controlId fields)
- Add `nist-800-53-r5.json` and `essential-eight.json` to module manifest FileList (added in PRs #38 and #40 but never registered)
- Extend HIPAA encoding test to catch the `┬º` corruption pattern and assert `§` is present
- Rebuild `registry.json` with corrected encoding

## Test plan

- [x] All 52 Pester tests pass
- [x] `Test-ModuleManifest` validates (15 files)
- [x] HIPAA test now catches `┬º`, `Â§`, and raw byte patterns
- [ ] CI pipeline passes

Closes #41, closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)