### PR TITLE
feat: add 3 derived framework definitions

### DIFF
--- a/data/frameworks/cis-controls-v8.json
+++ b/data/frameworks/cis-controls-v8.json
@@ -1,0 +1,15 @@
+{
+  "frameworkId": "cis-controls-v8",
+  "label": "CIS Controls v8.1",
+  "version": "8.1",
+  "css": "fw-cis-ctrl",
+  "totalControls": 153,
+  "registryKey": "cis-controls-v8",
+  "csvColumn": "CisControlsV8",
+  "displayOrder": 12,
+  "scoring": { "method": "coverage" },
+  "colors": {
+    "light": { "background": "#dbeafe", "color": "#1e40af" },
+    "dark": { "background": "#1E3A5F", "color": "#60A5FA" }
+  }
+}

--- a/data/frameworks/fedramp.json
+++ b/data/frameworks/fedramp.json
@@ -1,0 +1,15 @@
+{
+  "frameworkId": "fedramp",
+  "label": "FedRAMP Rev 5",
+  "version": "Rev 5",
+  "css": "fw-fedramp",
+  "totalControls": 325,
+  "registryKey": "fedramp",
+  "csvColumn": "Fedramp",
+  "displayOrder": 13,
+  "scoring": { "method": "coverage" },
+  "colors": {
+    "light": { "background": "#eff6ff", "color": "#1e40af" },
+    "dark": { "background": "#1E3A5F", "color": "#93C5FD" }
+  }
+}

--- a/data/frameworks/mitre-attack.json
+++ b/data/frameworks/mitre-attack.json
@@ -1,0 +1,15 @@
+{
+  "frameworkId": "mitre-attack",
+  "label": "MITRE ATT&CK",
+  "version": "v10",
+  "css": "fw-mitre",
+  "totalControls": 201,
+  "registryKey": "mitre-attack",
+  "csvColumn": "MitreAttack",
+  "displayOrder": 14,
+  "scoring": { "method": "coverage" },
+  "colors": {
+    "light": { "background": "#fef2f2", "color": "#991b1b" },
+    "dark": { "background": "#7F1D1D", "color": "#FCA5A5" }
+  }
+}


### PR DESCRIPTION
## Summary
- Creates framework definition JSONs for 3 derived frameworks (mapped via SCF transitive bridge)
- All use `"scoring": { "method": "coverage" }`

## New files
| File | Framework | Controls | displayOrder |
|------|-----------|----------|-------------|
| `cis-controls-v8.json` | CIS Controls v8.1 | 153 | 12 |
| `fedramp.json` | FedRAMP Rev 5 | 325 | 13 |
| `mitre-attack.json` | MITRE ATT&CK v10 | 201 | 14 |

## Test plan
- [ ] All JSONs are valid
- [ ] `frameworkId` matches `registryKey` in each file
- [ ] Framework validation test suite passes with these included

Closes remaining part of #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)