### PR TITLE
feat: add cross-repo CI workflows

### DIFF
--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -1,0 +1,54 @@
+name: Notify Downstream
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  notify:
+    name: Notify consumer repos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get release info
+        id: info
+        shell: bash
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch to M365-Assess
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: Galvnyz/M365-Assess
+          event-type: checkid-released
+          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}"}'
+
+      - name: Dispatch to M365-Remediate
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: Galvnyz/M365-Remediate
+          event-type: checkid-released
+          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}"}'
+
+      - name: Dispatch to StrykerScan
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: Galvnyz/StrykerScan
+          event-type: checkid-released
+          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}"}'
+
+      - name: Summary
+        run: |
+          echo "### Downstream notifications sent" >> "$GITHUB_STEP_SUMMARY"
+          echo "- M365-Assess" >> "$GITHUB_STEP_SUMMARY"
+          echo "- M365-Remediate" >> "$GITHUB_STEP_SUMMARY"
+          echo "- StrykerScan" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "CheckID **${{ steps.info.outputs.tag }}** released." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rebuild-from-secframe.yml
+++ b/.github/workflows/rebuild-from-secframe.yml
@@ -1,0 +1,59 @@
+name: Rebuild from SecFrame
+
+on:
+  repository_dispatch:
+    types: [secframe-updated]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rebuild:
+    name: Rebuild registry from SecFrame
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch latest SecFrame data
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        run: |
+          echo "SecFrame update triggered: ${{ github.event.client_payload.frameworks }}"
+          # Fetch the CIS crosswalk CSV (primary mapping source)
+          gh api repos/Galvnyz/SecFrame/contents/CIS/CIS_M365_to_NIST_to_FedRAMP_Crosswalk.csv \
+            --jq '.content' | base64 -d > data/framework-mappings.csv || true
+
+      - name: Rebuild registry
+        shell: pwsh
+        run: |
+          ./scripts/Build-Registry.ps1
+          ./scripts/Test-RegistryData.ps1
+
+      - name: Check for changes
+        id: diff
+        run: |
+          git diff --quiet data/ && echo "changed=false" >> "$GITHUB_OUTPUT" \
+            || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create PR if changed
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN }}
+        run: |
+          BRANCH="chore/secframe-sync-$(date +%Y%m%d)"
+          git checkout -b "$BRANCH"
+          git add data/
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: sync registry from SecFrame update"
+          git push origin "$BRANCH"
+          gh pr create \
+            --title "chore: sync registry from SecFrame update" \
+            --body "Automated PR triggered by SecFrame framework data update.
+
+Frameworks changed: ${{ github.event.client_payload.frameworks }}
+
+Review the registry diff and merge when ready." \
+            --base main \
+            --head "$BRANCH"


### PR DESCRIPTION
## Summary

- **notify-downstream.yml**: On new tag, dispatches `checkid-released` event to M365-Assess, M365-Remediate, and StrykerScan
- **rebuild-from-secframe.yml**: On `secframe-updated` dispatch, fetches latest SecFrame data, rebuilds registry, and opens a PR

### Prerequisites

Requires `CROSS_REPO_TOKEN` secret — a GitHub PAT with `repo` scope for the Galvnyz org.

## Test plan

- [ ] Tagging a new version triggers dispatch to all 3 consumer repos
- [ ] SecFrame dispatch triggers registry rebuild and PR creation

Part of #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)