### PR TITLE
feat: add Get-CheckAutomationGaps cmdlet and document M365-Remediate (#50, #51)

### DIFF
--- a/tests/module.Tests.ps1
+++ b/tests/module.Tests.ps1
@@ -12,7 +12,8 @@ Describe 'CheckID Module' {
     It 'Loads successfully with correct version' {
         $mod = Get-Module CheckID
         $mod | Should -Not -BeNullOrEmpty
-        $mod.Version | Should -Be '1.1.0'
+        $expected = (Import-PowerShellDataFile "$PSScriptRoot/../CheckID.psd1").ModuleVersion
+        $mod.Version | Should -Be $expected
     }
 
     It 'Exports exactly the expected functions' {


### PR DESCRIPTION
## Summary
- Adds `Get-CheckAutomationGaps` function to identify checks lacking automated assessment, with optional `-Framework` filter
- Adds M365-Remediate to the downstream consumers table in `REFERENCES.md`
- Updates CI to expect 6 exported functions (was 5)
- Adds 3 Pester tests for the new cmdlet (21 → 24 total tests)

## Test plan
- [ ] `Import-Module ./CheckID.psd1; Get-CheckAutomationGaps | Measure-Object` returns 14 manual checks
- [ ] `Get-CheckAutomationGaps -Framework 'hipaa'` filters correctly
- [ ] `Invoke-Pester ./tests/module.Tests.ps1` — all 24 tests pass
- [ ] CI `module-test` validates 6 exported functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)