### PR TITLE
feat: Build-Registry.py override append mode + ENTRA-ADMINROLE-SEPARATION-001 CMMC fix

### DIFF
--- a/data/framework-overrides.json
+++ b/data/framework-overrides.json
@@ -330,6 +330,12 @@
         "controlId": "PR.AA-05"
       }
     },
+    "ENTRA-ADMINROLE-SEPARATION-001": {
+      "cmmc": {
+        "mode": "append",
+        "controlId": "SC.L2-3.13.3"
+      }
+    },
     "ENTRA-CA-SESSIONFREQ-001": {
       "cmmc": {
         "controlId": "SC.L2-3.13.9"

--- a/data/registry.json
+++ b/data/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.0.0",
-  "dataVersion": "2026-04-16",
+  "dataVersion": "2026-04-17",
   "generatedFrom": "data/scf-check-mapping.json + SecFrame/SCF/scf.db + data/scf-framework-map.json + data/az-assess-source-checks.json",
   "checks": [
     {
@@ -15171,7 +15171,7 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L2-3.1.5;AC.L2-3.1.6"
+          "controlId": "AC.L2-3.1.5;AC.L2-3.1.6;SC.L2-3.13.3"
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -591,9 +591,18 @@ def main():
             frameworks["stig"] = stig_entry
 
         # Apply manual framework overrides (for gaps in SCF coverage)
+        # mode: "replace" (default) — fills when key is absent; "append" — merges controlIds into existing entry
         check_overrides = fw_overrides.get(check_id, {})
         for fw_key, fw_data in check_overrides.items():
-            if fw_key not in frameworks and fw_data.get("controlId"):
+            if not fw_data.get("controlId"):
+                continue
+            mode = fw_data.get("mode", "replace")
+            if mode == "append" and fw_key in frameworks:
+                existing_ids = [x.strip() for x in frameworks[fw_key].get("controlId", "").split(";") if x.strip()]
+                new_ids = [x.strip() for x in fw_data["controlId"].split(";") if x.strip()]
+                merged = existing_ids + [x for x in new_ids if x not in existing_ids]
+                frameworks[fw_key]["controlId"] = ";".join(merged)
+            elif fw_key not in frameworks:
                 entry = OrderedDict([("controlId", fw_data["controlId"])])
                 title = resolve_title(fw_data["controlId"], fw_key, titles)
                 if title:


### PR DESCRIPTION
## Summary

- Adds `mode: "append"` support to `framework-overrides.json` entries in `Build-Registry.py`
- Fixes `ENTRA-ADMINROLE-SEPARATION-001` CMMC mapping to include `SC.L2-3.13.3` alongside the DB-derived practices

## Details

### Override Append Mode (#161)

The `Build-Registry.py` override guard previously used `if fw_key not in frameworks`, meaning overrides could only **fill** missing framework keys — they couldn't extend existing ones. This blocked any check that already had CMMC coverage from DB derivation from also receiving a manually-specified practice via override.

New behavior with `mode: "append"` in the override entry:
- Merges `controlId` values into the existing entry (dedup, semicolon-delimited)
- Default (`mode: "replace"` or no mode field) preserves existing behavior — no regressions

### ENTRA-ADMINROLE-SEPARATION-001 Fix (#170)

The check was designed for `SC.L2-3.13.3` but `scfPrimary: IAC-21.2` already had DB-derived CMMC mappings (`AC.L2-3.1.5;AC.L2-3.1.6`), so the `SC.L2-3.13.3` override was silently dropped. With append mode, the CMMC field now correctly reads:

```
AC.L2-3.1.5;AC.L2-3.1.6;SC.L2-3.13.3
```

## Test plan

- [x] `scripts/Build-Registry.py` runs without errors
- [x] `ENTRA-ADMINROLE-SEPARATION-001` CMMC controlId includes `SC.L2-3.13.3`
- [x] All 281 Pester tests pass
- [x] Existing overrides without `mode` field unaffected (backwards-compatible)

Closes #161, closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)