### PR TITLE
Add CI validation for Python build scripts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -234,6 +234,30 @@ jobs:
           }
           Write-Host "Module import and basic operations OK"
 
+  python-validate:
+    name: Validate Python Scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Syntax-check Python scripts
+        run: |
+          python -m py_compile scripts/Build-DerivedMappings.py
+          python -m py_compile scripts/Build-FrameworkTitles.py
+          echo "All Python scripts compile clean"
+
+      - name: Validate committed JSON outputs
+        run: |
+          python -c "import json; json.load(open('data/derived-mappings.json'))"
+          echo "  OK: data/derived-mappings.json"
+          python -c "import json; json.load(open('data/framework-titles.json'))"
+          echo "  OK: data/framework-titles.json"
+
   publish:
     name: Publish to PSGallery
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a new `python-validate` CI job to `.github/workflows/validate.yml`
- Syntax-checks `scripts/Build-DerivedMappings.py` and `scripts/Build-FrameworkTitles.py` via `py_compile`
- Validates that their committed JSON outputs (`data/derived-mappings.json`, `data/framework-titles.json`) are parseable
- Runs independently of existing jobs; does not gate the publish step

Closes #44

## Test plan
- [x] Verify the new `Validate Python Scripts` job appears in the Actions tab on this PR
- [x] Confirm it passes: both `.py` files compile and both `.json` files parse
- [x] Confirm existing jobs are unaffected (no changes to their definitions or dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)