### PR TITLE
fix: escalate SPO anonymous sharing checks to Critical

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -1505,7 +1505,7 @@
         }
       },
       "impactRating": {
-        "severity": "High",
+        "severity": "Critical",
         "rationale": "Failure to uniquely identify and centrally Authenticate, Authorize and Audit (AAA) third-party users and processes that provide services to the organization exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
         "scfWeighting": 9
       }
@@ -12614,7 +12614,7 @@
         }
       },
       "impactRating": {
-        "severity": "Medium",
+        "severity": "Critical",
         "rationale": "Failure to utilize the concept of least privilege, allowing only authorized access to processes necessary to accomplish assigned tasks in accordance with organizational business functions exposes the tenant to: Inability to maintain individual accountability, Improper assignment.",
         "scfWeighting": 10
       }

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -2416,7 +2416,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "High",
+      "impactSeverity": "Critical",
       "impactRationale": "Failure to uniquely identify and centrally Authenticate, Authorize and Audit (AAA) third-party users and processes that provide services to the organization exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "7.2.3",
       "cisM365Profiles": [
@@ -2500,7 +2500,7 @@
       "scfAdditional": [
         "IAC-20"
       ],
-      "impactSeverity": "Medium",
+      "impactSeverity": "Critical",
       "impactRationale": "Failure to utilize the concept of least privilege, allowing only authorized access to processes necessary to accomplish assigned tasks in accordance with organizational business functions exposes the tenant to: Inability to maintain individual accountability, Improper assignment.",
       "cisM365ControlId": "7.2.7",
       "cisM365Profiles": [


### PR DESCRIPTION
Closes #124.

SPO-SHARING-001 (externalUserAndGuestSharing) and SPO-SHARING-004 (anonymous links) escalated from High to Critical.

Rationale: M365-Assess v1.8 escalated both to Fail verdict. CIS M365 v6.0.1 rates anonymous link sharing as Level 1 (highest priority). SPO-SHARING-003/005/006 unchanged — those are API data-quality signals, not risk re-assessments.