### PR TITLE
feat: register 23 new check IDs for M365-Remediate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to the CheckID module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased] - 2026-03-18
+## [Unreleased] - 2026-03-20
+
+### Added
+
+- 8 CA coverage gap analysis checks: CA-COVERAGE-001..008 (#80)
+- 3 API permission severity checks: ENTRA-APPS-002..004 (#81)
+- 5 enhanced PIM checks: ENTRA-PIM-006..010 (#82)
+- 7 Entra security checks: ENTRA-APPS-005..006, ENTRA-APPREG-002..003, ENTRA-ADMIN-004, ENTRA-GROUP-004..005 (#83)
+- Essential Eight framework mappings for all 23 new checks
 
 ### Removed
 

--- a/CheckID.psd1
+++ b/CheckID.psd1
@@ -1,7 +1,7 @@
 @{
     # Module metadata
     RootModule        = 'CheckID.psm1'
-    ModuleVersion     = '1.2.0'
+    ModuleVersion     = '1.3.0'
     GUID              = 'a3b7c4d5-1e2f-4a5b-8c9d-0e1f2a3b4c5d'
     Author            = 'Galvnyz'
     CompanyName       = 'Galvnyz'

--- a/data/registry.json
+++ b/data/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.1.0",
-  "dataVersion": "2026-03-18",
+  "dataVersion": "2026-03-20",
   "generatedFrom": "data/framework-mappings.csv + data/check-id-mapping.csv + data/standalone-checks.json",
   "checks": [
     {
@@ -6165,6 +6165,47 @@
       }
     },
     {
+      "checkId": "INTUNE-ENCRYPTION-001",
+      "name": "Device Encryption Policy",
+      "category": "ENCRYPTION",
+      "collector": "Intune",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "cis-m365-v6": {
+          "controlId": "6.2"
+        },
+        "nist-csf": {
+          "controlId": "PR.DS-1"
+        },
+        "nist-800-53": {
+          "controlId": "SC-28",
+          "title": "Protection of Information at Rest",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.10.1.1"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(2)(iv)",
+          "title": "Encryption and Decryption"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.7",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
       "checkId": "DEFENDER-SECURESCORE-001",
       "name": "Microsoft Secure Score Posture",
       "category": "SECURESCORE",
@@ -6205,47 +6246,6 @@
       },
       "impactRating": {
         "severity": "Medium"
-      }
-    },
-    {
-      "checkId": "INTUNE-ENCRYPTION-001",
-      "name": "Device Encryption Policy",
-      "category": "ENCRYPTION",
-      "collector": "Intune",
-      "hasAutomatedCheck": true,
-      "licensing": {
-        "minimum": "E3"
-      },
-      "frameworks": {
-        "cis-m365-v6": {
-          "controlId": "6.2"
-        },
-        "nist-csf": {
-          "controlId": "PR.DS-1"
-        },
-        "nist-800-53": {
-          "controlId": "SC-28",
-          "title": "Protection of Information at Rest",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
-        },
-        "iso-27001": {
-          "controlId": "A.10.1.1"
-        },
-        "hipaa": {
-          "controlId": "§164.312(a)(2)(iv)",
-          "title": "Encryption and Decryption"
-        },
-        "soc2": {
-          "controlId": "CC6.1;CC6.7",
-          "evidenceType": "config-export",
-          "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
-        }
-      },
-      "impactRating": {
-        "severity": "High"
       }
     },
     {
@@ -9757,6 +9757,778 @@
       }
     },
     {
+      "checkId": "CA-COVERAGE-008",
+      "name": "Device Registration Restricted by CA",
+      "category": "COVERAGE",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-03",
+          "title": "Users, services, and hardware are authenticated"
+        },
+        "nist-800-53": {
+          "controlId": "CM-8;IA-3",
+          "title": "System Component Inventory; Device Identification and Authentication",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.8.1;A.8.5",
+          "title": "User endpoint devices; Secure authentication"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "soc2": {
+          "controlId": "CC6.1",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        }
+      },
+      "impactRating": {
+        "severity": "Medium"
+      }
+    },
+    {
+      "checkId": "ENTRA-APPS-003",
+      "name": "Enterprise Apps with High-Level Permissions and No Recent Activity",
+      "category": "APPS",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05;PR.AC-4",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-6(5);AC-2(3)",
+          "title": "Privileged Accounts; Disable Accounts",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18;A.8.2",
+          "title": "Access control; Access rights; Privileged access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "ENTRA-APPS-002",
+      "name": "Enterprise Apps with Dangerous-Level Graph Permissions",
+      "category": "APPS",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05;PR.AC-4",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-6(5);AC-6(10)",
+          "title": "Privileged Accounts; Prohibit Non-privileged Users from Executing Privileged Functions",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18;A.8.2",
+          "title": "Access control; Access rights; Privileged access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "Critical"
+      }
+    },
+    {
+      "checkId": "ENTRA-ADMIN-004",
+      "name": "On-Premises Synced Accounts Holding Tier-0 Roles",
+      "category": "ADMIN",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-6(5);AC-2",
+          "title": "Privileged Accounts; Account Management",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18;A.8.2",
+          "title": "Access control; Access rights; Privileged access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5;ML3-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1);§164.308(a)(4)(i)",
+          "title": "Access Control; Information Access Management"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "Critical"
+      }
+    },
+    {
+      "checkId": "ENTRA-PIM-006",
+      "name": "Tier-0 Role Activation Duration Exceeds 4 Hours",
+      "category": "PIM",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-2(2);AC-6(5)",
+          "title": "Automated Temporary and Emergency Account Management; Privileged Accounts",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18;A.8.2",
+          "title": "Access control; Access rights; Privileged access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5;ML3-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1);§164.308(a)(4)(i)",
+          "title": "Access Control; Information Access Management"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "ENTRA-PIM-007",
+      "name": "Tier-0 Role Activation Does Not Require Approval",
+      "category": "PIM",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-2(2);AC-6(5)",
+          "title": "Automated Temporary and Emergency Account Management; Privileged Accounts",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18;A.8.2",
+          "title": "Access control; Access rights; Privileged access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5;ML3-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1);§164.308(a)(4)(i)",
+          "title": "Access Control; Information Access Management"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "Critical"
+      }
+    },
+    {
+      "checkId": "ENTRA-PIM-008",
+      "name": "Permanent Active Assignments on Tier-0 Roles",
+      "category": "PIM",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-2(2);AC-6(5)",
+          "title": "Automated Temporary and Emergency Account Management; Privileged Accounts",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18;A.8.2",
+          "title": "Access control; Access rights; Privileged access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5;ML3-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1);§164.308(a)(4)(i)",
+          "title": "Access Control; Information Access Management"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "Critical"
+      }
+    },
+    {
+      "checkId": "ENTRA-PIM-009",
+      "name": "Eligible Assignments Without Expiration",
+      "category": "PIM",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-2(2);AC-6(5)",
+          "title": "Automated Temporary and Emergency Account Management; Privileged Accounts",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18",
+          "title": "Access control; Access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "ENTRA-PIM-010",
+      "name": "PIM Activation Does Not Require MFA",
+      "category": "PIM",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-03;PR.AA-05",
+          "title": "Users, services, and hardware are authenticated; Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "IA-2(1);AC-6(5)",
+          "title": "Multi-factor Authentication to Privileged Accounts; Privileged Accounts",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.8.5",
+          "title": "Access control; Secure authentication"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5;ML3-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(d);§164.312(a)(1)",
+          "title": "Person or Entity Authentication; Access Control"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "ENTRA-APPS-005",
+      "name": "Enterprise Apps with No Sign-in Activity in 180+ Days",
+      "category": "APPS",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-2(3);CM-8",
+          "title": "Disable Accounts; System Component Inventory",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18",
+          "title": "Access control; Access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML1-P5"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "Medium"
+      }
+    },
+    {
+      "checkId": "ENTRA-APPS-006",
+      "name": "Enterprise Apps Owned by External Tenant Principals",
+      "category": "APPS",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05;PR.AC-4",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-6(5);SA-9",
+          "title": "Privileged Accounts; External System Services",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High",
+            "Privacy"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.19;A.5.20",
+          "title": "Access control; Information security in supplier relationships; Addressing information security within supplier agreements"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1);§164.308(b)(1)",
+          "title": "Access Control"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3;CC9.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials; Vendor and Business Partner Risk Management"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "ENTRA-APPREG-002",
+      "name": "App Registrations with Credentials Expiring Within 30 Days",
+      "category": "APPREG",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-01",
+          "title": "Identities and credentials for authorized users, services, and hardware are managed by the organization"
+        },
+        "nist-800-53": {
+          "controlId": "IA-5;IA-5(1)",
+          "title": "Authenticator Management; Password-based Authentication",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.17;A.8.5",
+          "title": "Authentication information; Secure authentication"
+        },
+        "essential-eight": {
+          "controlId": "ML1-P5"
+        },
+        "soc2": {
+          "controlId": "CC6.1",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        }
+      },
+      "impactRating": {
+        "severity": "Medium"
+      }
+    },
+    {
+      "checkId": "ENTRA-APPREG-003",
+      "name": "App Registrations with Credential Lifetime Exceeding 2 Years",
+      "category": "APPREG",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-01",
+          "title": "Identities and credentials for authorized users, services, and hardware are managed by the organization"
+        },
+        "nist-800-53": {
+          "controlId": "IA-5;IA-5(1)",
+          "title": "Authenticator Management; Password-based Authentication",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.17;A.8.5",
+          "title": "Authentication information; Secure authentication"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(d)",
+          "title": "Person or Entity Authentication"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "CA-COVERAGE-007",
+      "name": "Security Info Registration Protected by CA",
+      "category": "COVERAGE",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-03;PR.AA-05",
+          "title": "Users, services, and hardware are authenticated; Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "IA-2;IA-5",
+          "title": "Identification and Authentication (Organizational Users); Authenticator Management",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.8.5",
+          "title": "Access control; Secure authentication"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "ENTRA-APPS-004",
+      "name": "Managed Identities with Dangerous-Level Permissions",
+      "category": "APPS",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05;PR.AC-4",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-6(5);AC-6(10)",
+          "title": "Privileged Accounts; Prohibit Non-privileged Users from Executing Privileged Functions",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18;A.8.2",
+          "title": "Access control; Access rights; Privileged access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "Critical"
+      }
+    },
+    {
+      "checkId": "CA-COVERAGE-006",
+      "name": "User Risk-Based CA Policy Exists",
+      "category": "COVERAGE",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "DE.AE-2;PR.AA-03",
+          "title": "Users, services, and hardware are authenticated"
+        },
+        "nist-800-53": {
+          "controlId": "AC-7;SI-4",
+          "title": "Unsuccessful Logon Attempts; System Monitoring",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.8.16",
+          "title": "Access control; Monitoring activities"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC7.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Monitoring System Components for Anomalies"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "TEAMS-APPS-001",
+      "name": "Chat Resource-Specific Consent Enabled",
+      "category": "APPS",
+      "collector": "Teams",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.IP-1"
+        },
+        "nist-800-53": {
+          "controlId": "CM-7",
+          "title": "Least Functionality",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.12.6.2"
+        },
+        "pci-dss": {
+          "controlId": "2.2.x"
+        },
+        "cmmc": {
+          "controlId": "3.4.6"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
+        },
+        "soc2": {
+          "controlId": "CC5;CC8.1",
+          "evidenceType": "config-export",
+          "title": "Control Activities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "cis-controls-v8": {
+          "controlId": "4;4.6;4.8"
+        },
+        "fedramp": {
+          "controlId": "CM-7"
+        },
+        "mitre-attack": {
+          "controlId": "T1003;T1003.001;T1003.002;T1003.005;T1008;T1011;T1011.001;T1021.001;T1021.002;T1021.003"
+        }
+      }
+    },
+    {
+      "checkId": "CA-COVERAGE-004",
+      "name": "Phishing-Resistant MFA for Admins",
+      "category": "COVERAGE",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-03;PR.AA-05",
+          "title": "Users, services, and hardware are authenticated; Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "IA-2(6);AC-6(5)",
+          "title": "Access to Accounts —separate Device; Privileged Accounts",
+          "profiles": [
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.8.5",
+          "title": "Access control; Secure authentication"
+        },
+        "essential-eight": {
+          "controlId": "ML3-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(d)",
+          "title": "Person or Entity Authentication"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access"
+        }
+      },
+      "impactRating": {
+        "severity": "Critical"
+      }
+    },
+    {
       "checkId": "ENTRA-SECDEFAULT-001",
       "name": "Security Defaults Enabled",
       "category": "SECDEFAULT",
@@ -10040,183 +10812,6 @@
       }
     },
     {
-      "checkId": "TEAMS-INFO-001",
-      "name": "Teams Workload Active",
-      "category": "INFO",
-      "collector": "Teams",
-      "hasAutomatedCheck": true,
-      "licensing": {
-        "minimum": "E3"
-      },
-      "frameworks": {
-        "nist-800-53": {
-          "controlId": "CM-8",
-          "title": "System Component Inventory",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
-        },
-        "iso-27001": {
-          "controlId": "A.8.9",
-          "title": "Configuration management"
-        },
-        "soc2": {
-          "controlId": "CC6.1",
-          "evidenceType": "config-export",
-          "title": "Logical Access Security Software, Infrastructure, and Architectures"
-        },
-        "cis-controls-v8": {
-          "controlId": "1;1.1;1.3;2;2.1;2.2;2.4;6.6"
-        },
-        "essential-eight": {
-          "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
-        },
-        "fedramp": {
-          "controlId": "CM-8"
-        },
-        "mitre-attack": {
-          "controlId": "T1011.001;T1020.001;T1021.001;T1021.003;T1021.004;T1021.005;T1021.006;T1046;T1052;T1052.001"
-        }
-      }
-    },
-    {
-      "checkId": "TEAMS-APPS-001",
-      "name": "Chat Resource-Specific Consent Enabled",
-      "category": "APPS",
-      "collector": "Teams",
-      "hasAutomatedCheck": true,
-      "licensing": {
-        "minimum": "E3"
-      },
-      "frameworks": {
-        "nist-csf": {
-          "controlId": "PR.IP-1"
-        },
-        "nist-800-53": {
-          "controlId": "CM-7",
-          "title": "Least Functionality",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
-        },
-        "iso-27001": {
-          "controlId": "A.12.6.2"
-        },
-        "pci-dss": {
-          "controlId": "2.2.x"
-        },
-        "cmmc": {
-          "controlId": "3.4.6"
-        },
-        "hipaa": {
-          "controlId": "§164.312(a)(1)",
-          "title": "Access Control"
-        },
-        "soc2": {
-          "controlId": "CC5;CC8.1",
-          "evidenceType": "config-export",
-          "title": "Control Activities; Changes to Infrastructure, Data, Software, and Procedures"
-        },
-        "cis-controls-v8": {
-          "controlId": "4;4.6;4.8"
-        },
-        "fedramp": {
-          "controlId": "CM-7"
-        },
-        "mitre-attack": {
-          "controlId": "T1003;T1003.001;T1003.002;T1003.005;T1008;T1011;T1011.001;T1021.001;T1021.002;T1021.003"
-        }
-      }
-    },
-    {
-      "checkId": "SPO-LOOP-002",
-      "name": "OneDrive Loop Sharing",
-      "category": "LOOP",
-      "collector": "SharePoint",
-      "hasAutomatedCheck": true,
-      "licensing": {
-        "minimum": "E3"
-      },
-      "frameworks": {
-        "nist-800-53": {
-          "controlId": "CM-8",
-          "title": "System Component Inventory",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
-        },
-        "iso-27001": {
-          "controlId": "A.8.9",
-          "title": "Configuration management"
-        },
-        "soc2": {
-          "controlId": "CC6.1",
-          "evidenceType": "config-export",
-          "title": "Logical Access Security Software, Infrastructure, and Architectures"
-        },
-        "cis-controls-v8": {
-          "controlId": "1;1.1;1.3;2;2.1;2.2;2.4;6.6"
-        },
-        "essential-eight": {
-          "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
-        },
-        "fedramp": {
-          "controlId": "CM-8"
-        },
-        "mitre-attack": {
-          "controlId": "T1011.001;T1020.001;T1021.001;T1021.003;T1021.004;T1021.005;T1021.006;T1046;T1052;T1052.001"
-        }
-      }
-    },
-    {
-      "checkId": "SPO-LOOP-001",
-      "name": "Loop Components Enabled",
-      "category": "LOOP",
-      "collector": "SharePoint",
-      "hasAutomatedCheck": true,
-      "licensing": {
-        "minimum": "E3"
-      },
-      "frameworks": {
-        "nist-800-53": {
-          "controlId": "CM-8",
-          "title": "System Component Inventory",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
-        },
-        "iso-27001": {
-          "controlId": "A.8.9",
-          "title": "Configuration management"
-        },
-        "soc2": {
-          "controlId": "CC6.1",
-          "evidenceType": "config-export",
-          "title": "Logical Access Security Software, Infrastructure, and Architectures"
-        },
-        "cis-controls-v8": {
-          "controlId": "1;1.1;1.3;2;2.1;2.2;2.4;6.6"
-        },
-        "essential-eight": {
-          "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
-        },
-        "fedramp": {
-          "controlId": "CM-8"
-        },
-        "mitre-attack": {
-          "controlId": "T1011.001;T1020.001;T1021.001;T1021.003;T1021.004;T1021.005;T1021.006;T1046;T1052;T1052.001"
-        }
-      }
-    },
-    {
       "checkId": "ENTRA-PASSWORD-004",
       "name": "Custom Banned Password Count",
       "category": "PASSWORD",
@@ -10307,6 +10902,384 @@
         "mitre-attack": {
           "controlId": "T1011.001;T1020.001;T1021.001;T1021.003;T1021.004;T1021.005;T1021.006;T1046;T1052;T1052.001"
         }
+      }
+    },
+    {
+      "checkId": "SPO-LOOP-001",
+      "name": "Loop Components Enabled",
+      "category": "LOOP",
+      "collector": "SharePoint",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-800-53": {
+          "controlId": "CM-8",
+          "title": "System Component Inventory",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.8.9",
+          "title": "Configuration management"
+        },
+        "soc2": {
+          "controlId": "CC6.1",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "cis-controls-v8": {
+          "controlId": "1;1.1;1.3;2;2.1;2.2;2.4;6.6"
+        },
+        "essential-eight": {
+          "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
+        },
+        "fedramp": {
+          "controlId": "CM-8"
+        },
+        "mitre-attack": {
+          "controlId": "T1011.001;T1020.001;T1021.001;T1021.003;T1021.004;T1021.005;T1021.006;T1046;T1052;T1052.001"
+        }
+      }
+    },
+    {
+      "checkId": "SPO-LOOP-002",
+      "name": "OneDrive Loop Sharing",
+      "category": "LOOP",
+      "collector": "SharePoint",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-800-53": {
+          "controlId": "CM-8",
+          "title": "System Component Inventory",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.8.9",
+          "title": "Configuration management"
+        },
+        "soc2": {
+          "controlId": "CC6.1",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "cis-controls-v8": {
+          "controlId": "1;1.1;1.3;2;2.1;2.2;2.4;6.6"
+        },
+        "essential-eight": {
+          "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
+        },
+        "fedramp": {
+          "controlId": "CM-8"
+        },
+        "mitre-attack": {
+          "controlId": "T1011.001;T1020.001;T1021.001;T1021.003;T1021.004;T1021.005;T1021.006;T1046;T1052;T1052.001"
+        }
+      }
+    },
+    {
+      "checkId": "TEAMS-INFO-001",
+      "name": "Teams Workload Active",
+      "category": "INFO",
+      "collector": "Teams",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-800-53": {
+          "controlId": "CM-8",
+          "title": "System Component Inventory",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.8.9",
+          "title": "Configuration management"
+        },
+        "soc2": {
+          "controlId": "CC6.1",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "cis-controls-v8": {
+          "controlId": "1;1.1;1.3;2;2.1;2.2;2.4;6.6"
+        },
+        "essential-eight": {
+          "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
+        },
+        "fedramp": {
+          "controlId": "CM-8"
+        },
+        "mitre-attack": {
+          "controlId": "T1011.001;T1020.001;T1021.001;T1021.003;T1021.004;T1021.005;T1021.006;T1046;T1052;T1052.001"
+        }
+      }
+    },
+    {
+      "checkId": "ENTRA-GROUP-004",
+      "name": "Dynamic Groups with User-Modifiable Attribute Rules Granting Privileged Access",
+      "category": "GROUP",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05;PR.AC-4",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-6(5);AC-3",
+          "title": "Privileged Accounts; Access Enforcement",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18;A.8.2",
+          "title": "Access control; Access rights; Privileged access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "CA-COVERAGE-001",
+      "name": "Device Code Flow Blocked by CA Policy",
+      "category": "COVERAGE",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-03",
+          "title": "Users, services, and hardware are authenticated"
+        },
+        "nist-800-53": {
+          "controlId": "CM-7;IA-2",
+          "title": "Least Functionality; Identification and Authentication (Organizational Users)",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.8.5;A.8.20",
+          "title": "Secure authentication; Networks security"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.7",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "CA-COVERAGE-002",
+      "name": "Legacy Authentication Blocked by CA Policy",
+      "category": "COVERAGE",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-03",
+          "title": "Users, services, and hardware are authenticated"
+        },
+        "nist-800-53": {
+          "controlId": "CM-7;IA-2",
+          "title": "Least Functionality; Identification and Authentication (Organizational Users)",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.8.5;A.8.20",
+          "title": "Secure authentication; Networks security"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.7",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "CA-COVERAGE-003",
+      "name": "MFA Enforced for All Users",
+      "category": "COVERAGE",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-03;PR.AA-05",
+          "title": "Users, services, and hardware are authenticated; Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "IA-2(1);IA-2(2)",
+          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.8.5",
+          "title": "Access control; Secure authentication"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5;ML3-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(d)",
+          "title": "Person or Entity Authentication"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access"
+        }
+      },
+      "impactRating": {
+        "severity": "Critical"
+      }
+    },
+    {
+      "checkId": "CA-COVERAGE-005",
+      "name": "Sign-in Risk-Based CA Policy Exists",
+      "category": "COVERAGE",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "DE.AE-2;PR.AA-03",
+          "title": "Users, services, and hardware are authenticated"
+        },
+        "nist-800-53": {
+          "controlId": "AC-7;SI-4",
+          "title": "Unsuccessful Logon Attempts; System Monitoring",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.8.16",
+          "title": "Access control; Monitoring activities"
+        },
+        "essential-eight": {
+          "controlId": "ML2-P5"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC7.2",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Monitoring System Components for Anomalies"
+        }
+      },
+      "impactRating": {
+        "severity": "High"
+      }
+    },
+    {
+      "checkId": "ENTRA-GROUP-005",
+      "name": "Self-Service Group Management Enabled Without Restrictions",
+      "category": "GROUP",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "frameworks": {
+        "nist-csf": {
+          "controlId": "PR.AA-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
+        },
+        "nist-800-53": {
+          "controlId": "AC-3;CM-7",
+          "title": "Access Enforcement; Least Functionality",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High"
+          ]
+        },
+        "iso-27001": {
+          "controlId": "A.5.15;A.5.18",
+          "title": "Access control; Access rights"
+        },
+        "essential-eight": {
+          "controlId": "ML1-P5"
+        },
+        "hipaa": {
+          "controlId": "§164.312(a)(1)",
+          "title": "Access Control"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "evidenceType": "config-export",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials"
+        }
+      },
+      "impactRating": {
+        "severity": "Medium"
       }
     }
   ]

--- a/data/standalone-checks.json
+++ b/data/standalone-checks.json
@@ -817,5 +817,671 @@
         "evidenceType": "config-export"
       }
     }
+  },
+  {
+    "checkId": "CA-COVERAGE-001",
+    "name": "Device Code Flow Blocked by CA Policy",
+    "category": "COVERAGE",
+    "collector": "CAEvaluator",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-03"
+      },
+      "nist-800-53": {
+        "controlId": "CM-7;IA-2"
+      },
+      "iso-27001": {
+        "controlId": "A.8.5;A.8.20"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.7",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "CA-COVERAGE-002",
+    "name": "Legacy Authentication Blocked by CA Policy",
+    "category": "COVERAGE",
+    "collector": "CAEvaluator",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-03"
+      },
+      "nist-800-53": {
+        "controlId": "CM-7;IA-2"
+      },
+      "iso-27001": {
+        "controlId": "A.8.5;A.8.20"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.7",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "CA-COVERAGE-003",
+    "name": "MFA Enforced for All Users",
+    "category": "COVERAGE",
+    "collector": "CAEvaluator",
+    "impactRating": {
+      "severity": "Critical"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-03;PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "IA-2(1);IA-2(2)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.8.5"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5;ML3-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(d)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "CA-COVERAGE-004",
+    "name": "Phishing-Resistant MFA for Admins",
+    "category": "COVERAGE",
+    "collector": "CAEvaluator",
+    "impactRating": {
+      "severity": "Critical"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-03;PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "IA-2(6);AC-6(5)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.8.5"
+      },
+      "essential-eight": {
+        "controlId": "ML3-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(d)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "CA-COVERAGE-005",
+    "name": "Sign-in Risk-Based CA Policy Exists",
+    "category": "COVERAGE",
+    "collector": "CAEvaluator",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "DE.AE-2;PR.AA-03"
+      },
+      "nist-800-53": {
+        "controlId": "AC-7;SI-4"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.8.16"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC7.2",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "CA-COVERAGE-006",
+    "name": "User Risk-Based CA Policy Exists",
+    "category": "COVERAGE",
+    "collector": "CAEvaluator",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "DE.AE-2;PR.AA-03"
+      },
+      "nist-800-53": {
+        "controlId": "AC-7;SI-4"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.8.16"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC7.2",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "CA-COVERAGE-007",
+    "name": "Security Info Registration Protected by CA",
+    "category": "COVERAGE",
+    "collector": "CAEvaluator",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-03;PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "IA-2;IA-5"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.8.5"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "CA-COVERAGE-008",
+    "name": "Device Registration Restricted by CA",
+    "category": "COVERAGE",
+    "collector": "CAEvaluator",
+    "impactRating": {
+      "severity": "Medium"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-03"
+      },
+      "nist-800-53": {
+        "controlId": "CM-8;IA-3"
+      },
+      "iso-27001": {
+        "controlId": "A.8.1;A.8.5"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "soc2": {
+        "controlId": "CC6.1",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-APPS-002",
+    "name": "Enterprise Apps with Dangerous-Level Graph Permissions",
+    "category": "APPS",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "Critical"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05;PR.AC-4"
+      },
+      "nist-800-53": {
+        "controlId": "AC-6(5);AC-6(10)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18;A.8.2"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-APPS-003",
+    "name": "Enterprise Apps with High-Level Permissions and No Recent Activity",
+    "category": "APPS",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05;PR.AC-4"
+      },
+      "nist-800-53": {
+        "controlId": "AC-6(5);AC-2(3)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18;A.8.2"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-APPS-004",
+    "name": "Managed Identities with Dangerous-Level Permissions",
+    "category": "APPS",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "Critical"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05;PR.AC-4"
+      },
+      "nist-800-53": {
+        "controlId": "AC-6(5);AC-6(10)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18;A.8.2"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-PIM-006",
+    "name": "Tier-0 Role Activation Duration Exceeds 4 Hours",
+    "category": "PIM",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "AC-2(2);AC-6(5)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18;A.8.2"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5;ML3-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1);§164.308(a)(4)(i)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-PIM-007",
+    "name": "Tier-0 Role Activation Does Not Require Approval",
+    "category": "PIM",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "Critical"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "AC-2(2);AC-6(5)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18;A.8.2"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5;ML3-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1);§164.308(a)(4)(i)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-PIM-008",
+    "name": "Permanent Active Assignments on Tier-0 Roles",
+    "category": "PIM",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "Critical"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "AC-2(2);AC-6(5)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18;A.8.2"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5;ML3-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1);§164.308(a)(4)(i)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-PIM-009",
+    "name": "Eligible Assignments Without Expiration",
+    "category": "PIM",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "AC-2(2);AC-6(5)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-PIM-010",
+    "name": "PIM Activation Does Not Require MFA",
+    "category": "PIM",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-03;PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "IA-2(1);AC-6(5)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.8.5"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5;ML3-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(d);§164.312(a)(1)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-APPS-005",
+    "name": "Enterprise Apps with No Sign-in Activity in 180+ Days",
+    "category": "APPS",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "Medium"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "AC-2(3);CM-8"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18"
+      },
+      "essential-eight": {
+        "controlId": "ML1-P5"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-APPS-006",
+    "name": "Enterprise Apps Owned by External Tenant Principals",
+    "category": "APPS",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05;PR.AC-4"
+      },
+      "nist-800-53": {
+        "controlId": "AC-6(5);SA-9"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.19;A.5.20"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1);§164.308(b)(1)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.3;CC9.2",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-APPREG-002",
+    "name": "App Registrations with Credentials Expiring Within 30 Days",
+    "category": "APPREG",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "Medium"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-01"
+      },
+      "nist-800-53": {
+        "controlId": "IA-5;IA-5(1)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.17;A.8.5"
+      },
+      "essential-eight": {
+        "controlId": "ML1-P5"
+      },
+      "soc2": {
+        "controlId": "CC6.1",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-APPREG-003",
+    "name": "App Registrations with Credential Lifetime Exceeding 2 Years",
+    "category": "APPREG",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-01"
+      },
+      "nist-800-53": {
+        "controlId": "IA-5;IA-5(1)"
+      },
+      "iso-27001": {
+        "controlId": "A.5.17;A.8.5"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(d)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-ADMIN-004",
+    "name": "On-Premises Synced Accounts Holding Tier-0 Roles",
+    "category": "ADMIN",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "Critical"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "AC-6(5);AC-2"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18;A.8.2"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5;ML3-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1);§164.308(a)(4)(i)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.2;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-GROUP-004",
+    "name": "Dynamic Groups with User-Modifiable Attribute Rules Granting Privileged Access",
+    "category": "GROUP",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "High"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05;PR.AC-4"
+      },
+      "nist-800-53": {
+        "controlId": "AC-6(5);AC-3"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18;A.8.2"
+      },
+      "essential-eight": {
+        "controlId": "ML2-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
+  },
+  {
+    "checkId": "ENTRA-GROUP-005",
+    "name": "Self-Service Group Management Enabled Without Restrictions",
+    "category": "GROUP",
+    "collector": "Entra",
+    "impactRating": {
+      "severity": "Medium"
+    },
+    "frameworks": {
+      "nist-csf": {
+        "controlId": "PR.AA-05"
+      },
+      "nist-800-53": {
+        "controlId": "AC-3;CM-7"
+      },
+      "iso-27001": {
+        "controlId": "A.5.15;A.5.18"
+      },
+      "essential-eight": {
+        "controlId": "ML1-P5"
+      },
+      "hipaa": {
+        "controlId": "§164.312(a)(1)"
+      },
+      "soc2": {
+        "controlId": "CC6.1;CC6.3",
+        "evidenceType": "config-export"
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Summary

- Register **23 new standalone checks** across 4 M365-Remediate consumer requests
- **CA-COVERAGE-001..008** — Conditional Access policy coverage gap analysis (8 checks)
- **ENTRA-APPS-002..006** — API permission severity classification + app hygiene (5 checks)
- **ENTRA-PIM-006..010** — Granular PIM misconfiguration detection (5 checks)
- **ENTRA-APPREG-002..003** — Credential lifecycle monitoring (2 checks)
- **ENTRA-ADMIN-004** — On-premises synced Tier-0 account detection (1 check)
- **ENTRA-GROUP-004..005** — Dynamic group privilege escalation + self-service risks (2 checks)
- All 23 checks include NIST CSF, NIST 800-53, ISO 27001, Essential Eight, and SOC 2 mappings
- Registry total: 169 → 192 checks
- Module version bumped to **1.3.0**

Closes #80, #81, #82, #83

## Test plan

- [x] `Build-Registry.ps1` regenerates registry successfully (192 checks)
- [x] `Invoke-Pester ./tests/` — 204/204 tests pass
- [x] `Test-RegistryData.ps1` — 13/13 data quality checks pass
- [x] `Test-ModuleManifest ./CheckID.psd1` — valid, version 1.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)