### PR TITLE
fix: correct profiles array serialization in registry.json

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -11117,7 +11117,9 @@
         "nist-800-53": {
           "controlId": "AC-3(2);CM-5(1)",
           "title": "Dual Authorization; Automated Access Enforcement",
-          "profiles": "High"
+          "profiles": [
+            "High"
+          ]
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.PS-01",


### PR DESCRIPTION
## Summary

PowerShell's `ConvertTo-Json` unwraps single-element arrays into bare strings. `INTUNE-MAA-001`'s `nist-800-53.profiles` was serialized as `"High"` instead of `["High"]`, failing JSON schema validation.

## Test plan

- [x] JSON schema validation passes locally
- [x] CI Validate Data Files job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)