### PR TITLE
feat: enrich 10 framework definitions with scoring structures (#47)

### DIFF
--- a/data/frameworks/cis-controls-v8.json
+++ b/data/frameworks/cis-controls-v8.json
@@ -7,9 +7,31 @@
   "registryKey": "cis-controls-v8",
   "csvColumn": "CisControlsV8",
   "displayOrder": 12,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "profile-compliance",
+    "profiles": {
+      "IG1": {
+        "label": "IG1",
+        "controlCount": 56
+      },
+      "IG2": {
+        "label": "IG2",
+        "controlCount": 130
+      },
+      "IG3": {
+        "label": "IG3",
+        "controlCount": 153
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#dbeafe", "color": "#1e40af" },
-    "dark": { "background": "#1E3A5F", "color": "#60A5FA" }
+    "light": {
+      "background": "#dbeafe",
+      "color": "#1e40af"
+    },
+    "dark": {
+      "background": "#1E3A5F",
+      "color": "#60A5FA"
+    }
   }
 }

--- a/data/frameworks/cisa-scuba-baselines.json
+++ b/data/frameworks/cisa-scuba-baselines.json
@@ -7,9 +7,38 @@
   "registryKey": "cisa-scuba",
   "csvColumn": "CisaScuba",
   "displayOrder": 9,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "policy-compliance",
+    "products": {
+      "AAD": {
+        "label": "Entra ID"
+      },
+      "EXO": {
+        "label": "Exchange Online"
+      },
+      "Defender": {
+        "label": "Microsoft Defender"
+      },
+      "SharePoint": {
+        "label": "SharePoint"
+      },
+      "Teams": {
+        "label": "Teams"
+      },
+      "PowerPlatform": {
+        "label": "Power Platform"
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#fff7ed", "color": "#9a3412" },
-    "dark": { "background": "#7C2D12", "color": "#FDBA74" }
-  }
+    "light": {
+      "background": "#fff7ed",
+      "color": "#9a3412"
+    },
+    "dark": {
+      "background": "#7C2D12",
+      "color": "#FDBA74"
+    }
+  },
+  "controlIdFormat": "MS.{product}.{number}v{version}"
 }

--- a/data/frameworks/cmmc-2.json
+++ b/data/frameworks/cmmc-2.json
@@ -7,9 +7,31 @@
   "registryKey": "cmmc",
   "csvColumn": "Cmmc",
   "displayOrder": 7,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "maturity-level",
+    "maturityLevels": {
+      "L1": {
+        "label": "Foundational",
+        "practiceCount": 17
+      },
+      "L2": {
+        "label": "Advanced",
+        "practiceCount": 110
+      },
+      "L3": {
+        "label": "Expert",
+        "practiceCount": 134
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#f0fdfa", "color": "#134e4a" },
-    "dark": { "background": "#134E4A", "color": "#5EEAD4" }
+    "light": {
+      "background": "#f0fdfa",
+      "color": "#134e4a"
+    },
+    "dark": {
+      "background": "#134E4A",
+      "color": "#5EEAD4"
+    }
   }
 }

--- a/data/frameworks/disa-stig-m365.json
+++ b/data/frameworks/disa-stig-m365.json
@@ -7,9 +7,29 @@
   "registryKey": "stig",
   "csvColumn": "Stig",
   "displayOrder": 5,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "severity-coverage",
+    "categories": {
+      "CAT-I": {
+        "label": "High"
+      },
+      "CAT-II": {
+        "label": "Medium"
+      },
+      "CAT-III": {
+        "label": "Low"
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#f3e8ff", "color": "#6b21a8" },
-    "dark": { "background": "#3B0764", "color": "#C4B5FD" }
-  }
+    "light": {
+      "background": "#f3e8ff",
+      "color": "#6b21a8"
+    },
+    "dark": {
+      "background": "#3B0764",
+      "color": "#C4B5FD"
+    }
+  },
+  "controlIdFormat": "V-{number}"
 }

--- a/data/frameworks/fedramp.json
+++ b/data/frameworks/fedramp.json
@@ -7,9 +7,35 @@
   "registryKey": "fedramp",
   "csvColumn": "Fedramp",
   "displayOrder": 13,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "profile-compliance",
+    "profiles": {
+      "LI-SaaS": {
+        "label": "FedRAMP LI-SaaS",
+        "controlCount": 36
+      },
+      "Low": {
+        "label": "FedRAMP Low",
+        "controlCount": 156
+      },
+      "Moderate": {
+        "label": "FedRAMP Moderate",
+        "controlCount": 323
+      },
+      "High": {
+        "label": "FedRAMP High",
+        "controlCount": 370
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#eff6ff", "color": "#1e40af" },
-    "dark": { "background": "#1E3A5F", "color": "#93C5FD" }
+    "light": {
+      "background": "#eff6ff",
+      "color": "#1e40af"
+    },
+    "dark": {
+      "background": "#1E3A5F",
+      "color": "#93C5FD"
+    }
   }
 }

--- a/data/frameworks/hipaa-security-rule.json
+++ b/data/frameworks/hipaa-security-rule.json
@@ -7,9 +7,34 @@
   "registryKey": "hipaa",
   "csvColumn": "Hipaa",
   "displayOrder": 8,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "criteria-coverage",
+    "criteria": {
+      "164.308": {
+        "label": "Administrative Safeguards"
+      },
+      "164.310": {
+        "label": "Physical Safeguards"
+      },
+      "164.312": {
+        "label": "Technical Safeguards"
+      },
+      "164.314": {
+        "label": "Organizational Requirements"
+      },
+      "164.316": {
+        "label": "Policies and Procedures"
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#fdf2f8", "color": "#9d174d" },
-    "dark": { "background": "#831843", "color": "#F9A8D4" }
+    "light": {
+      "background": "#fdf2f8",
+      "color": "#9d174d"
+    },
+    "dark": {
+      "background": "#831843",
+      "color": "#F9A8D4"
+    }
   }
 }

--- a/data/frameworks/iso-27001-2022.json
+++ b/data/frameworks/iso-27001-2022.json
@@ -7,9 +7,35 @@
   "registryKey": "iso-27001",
   "csvColumn": "Iso27001",
   "displayOrder": 4,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "control-coverage",
+    "themes": {
+      "5": {
+        "label": "Organizational Controls",
+        "controlCount": 37
+      },
+      "6": {
+        "label": "People Controls",
+        "controlCount": 8
+      },
+      "7": {
+        "label": "Physical Controls",
+        "controlCount": 14
+      },
+      "8": {
+        "label": "Technological Controls",
+        "controlCount": 34
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#ecfdf5", "color": "#065f46" },
-    "dark": { "background": "#064E3B", "color": "#6EE7B7" }
+    "light": {
+      "background": "#ecfdf5",
+      "color": "#065f46"
+    },
+    "dark": {
+      "background": "#064E3B",
+      "color": "#6EE7B7"
+    }
   }
 }

--- a/data/frameworks/mitre-attack.json
+++ b/data/frameworks/mitre-attack.json
@@ -7,9 +7,56 @@
   "registryKey": "mitre-attack",
   "csvColumn": "MitreAttack",
   "displayOrder": 14,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "technique-coverage",
+    "tactics": {
+      "TA0001": {
+        "label": "Initial Access"
+      },
+      "TA0002": {
+        "label": "Execution"
+      },
+      "TA0003": {
+        "label": "Persistence"
+      },
+      "TA0004": {
+        "label": "Privilege Escalation"
+      },
+      "TA0005": {
+        "label": "Defense Evasion"
+      },
+      "TA0006": {
+        "label": "Credential Access"
+      },
+      "TA0007": {
+        "label": "Discovery"
+      },
+      "TA0008": {
+        "label": "Lateral Movement"
+      },
+      "TA0009": {
+        "label": "Collection"
+      },
+      "TA0010": {
+        "label": "Exfiltration"
+      },
+      "TA0011": {
+        "label": "Command and Control"
+      },
+      "TA0040": {
+        "label": "Impact"
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#fef2f2", "color": "#991b1b" },
-    "dark": { "background": "#7F1D1D", "color": "#FCA5A5" }
-  }
+    "light": {
+      "background": "#fef2f2",
+      "color": "#991b1b"
+    },
+    "dark": {
+      "background": "#7F1D1D",
+      "color": "#FCA5A5"
+    }
+  },
+  "controlIdFormat": "T{number}[.{sub}]"
 }

--- a/data/frameworks/nist-csf-2.json
+++ b/data/frameworks/nist-csf-2.json
@@ -7,9 +7,43 @@
   "registryKey": "nist-csf",
   "csvColumn": "NistCsf",
   "displayOrder": 3,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "function-coverage",
+    "functions": {
+      "GV": {
+        "label": "Govern",
+        "subcategories": 15
+      },
+      "ID": {
+        "label": "Identify",
+        "subcategories": 17
+      },
+      "PR": {
+        "label": "Protect",
+        "subcategories": 27
+      },
+      "DE": {
+        "label": "Detect",
+        "subcategories": 18
+      },
+      "RS": {
+        "label": "Respond",
+        "subcategories": 15
+      },
+      "RC": {
+        "label": "Recover",
+        "subcategories": 14
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#fef3c7", "color": "#92400e" },
-    "dark": { "background": "#78350F", "color": "#FCD34D" }
+    "light": {
+      "background": "#fef3c7",
+      "color": "#92400e"
+    },
+    "dark": {
+      "background": "#78350F",
+      "color": "#FCD34D"
+    }
   }
 }

--- a/data/frameworks/pci-dss-v4.json
+++ b/data/frameworks/pci-dss-v4.json
@@ -7,9 +7,55 @@
   "registryKey": "pci-dss",
   "csvColumn": "PciDss",
   "displayOrder": 6,
-  "scoring": { "method": "coverage" },
+  "scoring": {
+    "method": "requirement-compliance",
+    "requirements": {
+      "1": {
+        "label": "Network Security Controls"
+      },
+      "2": {
+        "label": "Secure Configurations"
+      },
+      "3": {
+        "label": "Stored Account Data"
+      },
+      "4": {
+        "label": "Strong Cryptography"
+      },
+      "5": {
+        "label": "Malicious Software"
+      },
+      "6": {
+        "label": "Secure Systems"
+      },
+      "7": {
+        "label": "Access Restriction"
+      },
+      "8": {
+        "label": "User Authentication"
+      },
+      "9": {
+        "label": "Physical Access"
+      },
+      "10": {
+        "label": "Logging and Monitoring"
+      },
+      "11": {
+        "label": "Security Testing"
+      },
+      "12": {
+        "label": "Organizational Policies"
+      }
+    }
+  },
   "colors": {
-    "light": { "background": "#fef2f2", "color": "#991b1b" },
-    "dark": { "background": "#7F1D1D", "color": "#FCA5A5" }
+    "light": {
+      "background": "#fef2f2",
+      "color": "#991b1b"
+    },
+    "dark": {
+      "background": "#7F1D1D",
+      "color": "#FCA5A5"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Replaces generic `"coverage"` scoring stubs in 10 framework definitions with framework-specific scoring methods
- Adds profile/tier breakdowns, control groupings, and structural metadata for dashboard rendering
- Scoring methods: `function-coverage` (CSF), `control-coverage` (ISO), `criteria-coverage` (HIPAA), `requirement-compliance` (PCI DSS), `maturity-level` (CMMC), `severity-coverage` (STIG), `policy-compliance` (SCuBA), `profile-compliance` (FedRAMP, CIS Controls v8), `technique-coverage` (MITRE ATT&CK)
- All 14 frameworks now return `TotalControls` and `CoveragePct` from `Get-FrameworkCoverage`

## Test plan
- [ ] `Test-ModuleManifest -Path ./CheckID.psd1` validates
- [ ] `Get-FrameworkCoverage` returns enriched data for all 14 frameworks
- [ ] CI `validate-data` job validates all JSON files
- [ ] Framework definition tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)