### PR TITLE
docs: update all documentation for v2.1.0 SCF coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to the CheckID module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.1.0] - 2026-03-23
+
+### Added
+
+- `data/framework-overrides.json` — manual framework mappings for 59 checks where SCF lacks coverage (NIST CSF 2.0 and SOC 2 gaps)
+- HIPAA HICP frameworks (Small/Medium/Large Practice) added to `scf-framework-map.json`
+- Parent control fallback in `Build-Registry.py` — sub-controls (e.g., IAC-21.3) inherit parent (IAC-21) framework mappings when missing
+
+### Changed
+
+- All 15 frameworks now meet or exceed v1.1.0 coverage levels — zero regressions
+- Framework coverage improvements vs v2.0.0:
+  - HIPAA: 84 → 203 (+119, via HICP frameworks)
+  - NIST CSF: 124 → 207 (+83, via parent fallback + overrides)
+  - SOC 2: 202 → 222 (+20, via overrides)
+  - MITRE ATT&CK: 187 → 213 (+26, via parent fallback)
+  - ISO 27001: 193 → 210 (+17, via parent fallback)
+  - CIS Controls: 174 → 199 (+25, via parent fallback)
+  - Essential Eight: 82 → 103 (+21, via parent fallback)
+  - CMMC: 206 → 215 (+9, via parent fallback)
+  - PCI DSS: 205 → 213 (+8, via parent fallback)
+- Updated all documentation for current coverage numbers
+
 ## [2.0.0] - 2026-03-22
 
 ### Added
@@ -43,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - HIPAA uses both Administrative Simplification and Security Rule from SCF
 - CI workflows updated for SCF-based validation
 
-## [Unreleased] - 2026-03-20
+## [1.3.0] - 2026-03-20
 
 ### Added
 
@@ -52,19 +75,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - 5 enhanced PIM checks: ENTRA-PIM-006..010 (#82)
 - 7 Entra security checks: ENTRA-APPS-005..006, ENTRA-APPREG-002..003, ENTRA-ADMIN-004, ENTRA-GROUP-004..005 (#83)
 - Essential Eight framework mappings for all 23 new checks
+- Cross-repo CI workflows for SecFrame → CheckID → downstream cascade (#97)
 
 ### Removed
 
-- All 94 MANUAL-CIS entries removed from the registry (169 checks remain, down from 250)
+- All 94 MANUAL-CIS entries removed from the registry (222 checks total)
 - `supersededBy` field removed from all registry entries (was on 81 checks)
 - `SupersededBy` column removed from CSV data files
 - `tests/search-registry.Tests.ps1` deleted
+- PSGallery publishing infrastructure (#94)
 
 ### Changed
 
 - 14 former MANUAL-CIS checks converted to proper `{SERVICE}-{AREA}-{NNN}` identifiers
 - `Import-ControlRegistry.ps1`, `Search-Registry.ps1`, and `Show-CheckProgress.ps1` removed — superseded by module cmdlets (`Get-CheckRegistry`, `Search-Check`, `Get-CheckAutomationGaps`) (#85)
-- Updated documentation to reflect new check counts and removal of supersession tracking
+- Reconciled 53 downstream checks into registry (#95)
 
 ## [1.2.0] - 2026-03-17
 

--- a/README.md
+++ b/README.md
@@ -83,22 +83,22 @@ for check in registry['checks']:
 
 ## Supported Frameworks
 
-All framework mappings are derived from the SCF database, except CIS M365, CISA ScuBA, and STIG (manually mapped).
+All framework mappings are derived from the SCF database, supplemented by manual overrides for gaps in SCF coverage and for frameworks not in SCF (CIS M365, CISA ScuBA, STIG).
 
 | Framework | Key | Coverage | Source | Profiles |
 |-----------|-----|----------|--------|----------|
 | NIST SP 800-53 Rev 5 | `nist-800-53` | 222 checks | SCF | Low, Moderate, High, Privacy |
 | FedRAMP Rev 5 | `fedramp` | 222 checks | SCF | |
-| CMMC 2.0 | `cmmc` | 206 checks | SCF | |
-| PCI DSS v4.0.1 | `pci-dss` | 205 checks | SCF | |
-| SOC 2 Trust Services Criteria | `soc2` | 202 checks | SCF | |
-| ISO/IEC 27001:2022 | `iso-27001` | 193 checks | SCF | |
-| MITRE ATT&CK v10 | `mitre-attack` | 187 checks | SCF | |
+| SOC 2 Trust Services Criteria | `soc2` | 222 checks | SCF + override | |
+| CMMC 2.0 | `cmmc` | 215 checks | SCF | |
+| MITRE ATT&CK v10 | `mitre-attack` | 213 checks | SCF | |
+| PCI DSS v4.0.1 | `pci-dss` | 213 checks | SCF | |
+| ISO/IEC 27001:2022 | `iso-27001` | 210 checks | SCF | |
+| NIST Cybersecurity Framework 2.0 | `nist-csf` | 207 checks | SCF + override | |
+| HIPAA | `hipaa` | 203 checks | SCF | |
+| CIS Controls v8.1 | `cis-controls-v8` | 199 checks | SCF | |
 | CIS Microsoft 365 v6.0.1 | `cis-m365-v6` | 175 checks | Manual | E3-L1, E3-L2, E5-L1, E5-L2 |
-| CIS Controls v8.1 | `cis-controls-v8` | 174 checks | SCF | |
-| NIST Cybersecurity Framework 2.0 | `nist-csf` | 124 checks | SCF | |
-| Essential Eight (ASD) | `essential-eight` | 82 checks | SCF | ML1, ML2, ML3 |
-| HIPAA Security Rule | `hipaa` | 84 checks | SCF | |
+| Essential Eight (ASD) | `essential-eight` | 103 checks | SCF | ML1, ML2, ML3 |
 | CISA SCuBA | `cisa-scuba` | 54 checks | Manual | |
 | DISA STIG | `stig` | 13 checks | Manual | |
 | EU GDPR | `gdpr` | 8 checks | SCF | |
@@ -147,6 +147,7 @@ CheckID/
 │   ├── registry.json              Master registry (222 checks, 15 frameworks, schema v2.0.0)
 │   ├── scf-check-mapping.json     Check → SCF control assignments (source of truth)
 │   ├── scf-framework-map.json     SCF framework ID → CheckID key config
+│   ├── framework-overrides.json   Manual framework mappings for SCF coverage gaps
 │   ├── framework-titles.json      Human-readable control titles
 │   └── frameworks/                Framework definitions (15 JSON files)
 ├── scripts/

--- a/REFERENCES.md
+++ b/REFERENCES.md
@@ -3,16 +3,15 @@
 ## Upstream: SecFrame
 
 [SecFrame](https://github.com/Galvnyz/SecFrame) is the authoritative source
-for security framework reference data. CheckID's framework mappings are derived from:
+for security framework reference data. Since v2.0.0, CheckID uses the SCF
+(Secure Controls Framework) database as its primary source of truth:
 
 | SecFrame File | What It Provides |
 |---------------|-----------------|
-| `CIS/CIS_M365_to_NIST_to_FedRAMP_Crosswalk.csv` | CIS M365 to NIST 800-53 to FedRAMP mappings |
-| `SOC/tsc_to_nist_800-53.xlsx` | SOC 2 Trust Services Criteria to NIST 800-53 |
-| `SCF/secure-controls-framework-scf-2025-4.csv` | Master cross-framework mapping (80+ frameworks) |
-| `SCF/scf.db` | Normalized SQLite database (13 tables, 261 frameworks, 66K+ mappings) |
-| `SCF/checkid-framework-export.csv` | CheckID-compatible flat export from SCF database |
-| `NIST/csf-pf-to-sp800-53r5-mappings.xlsx` | NIST CSF 2.0 to NIST 800-53 R5 |
+| `SCF/scf.db` | **Primary source** — Normalized SQLite database (13 tables, 261 frameworks, 66K+ mappings) |
+| `SCF/secure-controls-framework-scf-2025-4.csv` | Master cross-framework mapping (SCF 2025.4) |
+| `NIST/NIST_SP-800-53_rev5_catalog.json` | NIST 800-53 OSCAL catalog (for title resolution) |
+| `NIST/NIST_CSF_v2.0_catalog.json` | NIST CSF 2.0 OSCAL catalog (for title resolution) |
 
 ### Update Workflow (Automated)
 
@@ -23,7 +22,13 @@ When SecFrame merges changes to framework data directories, the CI cascade trigg
 3. After PR merge and tag, `notify-downstream.yml` dispatches `checkid-released` to consumers
 4. Consumers receive dispatch and auto-create sync PRs
 
-Manual workflow: edit CSVs → `Build-Registry.ps1` → `Test-RegistryData.ps1` → commit → tag
+Manual workflow: edit `data/scf-check-mapping.json` → `python scripts/Build-Registry.py` → `Test-RegistryData.ps1` → commit → tag
+
+**Build pipeline inputs:**
+- `data/scf-check-mapping.json` — check → SCF control assignments (human-curated)
+- `data/scf-framework-map.json` — which SCF frameworks to include
+- `data/framework-overrides.json` — manual mappings for SCF coverage gaps
+- `SecFrame/SCF/scf.db` — SCF SQLite database (upstream)
 
 ## Downstream Consumers
 

--- a/docs/CheckId-Guide.md
+++ b/docs/CheckId-Guide.md
@@ -1,6 +1,6 @@
 # CheckId System Guide
 
-The CheckId system is the backbone of M365-Assess's multi-framework compliance reporting. Each security check gets a framework-agnostic identifier that maps to controls across 14 compliance frameworks simultaneously.
+The CheckId system is the backbone of M365-Assess's multi-framework compliance reporting. Each security check gets a framework-agnostic identifier anchored to an SCF (Secure Controls Framework) control and mapped across 15 compliance frameworks simultaneously.
 
 ## What Is a CheckId?
 
@@ -40,13 +40,13 @@ This is handled automatically by the `Add-Setting` function's `$checkIdCounter` 
 
 | Type | Count | Description |
 |------|-------|-------------|
-| Automated | 168 | Checked by collectors, appear in CSV output and reports |
-| Manual | 1 | CIS benchmark controls not yet automated, tracked for coverage |
-| **Total** | **169** | Full registry across all frameworks |
+| Automated | 221 | Checked by collectors, appear in CSV output and reports |
+| Manual | 1 | Requires human assessment, tracked for coverage |
+| **Total** | **222** | Full registry across 15 frameworks |
 
 ## The Control Registry
 
-All CheckIds live in `data/registry.json`. Each entry contains:
+All CheckIds live in `data/registry.json` (schema v2.0.0). Each entry contains:
 
 ```json
 {
@@ -56,34 +56,36 @@ All CheckIds live in `data/registry.json`. Each entry contains:
   "collector": "Entra",
   "hasAutomatedCheck": true,
   "licensing": { "minimum": "E3" },
+  "scf": {
+    "primaryControlId": "IAC-21.3",
+    "domain": "Identification & Authentication",
+    "controlName": "Privileged Account Management...",
+    "controlDescription": "...",
+    "relativeWeighting": 10,
+    "csfFunction": "Protect",
+    "maturityLevels": { "cmm0_notPerformed": true, "...": "..." },
+    "assessmentObjectives": [{ "aoId": "IAC-21.3_A01", "text": "..." }],
+    "risks": ["R-AC-1", "R-AC-2"],
+    "threats": ["NT-7", "MT-1"]
+  },
   "frameworks": {
-    "cis-m365-v6": {
-      "controlId": "1.1.3",
-      "title": "Ensure that between two and four global admins are designated",
-      "profiles": ["E3-L1", "E5-L1"]
-    },
-    "nist-800-53": {
-      "controlId": "AC-2;AC-6",
-      "title": "Account Management; Least Privilege",
-      "profiles": ["Low", "Moderate", "High"]
-    },
-    "nist-csf": { "controlId": "PR.AA-05" },
-    "iso-27001": { "controlId": "A.5.15;A.5.18;A.8.2" },
+    "nist-800-53": { "controlId": "AC-6(5)", "profiles": ["Moderate", "High"] },
+    "cis-m365-v6": { "controlId": "1.1.3", "profiles": ["E3-L1", "E5-L1"] },
+    "iso-27001": { "controlId": "5.18;8.2" },
     "stig": { "controlId": "V-260335" },
-    "pci-dss": { "controlId": "8.2.x" },
-    "cmmc": { "controlId": "3.1.5;3.1.6" },
-    "hipaa": { "controlId": "§164.312(a)(1);§164.308(a)(4)(i)" },
-    "cisa-scuba": { "controlId": "MS.AAD.7.1v1" },
-    "soc2": { "controlId": "CC6.1;CC6.2;CC6.3", "evidenceType": "config-export" }
-  }
+    "soc2": { "controlId": "CC6.1;CC6.3" }
+  },
+  "impactRating": { "severity": "Medium", "scfWeighting": 10 }
 }
 ```
 
 **Key fields:**
+- `scf` -- SCF control metadata: domain, maturity levels, assessment objectives, risks, threats
 - `hasAutomatedCheck` -- Whether a collector evaluates this check automatically
 - `collector` -- Which collector script produces the result (see Collectors table below)
 - `licensing.minimum` -- E3 or E5 license required
-- `frameworks` -- Maps to every applicable compliance framework
+- `frameworks` -- Maps to every applicable compliance framework (derived from SCF + manual overlays)
+- `impactRating` -- Severity and SCF relative weighting for prioritization
 
 ### Collectors
 
@@ -101,24 +103,25 @@ All CheckIds live in `data/registry.json`. Each entry contains:
 
 ## Supported Frameworks
 
-| Framework | Registry Key | Notes |
-|-----------|-------------|-------|
-| CIS M365 v6.0.1 | `cis-m365-v6` | 4 profiles: E3-L1, E3-L2, E5-L1, E5-L2 |
-| NIST 800-53 Rev 5 | `nist-800-53` | 4 baseline profiles: Low, Moderate, High, Privacy |
-| NIST CSF 2.0 | `nist-csf` | Functions and categories (PR.AC, DE.CM, etc.) |
-| ISO 27001:2022 | `iso-27001` | Annex A controls |
-| DISA STIG | `stig` | Vulnerability IDs (V-xxxxxx) |
-| PCI DSS v4.0.1 | `pci-dss` | Requirements |
-| CMMC 2.0 | `cmmc` | Practices (3.x.x) |
-| HIPAA Security Rule | `hipaa` | Sec. 164.3xx references |
-| CISA SCuBA | `cisa-scuba` | MS.AAD/EXO/DEFENDER/SPO/TEAMS baselines |
-| SOC 2 TSC | `soc2` | Trust Services Criteria (CC/A/C/PI/P) |
-| FedRAMP Rev 5 | `fedramp` | Derived from NIST 800-53 via SCF bridge |
-| CIS Controls v8.1 | `cis-controls-v8` | Derived from NIST 800-53 via SCF bridge |
-| Essential Eight (ASD) | `essential-eight` | ML1–ML3 maturity levels, P1–P7 strategies; derived via SCF bridge |
-| MITRE ATT&CK v10 | `mitre-attack` | Derived from NIST 800-53 via SCF bridge |
+All framework mappings are derived from the SCF database, with parent control fallback and manual overrides for coverage gaps. CIS M365, CISA ScuBA, and STIG are manually mapped (not in SCF).
 
-SOC 2 mappings are auto-derived from NIST 800-53 control families using rules in `scripts/Build-Registry.ps1`. FedRAMP, CIS Controls v8, Essential Eight, and MITRE ATT&CK are derived via the SecFrame SCF transitive bridge.
+| Framework | Registry Key | Coverage | Source | Notes |
+|-----------|-------------|----------|--------|-------|
+| NIST 800-53 Rev 5 | `nist-800-53` | 222 | SCF | 4 baselines: Low, Moderate, High, Privacy |
+| FedRAMP Rev 5 | `fedramp` | 222 | SCF | |
+| SOC 2 TSC | `soc2` | 222 | SCF + override | AICPA Trust Services Criteria |
+| CMMC 2.0 | `cmmc` | 215 | SCF | Levels 1-3 |
+| MITRE ATT&CK v10 | `mitre-attack` | 213 | SCF | Technique IDs |
+| PCI DSS v4.0.1 | `pci-dss` | 213 | SCF | |
+| ISO 27001:2022 | `iso-27001` | 210 | SCF | ISO 27001 + 27002 (Annex A) |
+| NIST CSF 2.0 | `nist-csf` | 207 | SCF + override | Functions/categories (PR.AA, DE.CM, etc.) |
+| HIPAA | `hipaa` | 203 | SCF | Admin Simplification + Security Rule + HICP |
+| CIS Controls v8.1 | `cis-controls-v8` | 199 | SCF | Implementation Groups |
+| CIS M365 v6.0.1 | `cis-m365-v6` | 175 | Manual | 4 profiles: E3-L1, E3-L2, E5-L1, E5-L2 |
+| Essential Eight (ASD) | `essential-eight` | 103 | SCF | ML1-ML3 maturity, P1-P8 strategies |
+| CISA SCuBA | `cisa-scuba` | 54 | Manual | MS.AAD/EXO/DEFENDER/SPO/TEAMS baselines |
+| DISA STIG | `stig` | 13 | Manual | Vulnerability IDs (V-xxxxxx) |
+| EU GDPR | `gdpr` | 8 | SCF | |
 
 ### NIST 800-53 Coverage Scope
 
@@ -164,7 +167,7 @@ The [Essential Eight](https://www.cyber.gov.au/resources-business-and-government
 
 Control IDs use the format `ML{level}-P{strategy}` (e.g., `ML1-P4;ML2-P4;ML3-P4`). Higher maturity levels are cumulative — ML3 includes all ML2 requirements, which include all ML1 requirements.
 
-Seven of the eight strategies (P1–P7) are mapped to M365 checks. P8 (Regular Backups) is not assessable through M365 configuration export. Essential Eight mappings are derived from NIST 800-53 controls via the SecFrame SCF transitive bridge.
+Seven of the eight strategies (P1–P7) are mapped to M365 checks. P8 (Regular Backups) is not assessable through M365 configuration export. Essential Eight mappings are derived directly from SCF control mappings (framework_id=219), supplemented by parent control fallback.
 
 The framework definition is in `data/frameworks/essential-eight.json`.
 
@@ -177,11 +180,11 @@ Entra collector   ->  CheckId column in CSV  ->  Looks up CheckId
 checks settings      (e.g., ENTRA-ADMIN-001)   in registry.json
                                                     |
                                                     v
-                                              Extracts ALL framework
-                                              mappings from one entry
+                                              Extracts SCF metadata
+                                              + ALL framework mappings
                                                     |
                                                     v
-                                              Populates 14 framework
+                                              Populates 15 framework
                                               columns in compliance
                                               matrix (HTML + XLSX)
 ```
@@ -205,39 +208,43 @@ Each check produces one of five statuses:
 
 ## Building the Registry
 
-The registry can be generated from two CSV source files:
+The registry is built from `scf-check-mapping.json` + the SCF SQLite database:
 
 ```
-data/framework-mappings.csv          ->  CIS controls + framework cross-references
-data/check-id-mapping.csv            ->  CheckId assignments + collector mapping
+data/scf-check-mapping.json         ->  Check → SCF control assignments (source of truth)
+data/scf-framework-map.json         ->  Which SCF frameworks to include
+data/framework-overrides.json       ->  Manual mappings for SCF coverage gaps
+SecFrame/SCF/scf.db                 ->  SCF SQLite database (upstream)
                                          |
                                          v
-                               scripts/Build-Registry.ps1
+                               scripts/Build-Registry.py
                                          |
                                          v
-                               data/registry.json (169 entries)
+                               data/registry.json (222 entries, schema v2.0.0)
 ```
 
-To rebuild after editing the source CSVs:
+To rebuild (requires `scf.db` accessible locally):
 
 ```powershell
+python scripts/Build-Registry.py
+# Or via PowerShell wrapper:
 .\scripts\Build-Registry.ps1
 ```
-
-> **Note:** New automated checks added since v0.7.0 are typically added directly to `registry.json` rather than going through the CSV pipeline. Both approaches produce the same registry format.
 
 ## Adding a New CheckId
 
 1. **Assign the CheckId** following the `{COLLECTOR}-{AREA}-{NNN}` convention
-2. **Add the entry** to `data/registry.json` with framework mappings
-3. **Add the check** to the appropriate collector script using `Add-Setting -CheckId 'YOUR-CHECK-001'`
+2. **Add the entry** to `data/scf-check-mapping.json` with SCF primary control and metadata
+3. **Rebuild the registry**: `python scripts/Build-Registry.py`
+4. **Add the check** to the appropriate collector script using `Add-Setting -CheckId 'YOUR-CHECK-001'`
 5. **Run tests** to validate: `Invoke-Pester -Path './tests'`
 
 ### Checklist for New Checks
 
 - [ ] CheckId follows `{COLLECTOR}-{AREA}-{NNN}` format
 - [ ] Registry entry has `hasAutomatedCheck: true`, `collector`, `category`, and `licensing`
-- [ ] All applicable framework mappings included (at minimum: `cis-m365-v6`, `nist-800-53`, `soc2`)
+- [ ] SCF primary control assigned in `data/scf-check-mapping.json`
+- [ ] All applicable framework mappings derived from SCF (verify after rebuild)
 - [ ] Collector uses `Add-Setting` with `-CheckId` parameter
 - [ ] Status logic: Pass/Fail for deterministic checks, Review for API gaps, Info for data points
 - [ ] Remediation text includes specific portal path or PowerShell command


### PR DESCRIPTION
## Summary
- **README.md**: Framework coverage table updated to final v2.1.0 numbers (all 15 frameworks meet or exceed v1.1.0), added `framework-overrides.json` to repo structure
- **CHANGELOG.md**: Added v2.1.0 entry with coverage recovery details, fixed stale `[Unreleased]` section (now versioned as v1.3.0)
- **REFERENCES.md**: Replaced CSV pipeline references with SCF-based workflow, updated SecFrame file table
- **docs/CheckId-Guide.md**: Updated check counts (169 -> 222), rewrote build pipeline for SCF, updated schema example with `scf{}` object, updated framework table with 15 frameworks, updated new-check workflow

## Test plan
- [x] No code changes — docs only
- [ ] CI passes (lint + existing tests unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)