### PR TITLE
fix: resolve data quality regressions from SCF rebase (v2.6.1)

### DIFF
--- a/data/az-assess-source-checks.json
+++ b/data/az-assess-source-checks.json
@@ -5,17 +5,26 @@
     "category": "PRIVILEGED_ACCESS",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "IAC-14",
       "domain": "Identification & Authentication",
       "controlName": "Least Privilege",
-      "controlDescription": "Access to Azure subscription management must be restricted. Owner role assignments should not exceed 3 principals to limit blast radius from compromised accounts."
+      "controlDescription": "Access to Azure subscription management must be restricted. Owner role assignments should not exceed 3 principals to limit blast radius from compromised accounts.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "AC.L2-3.1.1; AC.L2-3.1.5", "title": "Limit system access to authorized users and enforce least privilege" }
+      "cmmc": {
+        "controlId": "AC.L2-3.1.1; AC.L2-3.1.5",
+        "title": "Limit system access to authorized users and enforce least privilege"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Excessive Owner assignments violate least privilege and expand the attack surface for subscription takeover." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Excessive Owner assignments violate least privilege and expand the attack surface for subscription takeover."
+    }
   },
   {
     "checkId": "AZ-GOVERNANCE-002",
@@ -23,17 +32,26 @@
     "category": "CONFIGURATION_MANAGEMENT",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CFG-02",
       "domain": "Configuration Management",
       "controlName": "Configuration Baselines",
-      "controlDescription": "Azure subscriptions must have at least one resource lock configured to prevent accidental or unauthorized deletion or modification of critical resources."
+      "controlDescription": "Azure subscriptions must have at least one resource lock configured to prevent accidental or unauthorized deletion or modification of critical resources.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "CM.L2-3.4.2", "title": "Establish and enforce security configuration settings" }
+      "cmmc": {
+        "controlId": "CM.L2-3.4.2",
+        "title": "Establish and enforce security configuration settings"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Absence of locks allows accidental or malicious deletion of production resources with no rollback protection." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Absence of locks allows accidental or malicious deletion of production resources with no rollback protection."
+    }
   },
   {
     "checkId": "AZ-GOVERNANCE-003",
@@ -41,17 +59,26 @@
     "category": "CONFIGURATION_MANAGEMENT",
     "collector": "AzAssess",
     "hasAutomatedCheck": false,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CFG-01",
       "domain": "Configuration Management",
       "controlName": "Configuration Management Policy",
-      "controlDescription": "Azure Policy compliance must be reviewed manually in the Portal to confirm that assigned policies are not generating non-compliant findings against baseline configurations."
+      "controlDescription": "Azure Policy compliance must be reviewed manually in the Portal to confirm that assigned policies are not generating non-compliant findings against baseline configurations.",
+      "csfFunction": "Govern"
     },
     "frameworks": {
-      "cmmc": { "controlId": "CM.L2-3.4.1", "title": "Establish and maintain baseline configurations and inventories" }
+      "cmmc": {
+        "controlId": "CM.L2-3.4.1",
+        "title": "Establish and maintain baseline configurations and inventories"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Unreviewed policy non-compliance indicates configuration drift from the security baseline." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Unreviewed policy non-compliance indicates configuration drift from the security baseline."
+    }
   },
   {
     "checkId": "AZ-IDENTITY-001",
@@ -59,17 +86,26 @@
     "category": "ACCOUNT_MANAGEMENT",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "IAC-06",
       "domain": "Identification & Authentication",
       "controlName": "Account Management",
-      "controlDescription": "Guest user accounts in Azure AD should be reviewed and minimized. External identities with persistent access to Azure resources increase the risk of unauthorized access."
+      "controlDescription": "Guest user accounts in Azure AD should be reviewed and minimized. External identities with persistent access to Azure resources increase the risk of unauthorized access.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "AC.L2-3.1.1", "title": "Limit system access to authorized users" }
+      "cmmc": {
+        "controlId": "AC.L2-3.1.1",
+        "title": "Limit system access to authorized users"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Guest accounts are often over-privileged and rarely reviewed, creating persistent unauthorized access paths." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Guest accounts are often over-privileged and rarely reviewed, creating persistent unauthorized access paths."
+    }
   },
   {
     "checkId": "AZ-IDENTITY-002",
@@ -77,17 +113,26 @@
     "category": "CREDENTIAL_MANAGEMENT",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "IAC-07",
       "domain": "Identification & Authentication",
       "controlName": "Identifier Management",
-      "controlDescription": "Service principal credentials (client secrets and certificates) must not be expired. Expired credentials indicate abandoned applications or poor credential lifecycle management."
+      "controlDescription": "Service principal credentials (client secrets and certificates) must not be expired. Expired credentials indicate abandoned applications or poor credential lifecycle management.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "IA.L2-3.5.2", "title": "Authenticate the identities of users, processes, and devices" }
+      "cmmc": {
+        "controlId": "IA.L2-3.5.2",
+        "title": "Authenticate the identities of users, processes, and devices"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Expired credentials on active service principals indicate unmanaged automation that may have been compromised or abandoned." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Expired credentials on active service principals indicate unmanaged automation that may have been compromised or abandoned."
+    }
   },
   {
     "checkId": "AZ-IDENTITY-003",
@@ -95,17 +140,26 @@
     "category": "PRIVILEGED_ACCESS",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "IAC-14",
       "domain": "Identification & Authentication",
       "controlName": "Least Privilege",
-      "controlDescription": "Azure resources should use managed identities instead of service principals with stored secrets where possible, reducing credential exposure and enforcing least-privilege identity patterns."
+      "controlDescription": "Azure resources should use managed identities instead of service principals with stored secrets where possible, reducing credential exposure and enforcing least-privilege identity patterns.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "AC.L2-3.1.5", "title": "Employ the principle of least privilege" }
+      "cmmc": {
+        "controlId": "AC.L2-3.1.5",
+        "title": "Employ the principle of least privilege"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Service principals with stored secrets are a common attack vector; managed identities eliminate secret management overhead." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Service principals with stored secrets are a common attack vector; managed identities eliminate secret management overhead."
+    }
   },
   {
     "checkId": "AZ-NETWORK-001",
@@ -113,17 +167,26 @@
     "category": "NETWORK_SECURITY",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "NET-03",
       "domain": "Network Security",
       "controlName": "Boundary Protection",
-      "controlDescription": "Network Security Groups must not allow inbound RDP (TCP 3389) from any internet source (0.0.0.0/0, *, or Internet). Unrestricted RDP exposure is a primary vector for brute-force and ransomware attacks."
+      "controlDescription": "Network Security Groups must not allow inbound RDP (TCP 3389) from any internet source (0.0.0.0/0, *, or Internet). Unrestricted RDP exposure is a primary vector for brute-force and ransomware attacks.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.1", "title": "Monitor, control, and protect organizational communications" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.1",
+        "title": "Monitor, control, and protect organizational communications"
+      }
     },
-    "impactRating": { "severity": "Critical", "rationale": "Internet-exposed RDP is consistently exploited for ransomware deployment and lateral movement." }
+    "impactRating": {
+      "severity": "Critical",
+      "rationale": "Internet-exposed RDP is consistently exploited for ransomware deployment and lateral movement."
+    }
   },
   {
     "checkId": "AZ-NETWORK-002",
@@ -131,17 +194,26 @@
     "category": "NETWORK_SECURITY",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "NET-03",
       "domain": "Network Security",
       "controlName": "Boundary Protection",
-      "controlDescription": "Network Security Groups must not allow inbound SSH (TCP 22) from any internet source. Unrestricted SSH exposure enables brute-force credential attacks against Linux VMs."
+      "controlDescription": "Network Security Groups must not allow inbound SSH (TCP 22) from any internet source. Unrestricted SSH exposure enables brute-force credential attacks against Linux VMs.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.1", "title": "Monitor, control, and protect organizational communications" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.1",
+        "title": "Monitor, control, and protect organizational communications"
+      }
     },
-    "impactRating": { "severity": "Critical", "rationale": "Internet-exposed SSH is a top attack vector for Linux VM compromise and cryptomining deployments." }
+    "impactRating": {
+      "severity": "Critical",
+      "rationale": "Internet-exposed SSH is a top attack vector for Linux VM compromise and cryptomining deployments."
+    }
   },
   {
     "checkId": "AZ-NETWORK-003",
@@ -149,17 +221,26 @@
     "category": "NETWORK_SECURITY",
     "collector": "AzAssess",
     "hasAutomatedCheck": false,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "NET-01",
       "domain": "Network Security",
       "controlName": "Network Architecture",
-      "controlDescription": "VMs with public IP addresses must each have an associated NSG. Review all public-IP VMs to verify the exposure is intentional and protected."
+      "controlDescription": "VMs with public IP addresses must each have an associated NSG. Review all public-IP VMs to verify the exposure is intentional and protected.",
+      "csfFunction": "Govern"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.1", "title": "Monitor, control, and protect organizational communications" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.1",
+        "title": "Monitor, control, and protect organizational communications"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Public IPs without NSGs expose the VM attack surface directly to the internet." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Public IPs without NSGs expose the VM attack surface directly to the internet."
+    }
   },
   {
     "checkId": "AZ-STORAGE-001",
@@ -167,17 +248,26 @@
     "category": "DATA_PROTECTION",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CRY-04",
       "domain": "Cryptographic Protections",
       "controlName": "Encryption at Rest",
-      "controlDescription": "Storage accounts must not allow anonymous (unauthenticated) access to blob containers. Public blob access exposes potentially sensitive data to the internet without any authentication."
+      "controlDescription": "Storage accounts must not allow anonymous (unauthenticated) access to blob containers. Public blob access exposes potentially sensitive data to the internet without any authentication.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.3", "title": "Employ architectural designs and implement security functionality" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.3",
+        "title": "Employ architectural designs and implement security functionality"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Public blob containers have caused numerous data breaches through accidental exposure of sensitive files." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Public blob containers have caused numerous data breaches through accidental exposure of sensitive files."
+    }
   },
   {
     "checkId": "AZ-STORAGE-002",
@@ -185,17 +275,26 @@
     "category": "ENCRYPTION_IN_TRANSIT",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CRY-03",
       "domain": "Cryptographic Protections",
       "controlName": "Encryption in Transit",
-      "controlDescription": "All storage accounts must enforce HTTPS-only traffic to protect data in transit. HTTP connections must be rejected to prevent interception of data or credentials."
+      "controlDescription": "All storage accounts must enforce HTTPS-only traffic to protect data in transit. HTTP connections must be rejected to prevent interception of data or credentials.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.8", "title": "Implement cryptographic mechanisms to prevent unauthorized disclosure" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.8",
+        "title": "Implement cryptographic mechanisms to prevent unauthorized disclosure"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Unencrypted HTTP transfers can expose storage access keys and data to network-level interception." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Unencrypted HTTP transfers can expose storage access keys and data to network-level interception."
+    }
   },
   {
     "checkId": "AZ-STORAGE-003",
@@ -203,17 +302,26 @@
     "category": "ENCRYPTION_IN_TRANSIT",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CRY-03",
       "domain": "Cryptographic Protections",
       "controlName": "Encryption in Transit",
-      "controlDescription": "Storage accounts must enforce TLS 1.2 as the minimum version. TLS 1.0 and 1.1 have known vulnerabilities (POODLE, BEAST) that can be exploited to decrypt communications."
+      "controlDescription": "Storage accounts must enforce TLS 1.2 as the minimum version. TLS 1.0 and 1.1 have known vulnerabilities (POODLE, BEAST) that can be exploited to decrypt communications.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.8", "title": "Implement cryptographic mechanisms to prevent unauthorized disclosure" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.8",
+        "title": "Implement cryptographic mechanisms to prevent unauthorized disclosure"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "TLS 1.0/1.1 vulnerabilities allow downgrade attacks against storage communications." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "TLS 1.0/1.1 vulnerabilities allow downgrade attacks against storage communications."
+    }
   },
   {
     "checkId": "AZ-KEYVAULT-001",
@@ -221,17 +329,26 @@
     "category": "DATA_PROTECTION",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CRY-02",
       "domain": "Cryptographic Protections",
       "controlName": "Key Management",
-      "controlDescription": "Azure Key Vaults must have soft delete enabled to allow recovery of accidentally or maliciously deleted secrets, keys, and certificates within the retention period."
+      "controlDescription": "Azure Key Vaults must have soft delete enabled to allow recovery of accidentally or maliciously deleted secrets, keys, and certificates within the retention period.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.10", "title": "Employ FIPS-validated cryptography" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.10",
+        "title": "Employ FIPS-validated cryptography"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Without soft delete, a deleted Key Vault permanently destroys all cryptographic material, potentially causing application outages." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Without soft delete, a deleted Key Vault permanently destroys all cryptographic material, potentially causing application outages."
+    }
   },
   {
     "checkId": "AZ-KEYVAULT-002",
@@ -239,17 +356,26 @@
     "category": "DATA_PROTECTION",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CRY-02",
       "domain": "Cryptographic Protections",
       "controlName": "Key Management",
-      "controlDescription": "Azure Key Vaults must have purge protection enabled to prevent permanent deletion during the soft-delete retention period, protecting against ransomware-style attacks targeting cryptographic material."
+      "controlDescription": "Azure Key Vaults must have purge protection enabled to prevent permanent deletion during the soft-delete retention period, protecting against ransomware-style attacks targeting cryptographic material.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.10", "title": "Employ FIPS-validated cryptography" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.10",
+        "title": "Employ FIPS-validated cryptography"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Without purge protection, an attacker with Key Vault delete permissions can permanently destroy all secrets, keys, and certificates." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Without purge protection, an attacker with Key Vault delete permissions can permanently destroy all secrets, keys, and certificates."
+    }
   },
   {
     "checkId": "AZ-KEYVAULT-003",
@@ -257,17 +383,26 @@
     "category": "CREDENTIAL_MANAGEMENT",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CRY-02",
       "domain": "Cryptographic Protections",
       "controlName": "Key Management",
-      "controlDescription": "Cryptographic keys and secrets stored in Azure Key Vault must have expiry dates configured to enforce key rotation and reduce the window of exposure if a key is compromised."
+      "controlDescription": "Cryptographic keys and secrets stored in Azure Key Vault must have expiry dates configured to enforce key rotation and reduce the window of exposure if a key is compromised.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "IA.L2-3.5.10", "title": "Store and transmit only cryptographically-protected passwords" }
+      "cmmc": {
+        "controlId": "IA.L2-3.5.10",
+        "title": "Store and transmit only cryptographically-protected passwords"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Keys without expiry never rotate, allowing long-term exploitation of any compromise without detection." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Keys without expiry never rotate, allowing long-term exploitation of any compromise without detection."
+    }
   },
   {
     "checkId": "AZ-DEFENDER-001",
@@ -275,17 +410,26 @@
     "category": "VULNERABILITY_MANAGEMENT",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "VUL-01",
       "domain": "Vulnerability & Patch Management",
       "controlName": "Vulnerability Management",
-      "controlDescription": "Microsoft Defender for Cloud paid plans (Servers, Databases, Storage, etc.) must be enabled to provide threat detection, vulnerability assessment, and security recommendations for CUI-handling workloads."
+      "controlDescription": "Microsoft Defender for Cloud paid plans (Servers, Databases, Storage, etc.) must be enabled to provide threat detection, vulnerability assessment, and security recommendations for CUI-handling workloads.",
+      "csfFunction": "Identify"
     },
     "frameworks": {
-      "cmmc": { "controlId": "RA.L2-3.11.2", "title": "Scan for vulnerabilities in organizational systems" }
+      "cmmc": {
+        "controlId": "RA.L2-3.11.2",
+        "title": "Scan for vulnerabilities in organizational systems"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Without paid Defender plans, threat detection and vulnerability scanning are absent for critical workloads." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Without paid Defender plans, threat detection and vulnerability scanning are absent for critical workloads."
+    }
   },
   {
     "checkId": "AZ-DEFENDER-002",
@@ -293,17 +437,26 @@
     "category": "VULNERABILITY_MANAGEMENT",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "VUL-01",
       "domain": "Vulnerability & Patch Management",
       "controlName": "Vulnerability Management",
-      "controlDescription": "The Defender for Cloud Secure Score must meet a minimum threshold (>=50%) to indicate that foundational security recommendations have been addressed across the subscription."
+      "controlDescription": "The Defender for Cloud Secure Score must meet a minimum threshold (>=50%) to indicate that foundational security recommendations have been addressed across the subscription.",
+      "csfFunction": "Identify"
     },
     "frameworks": {
-      "cmmc": { "controlId": "RA.L2-3.11.2", "title": "Scan for vulnerabilities in organizational systems" }
+      "cmmc": {
+        "controlId": "RA.L2-3.11.2",
+        "title": "Scan for vulnerabilities in organizational systems"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "A low secure score indicates widespread unresolved security findings that increase risk of compromise." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "A low secure score indicates widespread unresolved security findings that increase risk of compromise."
+    }
   },
   {
     "checkId": "AZ-DEFENDER-003",
@@ -311,17 +464,26 @@
     "category": "ENDPOINT_MONITORING",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "MON-01",
       "domain": "Continuous Monitoring",
       "controlName": "Audit Logging",
-      "controlDescription": "Defender for Cloud auto-provisioning of monitoring agents (MMA/AMA) must be enabled to ensure all VMs automatically receive threat detection coverage without manual intervention."
+      "controlDescription": "Defender for Cloud auto-provisioning of monitoring agents (MMA/AMA) must be enabled to ensure all VMs automatically receive threat detection coverage without manual intervention.",
+      "csfFunction": "Govern"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SI.L2-3.14.6", "title": "Monitor organizational systems to detect attacks and indicators of potential attacks" }
+      "cmmc": {
+        "controlId": "SI.L2-3.14.6",
+        "title": "Monitor organizational systems to detect attacks and indicators of potential attacks"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "VMs without monitoring agents are invisible to Defender for Cloud threat detection." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "VMs without monitoring agents are invisible to Defender for Cloud threat detection."
+    }
   },
   {
     "checkId": "AZ-MONITOR-001",
@@ -329,17 +491,26 @@
     "category": "AUDIT_LOGGING",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "MON-01",
       "domain": "Continuous Monitoring",
       "controlName": "Audit Logging",
-      "controlDescription": "At least one Log Analytics workspace must exist in the subscription to serve as a central repository for audit logs, diagnostic data, and security events."
+      "controlDescription": "At least one Log Analytics workspace must exist in the subscription to serve as a central repository for audit logs, diagnostic data, and security events.",
+      "csfFunction": "Govern"
     },
     "frameworks": {
-      "cmmc": { "controlId": "AU.L2-3.3.1", "title": "Create and retain system audit logs to enable monitoring, analysis, investigation, and reporting" }
+      "cmmc": {
+        "controlId": "AU.L2-3.3.1",
+        "title": "Create and retain system audit logs to enable monitoring, analysis, investigation, and reporting"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Without a Log Analytics workspace, audit log collection cannot be centralized, making incident investigation impossible." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Without a Log Analytics workspace, audit log collection cannot be centralized, making incident investigation impossible."
+    }
   },
   {
     "checkId": "AZ-MONITOR-002",
@@ -347,17 +518,26 @@
     "category": "AUDIT_LOGGING",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "MON-03",
       "domain": "Continuous Monitoring",
       "controlName": "Audit Log Review",
-      "controlDescription": "An enabled Activity Log Alert must exist for the Microsoft.Authorization/policyAssignments/delete operation to detect and respond to unauthorized removal of security policies."
+      "controlDescription": "An enabled Activity Log Alert must exist for the Microsoft.Authorization/policyAssignments/delete operation to detect and respond to unauthorized removal of security policies.",
+      "csfFunction": "Detect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "AU.L2-3.3.5", "title": "Correlate audit record review, analysis, and reporting processes" }
+      "cmmc": {
+        "controlId": "AU.L2-3.3.5",
+        "title": "Correlate audit record review, analysis, and reporting processes"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Silent policy deletion can remove compliance guardrails without anyone noticing until the next audit." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Silent policy deletion can remove compliance guardrails without anyone noticing until the next audit."
+    }
   },
   {
     "checkId": "AZ-VM-001",
@@ -365,17 +545,26 @@
     "category": "ENCRYPTION_AT_REST",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CRY-04",
       "domain": "Cryptographic Protections",
       "controlName": "Encryption at Rest",
-      "controlDescription": "All virtual machines must have the Azure Disk Encryption extension installed and in a Succeeded provisioning state to protect OS and data disks with BitLocker (Windows) or dm-crypt (Linux)."
+      "controlDescription": "All virtual machines must have the Azure Disk Encryption extension installed and in a Succeeded provisioning state to protect OS and data disks with BitLocker (Windows) or dm-crypt (Linux).",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.16", "title": "Protect the confidentiality of CUI at rest" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.16",
+        "title": "Protect the confidentiality of CUI at rest"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Unencrypted VM disks expose CUI if the underlying hardware is repurposed or physically accessed." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Unencrypted VM disks expose CUI if the underlying hardware is repurposed or physically accessed."
+    }
   },
   {
     "checkId": "AZ-VM-002",
@@ -383,17 +572,26 @@
     "category": "ENDPOINT_SECURITY",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "END-04",
       "domain": "Endpoint Security",
       "controlName": "Malicious Code Protection",
-      "controlDescription": "All virtual machines must have an endpoint protection extension installed (Microsoft Antimalware or Microsoft Defender for Endpoint) to detect and prevent malicious code execution."
+      "controlDescription": "All virtual machines must have an endpoint protection extension installed (Microsoft Antimalware or Microsoft Defender for Endpoint) to detect and prevent malicious code execution.",
+      "csfFunction": "Detect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SI.L2-3.14.2", "title": "Provide protection from malicious code at appropriate locations within organizational systems" }
+      "cmmc": {
+        "controlId": "SI.L2-3.14.2",
+        "title": "Provide protection from malicious code at appropriate locations within organizational systems"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "VMs without endpoint protection are undefended against malware, ransomware, and fileless attacks." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "VMs without endpoint protection are undefended against malware, ransomware, and fileless attacks."
+    }
   },
   {
     "checkId": "AZ-SQL-001",
@@ -401,17 +599,26 @@
     "category": "ENCRYPTION_AT_REST",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "CRY-04",
       "domain": "Cryptographic Protections",
       "controlName": "Encryption at Rest",
-      "controlDescription": "All Azure SQL databases (excluding system databases) must have Transparent Data Encryption enabled to protect database files, log files, and backups at rest."
+      "controlDescription": "All Azure SQL databases (excluding system databases) must have Transparent Data Encryption enabled to protect database files, log files, and backups at rest.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.16", "title": "Protect the confidentiality of CUI at rest" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.16",
+        "title": "Protect the confidentiality of CUI at rest"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Unencrypted SQL databases expose CUI stored in database files and backups." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Unencrypted SQL databases expose CUI stored in database files and backups."
+    }
   },
   {
     "checkId": "AZ-SQL-002",
@@ -419,17 +626,26 @@
     "category": "AUDIT_LOGGING",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "MON-01",
       "domain": "Continuous Monitoring",
       "controlName": "Audit Logging",
-      "controlDescription": "SQL Server auditing must be enabled on all Azure SQL servers to track database events, schema changes, and data access for compliance and incident investigation."
+      "controlDescription": "SQL Server auditing must be enabled on all Azure SQL servers to track database events, schema changes, and data access for compliance and incident investigation.",
+      "csfFunction": "Govern"
     },
     "frameworks": {
-      "cmmc": { "controlId": "AU.L2-3.3.1", "title": "Create and retain system audit logs" }
+      "cmmc": {
+        "controlId": "AU.L2-3.3.1",
+        "title": "Create and retain system audit logs"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Without auditing, SQL Server access and schema changes are untracked and cannot be investigated after a breach." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Without auditing, SQL Server access and schema changes are untracked and cannot be investigated after a breach."
+    }
   },
   {
     "checkId": "AZ-SQL-003",
@@ -437,17 +653,26 @@
     "category": "NETWORK_SECURITY",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "NET-03",
       "domain": "Network Security",
       "controlName": "Boundary Protection",
-      "controlDescription": "Azure SQL Server firewall rules must not allow unrestricted access from all Azure services (0.0.0.0-0.0.0.0) or from the entire internet (0.0.0.0-255.255.255.255)."
+      "controlDescription": "Azure SQL Server firewall rules must not allow unrestricted access from all Azure services (0.0.0.0-0.0.0.0) or from the entire internet (0.0.0.0-255.255.255.255).",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.1", "title": "Monitor, control, and protect organizational communications" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.1",
+        "title": "Monitor, control, and protect organizational communications"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Overly broad SQL firewall rules expose the database server to unauthorized connection attempts from anywhere in Azure or the internet." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Overly broad SQL firewall rules expose the database server to unauthorized connection attempts from anywhere in Azure or the internet."
+    }
   },
   {
     "checkId": "AZ-AKS-001",
@@ -455,17 +680,26 @@
     "category": "AUTHORIZATION",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "IAC-14",
       "domain": "Identification & Authentication",
       "controlName": "Least Privilege",
-      "controlDescription": "All AKS clusters must have Kubernetes RBAC enabled to enforce role-based access control on Kubernetes API operations and prevent unauthorized access to cluster resources."
+      "controlDescription": "All AKS clusters must have Kubernetes RBAC enabled to enforce role-based access control on Kubernetes API operations and prevent unauthorized access to cluster resources.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "AC.L2-3.1.2", "title": "Limit system access to the types of transactions and functions authorized users are permitted to execute" }
+      "cmmc": {
+        "controlId": "AC.L2-3.1.2",
+        "title": "Limit system access to the types of transactions and functions authorized users are permitted to execute"
+      }
     },
-    "impactRating": { "severity": "High", "rationale": "Without RBAC, all authenticated users have unrestricted access to Kubernetes API operations including cluster-admin capabilities." }
+    "impactRating": {
+      "severity": "High",
+      "rationale": "Without RBAC, all authenticated users have unrestricted access to Kubernetes API operations including cluster-admin capabilities."
+    }
   },
   {
     "checkId": "AZ-AKS-002",
@@ -473,17 +707,26 @@
     "category": "NETWORK_SECURITY",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "NET-03",
       "domain": "Network Security",
       "controlName": "Boundary Protection",
-      "controlDescription": "AKS clusters must have a network policy (Azure or Calico) configured to control pod-to-pod traffic and enforce microsegmentation within the cluster."
+      "controlDescription": "AKS clusters must have a network policy (Azure or Calico) configured to control pod-to-pod traffic and enforce microsegmentation within the cluster.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "SC.L2-3.13.1", "title": "Monitor, control, and protect organizational communications" }
+      "cmmc": {
+        "controlId": "SC.L2-3.13.1",
+        "title": "Monitor, control, and protect organizational communications"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Without network policies, a compromised pod can communicate freely with all other pods, enabling lateral movement." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Without network policies, a compromised pod can communicate freely with all other pods, enabling lateral movement."
+    }
   },
   {
     "checkId": "AZ-AKS-003",
@@ -491,16 +734,25 @@
     "category": "AUTHENTICATION",
     "collector": "AzAssess",
     "hasAutomatedCheck": true,
-    "licensing": { "minimum": "AzureSubscription" },
+    "licensing": {
+      "minimum": "AzureSubscription"
+    },
     "scf": {
       "primaryControlId": "IAC-06",
       "domain": "Identification & Authentication",
       "controlName": "Account Management",
-      "controlDescription": "AKS clusters must have Azure AD integration (AAD profile or OIDC issuer) enabled to enforce organizational identity policies, MFA, and conditional access for cluster authentication."
+      "controlDescription": "AKS clusters must have Azure AD integration (AAD profile or OIDC issuer) enabled to enforce organizational identity policies, MFA, and conditional access for cluster authentication.",
+      "csfFunction": "Protect"
     },
     "frameworks": {
-      "cmmc": { "controlId": "IA.L2-3.5.1", "title": "Identify information system users, processes acting on behalf of users, and devices" }
+      "cmmc": {
+        "controlId": "IA.L2-3.5.1",
+        "title": "Identify information system users, processes acting on behalf of users, and devices"
+      }
     },
-    "impactRating": { "severity": "Medium", "rationale": "Without Azure AD integration, AKS authentication relies on local credentials that bypass organizational MFA and conditional access policies." }
+    "impactRating": {
+      "severity": "Medium",
+      "rationale": "Without Azure AD integration, AKS authentication relies on local credentials that bypass organizational MFA and conditional access policies."
+    }
   }
 ]

--- a/data/framework-overrides.json
+++ b/data/framework-overrides.json
@@ -336,19 +336,43 @@
         "controlId": "SC.L2-3.13.3"
       }
     },
+    "CA-SESSION-001": {
+      "soc2": {
+        "controlId": "CC6.1"
+      }
+    },
+    "ENTRA-TOU-001": {
+      "soc2": {
+        "controlId": "CC2.2"
+      }
+    },
     "ENTRA-CA-SESSIONFREQ-001": {
       "cmmc": {
         "controlId": "SC.L2-3.13.9"
+      },
+      "soc2": {
+        "controlId": "CC6.6"
       }
     },
     "INTUNE-MOBILECODE-001": {
       "cmmc": {
         "controlId": "SC.L2-3.13.13"
+      },
+      "soc2": {
+        "controlId": "CC6.6"
       }
     },
     "ENTRA-SESSIONAUTH-001": {
       "cmmc": {
         "controlId": "SC.L2-3.13.15"
+      },
+      "soc2": {
+        "controlId": "CC6.6"
+      }
+    },
+    "INTUNE-WIFI-001": {
+      "soc2": {
+        "controlId": "CC6.1;CC6.3"
       }
     },
     "SPO-CUIACCESS-001": {

--- a/data/frameworks/soc2-tsc.json
+++ b/data/frameworks/soc2-tsc.json
@@ -1,5 +1,5 @@
 {
-  "frameworkId": "soc2-tsc",
+  "frameworkId": "soc2",
   "label": "SOC 2 Trust Services Criteria",
   "version": "2022",
   "css": "fw-soc2",

--- a/data/registry.json
+++ b/data/registry.json
@@ -2166,7 +2166,8 @@
         "primaryControlId": "IAC-06",
         "domain": "Identification & Authentication",
         "controlName": "Account Management",
-        "controlDescription": "Guest user accounts in Azure AD should be reviewed and minimized. External identities with persistent access to Azure resources increase the risk of unauthorized access."
+        "controlDescription": "Guest user accounts in Azure AD should be reviewed and minimized. External identities with persistent access to Azure resources increase the risk of unauthorized access.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -2192,7 +2193,8 @@
         "primaryControlId": "IAC-06",
         "domain": "Identification & Authentication",
         "controlName": "Account Management",
-        "controlDescription": "AKS clusters must have Azure AD integration (AAD profile or OIDC issuer) enabled to enforce organizational identity policies, MFA, and conditional access for cluster authentication."
+        "controlDescription": "AKS clusters must have Azure AD integration (AAD profile or OIDC issuer) enabled to enforce organizational identity policies, MFA, and conditional access for cluster authentication.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -3638,7 +3640,8 @@
         "primaryControlId": "IAC-07",
         "domain": "Identification & Authentication",
         "controlName": "Identifier Management",
-        "controlDescription": "Service principal credentials (client secrets and certificates) must not be expired. Expired credentials indicate abandoned applications or poor credential lifecycle management."
+        "controlDescription": "Service principal credentials (client secrets and certificates) must not be expired. Expired credentials indicate abandoned applications or poor credential lifecycle management.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -5820,6 +5823,10 @@
         },
         "pci-dss": {
           "controlId": "8.2.8"
+        },
+        "soc2": {
+          "controlId": "CC6.1",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
       "impactRating": {
@@ -5841,7 +5848,8 @@
         "primaryControlId": "IAC-14",
         "domain": "Identification & Authentication",
         "controlName": "Least Privilege",
-        "controlDescription": "Access to Azure subscription management must be restricted. Owner role assignments should not exceed 3 principals to limit blast radius from compromised accounts."
+        "controlDescription": "Access to Azure subscription management must be restricted. Owner role assignments should not exceed 3 principals to limit blast radius from compromised accounts.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -5867,7 +5875,8 @@
         "primaryControlId": "IAC-14",
         "domain": "Identification & Authentication",
         "controlName": "Least Privilege",
-        "controlDescription": "Azure resources should use managed identities instead of service principals with stored secrets where possible, reducing credential exposure and enforcing least-privilege identity patterns."
+        "controlDescription": "Azure resources should use managed identities instead of service principals with stored secrets where possible, reducing credential exposure and enforcing least-privilege identity patterns.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -5893,7 +5902,8 @@
         "primaryControlId": "IAC-14",
         "domain": "Identification & Authentication",
         "controlName": "Least Privilege",
-        "controlDescription": "All AKS clusters must have Kubernetes RBAC enabled to enforce role-based access control on Kubernetes API operations and prevent unauthorized access to cluster resources."
+        "controlDescription": "All AKS clusters must have Kubernetes RBAC enabled to enforce role-based access control on Kubernetes API operations and prevent unauthorized access to cluster resources.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -24339,7 +24349,8 @@
         "primaryControlId": "CFG-01",
         "domain": "Configuration Management",
         "controlName": "Configuration Management Policy",
-        "controlDescription": "Azure Policy compliance must be reviewed manually in the Portal to confirm that assigned policies are not generating non-compliant findings against baseline configurations."
+        "controlDescription": "Azure Policy compliance must be reviewed manually in the Portal to confirm that assigned policies are not generating non-compliant findings against baseline configurations.",
+        "csfFunction": "Govern"
       },
       "frameworks": {
         "cmmc": {
@@ -24651,7 +24662,8 @@
         "primaryControlId": "CFG-02",
         "domain": "Configuration Management",
         "controlName": "Configuration Baselines",
-        "controlDescription": "Azure subscriptions must have at least one resource lock configured to prevent accidental or unauthorized deletion or modification of critical resources."
+        "controlDescription": "Azure subscriptions must have at least one resource lock configured to prevent accidental or unauthorized deletion or modification of critical resources.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -36339,7 +36351,8 @@
         "primaryControlId": "MON-01",
         "domain": "Continuous Monitoring",
         "controlName": "Audit Logging",
-        "controlDescription": "Defender for Cloud auto-provisioning of monitoring agents (MMA/AMA) must be enabled to ensure all VMs automatically receive threat detection coverage without manual intervention."
+        "controlDescription": "Defender for Cloud auto-provisioning of monitoring agents (MMA/AMA) must be enabled to ensure all VMs automatically receive threat detection coverage without manual intervention.",
+        "csfFunction": "Govern"
       },
       "frameworks": {
         "cmmc": {
@@ -36365,7 +36378,8 @@
         "primaryControlId": "MON-01",
         "domain": "Continuous Monitoring",
         "controlName": "Audit Logging",
-        "controlDescription": "At least one Log Analytics workspace must exist in the subscription to serve as a central repository for audit logs, diagnostic data, and security events."
+        "controlDescription": "At least one Log Analytics workspace must exist in the subscription to serve as a central repository for audit logs, diagnostic data, and security events.",
+        "csfFunction": "Govern"
       },
       "frameworks": {
         "cmmc": {
@@ -36391,7 +36405,8 @@
         "primaryControlId": "MON-01",
         "domain": "Continuous Monitoring",
         "controlName": "Audit Logging",
-        "controlDescription": "SQL Server auditing must be enabled on all Azure SQL servers to track database events, schema changes, and data access for compliance and incident investigation."
+        "controlDescription": "SQL Server auditing must be enabled on all Azure SQL servers to track database events, schema changes, and data access for compliance and incident investigation.",
+        "csfFunction": "Govern"
       },
       "frameworks": {
         "cmmc": {
@@ -38275,7 +38290,8 @@
         "primaryControlId": "MON-03",
         "domain": "Continuous Monitoring",
         "controlName": "Audit Log Review",
-        "controlDescription": "An enabled Activity Log Alert must exist for the Microsoft.Authorization/policyAssignments/delete operation to detect and respond to unauthorized removal of security policies."
+        "controlDescription": "An enabled Activity Log Alert must exist for the Microsoft.Authorization/policyAssignments/delete operation to detect and respond to unauthorized removal of security policies.",
+        "csfFunction": "Detect"
       },
       "frameworks": {
         "cmmc": {
@@ -39772,6 +39788,10 @@
             "Moderate",
             "High"
           ]
+        },
+        "soc2": {
+          "controlId": "CC2.2",
+          "title": "COSO Principle 14: Internal Communication"
         }
       },
       "impactRating": {
@@ -40346,7 +40366,8 @@
         "primaryControlId": "NET-01",
         "domain": "Network Security",
         "controlName": "Network Architecture",
-        "controlDescription": "VMs with public IP addresses must each have an associated NSG. Review all public-IP VMs to verify the exposure is intentional and protected."
+        "controlDescription": "VMs with public IP addresses must each have an associated NSG. Review all public-IP VMs to verify the exposure is intentional and protected.",
+        "csfFunction": "Govern"
       },
       "frameworks": {
         "cmmc": {
@@ -40542,7 +40563,8 @@
         "primaryControlId": "NET-03",
         "domain": "Network Security",
         "controlName": "Boundary Protection",
-        "controlDescription": "Network Security Groups must not allow inbound RDP (TCP 3389) from any internet source (0.0.0.0/0, *, or Internet). Unrestricted RDP exposure is a primary vector for brute-force and ransomware attacks."
+        "controlDescription": "Network Security Groups must not allow inbound RDP (TCP 3389) from any internet source (0.0.0.0/0, *, or Internet). Unrestricted RDP exposure is a primary vector for brute-force and ransomware attacks.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -40568,7 +40590,8 @@
         "primaryControlId": "NET-03",
         "domain": "Network Security",
         "controlName": "Boundary Protection",
-        "controlDescription": "Network Security Groups must not allow inbound SSH (TCP 22) from any internet source. Unrestricted SSH exposure enables brute-force credential attacks against Linux VMs."
+        "controlDescription": "Network Security Groups must not allow inbound SSH (TCP 22) from any internet source. Unrestricted SSH exposure enables brute-force credential attacks against Linux VMs.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -40594,7 +40617,8 @@
         "primaryControlId": "NET-03",
         "domain": "Network Security",
         "controlName": "Boundary Protection",
-        "controlDescription": "Azure SQL Server firewall rules must not allow unrestricted access from all Azure services (0.0.0.0-0.0.0.0) or from the entire internet (0.0.0.0-255.255.255.255)."
+        "controlDescription": "Azure SQL Server firewall rules must not allow unrestricted access from all Azure services (0.0.0.0-0.0.0.0) or from the entire internet (0.0.0.0-255.255.255.255).",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -40620,7 +40644,8 @@
         "primaryControlId": "NET-03",
         "domain": "Network Security",
         "controlName": "Boundary Protection",
-        "controlDescription": "AKS clusters must have a network policy (Azure or Calico) configured to control pod-to-pod traffic and enforce microsegmentation within the cluster."
+        "controlDescription": "AKS clusters must have a network policy (Azure or Calico) configured to control pod-to-pod traffic and enforce microsegmentation within the cluster.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -43936,6 +43961,10 @@
         },
         "pci-dss": {
           "controlId": "8.2.8"
+        },
+        "soc2": {
+          "controlId": "CC6.6",
+          "title": "Restriction of Access to System Boundaries"
         }
       },
       "impactRating": {
@@ -44051,6 +44080,10 @@
         },
         "pci-dss": {
           "controlId": "1.4.1"
+        },
+        "soc2": {
+          "controlId": "CC6.6",
+          "title": "Restriction of Access to System Boundaries"
         }
       },
       "impactRating": {
@@ -45021,6 +45054,10 @@
         },
         "pci-dss": {
           "controlId": "1.3;11.2;11.2.1;11.2.2;2.3;2.3.1;2.3.2;4.2.1"
+        },
+        "soc2": {
+          "controlId": "CC6.1;CC6.3",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Enrollment and Authorization Based on Credentials"
         }
       },
       "impactRating": {
@@ -49862,7 +49899,8 @@
         "primaryControlId": "END-04",
         "domain": "Endpoint Security",
         "controlName": "Malicious Code Protection",
-        "controlDescription": "All virtual machines must have an endpoint protection extension installed (Microsoft Antimalware or Microsoft Defender for Endpoint) to detect and prevent malicious code execution."
+        "controlDescription": "All virtual machines must have an endpoint protection extension installed (Microsoft Antimalware or Microsoft Defender for Endpoint) to detect and prevent malicious code execution.",
+        "csfFunction": "Detect"
       },
       "frameworks": {
         "cmmc": {
@@ -51282,6 +51320,10 @@
             "Moderate",
             "High"
           ]
+        },
+        "soc2": {
+          "controlId": "CC6.6",
+          "title": "Restriction of Access to System Boundaries"
         }
       },
       "impactRating": {
@@ -52666,7 +52708,8 @@
         "primaryControlId": "CRY-02",
         "domain": "Cryptographic Protections",
         "controlName": "Key Management",
-        "controlDescription": "Azure Key Vaults must have soft delete enabled to allow recovery of accidentally or maliciously deleted secrets, keys, and certificates within the retention period."
+        "controlDescription": "Azure Key Vaults must have soft delete enabled to allow recovery of accidentally or maliciously deleted secrets, keys, and certificates within the retention period.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -52692,7 +52735,8 @@
         "primaryControlId": "CRY-02",
         "domain": "Cryptographic Protections",
         "controlName": "Key Management",
-        "controlDescription": "Azure Key Vaults must have purge protection enabled to prevent permanent deletion during the soft-delete retention period, protecting against ransomware-style attacks targeting cryptographic material."
+        "controlDescription": "Azure Key Vaults must have purge protection enabled to prevent permanent deletion during the soft-delete retention period, protecting against ransomware-style attacks targeting cryptographic material.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -52718,7 +52762,8 @@
         "primaryControlId": "CRY-02",
         "domain": "Cryptographic Protections",
         "controlName": "Key Management",
-        "controlDescription": "Cryptographic keys and secrets stored in Azure Key Vault must have expiry dates configured to enforce key rotation and reduce the window of exposure if a key is compromised."
+        "controlDescription": "Cryptographic keys and secrets stored in Azure Key Vault must have expiry dates configured to enforce key rotation and reduce the window of exposure if a key is compromised.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -53062,7 +53107,8 @@
         "primaryControlId": "CRY-03",
         "domain": "Cryptographic Protections",
         "controlName": "Encryption in Transit",
-        "controlDescription": "All storage accounts must enforce HTTPS-only traffic to protect data in transit. HTTP connections must be rejected to prevent interception of data or credentials."
+        "controlDescription": "All storage accounts must enforce HTTPS-only traffic to protect data in transit. HTTP connections must be rejected to prevent interception of data or credentials.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -53088,7 +53134,8 @@
         "primaryControlId": "CRY-03",
         "domain": "Cryptographic Protections",
         "controlName": "Encryption in Transit",
-        "controlDescription": "Storage accounts must enforce TLS 1.2 as the minimum version. TLS 1.0 and 1.1 have known vulnerabilities (POODLE, BEAST) that can be exploited to decrypt communications."
+        "controlDescription": "Storage accounts must enforce TLS 1.2 as the minimum version. TLS 1.0 and 1.1 have known vulnerabilities (POODLE, BEAST) that can be exploited to decrypt communications.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -53114,7 +53161,8 @@
         "primaryControlId": "CRY-04",
         "domain": "Cryptographic Protections",
         "controlName": "Encryption at Rest",
-        "controlDescription": "Storage accounts must not allow anonymous (unauthenticated) access to blob containers. Public blob access exposes potentially sensitive data to the internet without any authentication."
+        "controlDescription": "Storage accounts must not allow anonymous (unauthenticated) access to blob containers. Public blob access exposes potentially sensitive data to the internet without any authentication.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -53140,7 +53188,8 @@
         "primaryControlId": "CRY-04",
         "domain": "Cryptographic Protections",
         "controlName": "Encryption at Rest",
-        "controlDescription": "All virtual machines must have the Azure Disk Encryption extension installed and in a Succeeded provisioning state to protect OS and data disks with BitLocker (Windows) or dm-crypt (Linux)."
+        "controlDescription": "All virtual machines must have the Azure Disk Encryption extension installed and in a Succeeded provisioning state to protect OS and data disks with BitLocker (Windows) or dm-crypt (Linux).",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -53166,7 +53215,8 @@
         "primaryControlId": "CRY-04",
         "domain": "Cryptographic Protections",
         "controlName": "Encryption at Rest",
-        "controlDescription": "All Azure SQL databases (excluding system databases) must have Transparent Data Encryption enabled to protect database files, log files, and backups at rest."
+        "controlDescription": "All Azure SQL databases (excluding system databases) must have Transparent Data Encryption enabled to protect database files, log files, and backups at rest.",
+        "csfFunction": "Protect"
       },
       "frameworks": {
         "cmmc": {
@@ -53740,7 +53790,8 @@
         "primaryControlId": "VUL-01",
         "domain": "Vulnerability & Patch Management",
         "controlName": "Vulnerability Management",
-        "controlDescription": "Microsoft Defender for Cloud paid plans (Servers, Databases, Storage, etc.) must be enabled to provide threat detection, vulnerability assessment, and security recommendations for CUI-handling workloads."
+        "controlDescription": "Microsoft Defender for Cloud paid plans (Servers, Databases, Storage, etc.) must be enabled to provide threat detection, vulnerability assessment, and security recommendations for CUI-handling workloads.",
+        "csfFunction": "Identify"
       },
       "frameworks": {
         "cmmc": {
@@ -53766,7 +53817,8 @@
         "primaryControlId": "VUL-01",
         "domain": "Vulnerability & Patch Management",
         "controlName": "Vulnerability Management",
-        "controlDescription": "The Defender for Cloud Secure Score must meet a minimum threshold (>=50%) to indicate that foundational security recommendations have been addressed across the subscription."
+        "controlDescription": "The Defender for Cloud Secure Score must meet a minimum threshold (>=50%) to indicate that foundational security recommendations have been addressed across the subscription.",
+        "csfFunction": "Identify"
       },
       "frameworks": {
         "cmmc": {

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -294,7 +294,7 @@ def load_az_assess_source_checks(repo_root: Path) -> list[dict]:
         # SCF — use directly from source (no database enrichment for ARM checks)
         scf_src = entry.get("scf", {})
         scf_obj = OrderedDict()
-        for key in ("primaryControlId", "domain", "controlName", "controlDescription"):
+        for key in ("primaryControlId", "domain", "controlName", "controlDescription", "csfFunction"):
             if key in scf_src:
                 scf_obj[key] = scf_src[key]
         check_obj["scf"] = scf_obj


### PR DESCRIPTION
Closes #179
Closes #180
Closes #181

## Summary

- **soc2-tsc.json**: Corrects `frameworkId` from `"soc2-tsc"` back to `"soc2"` — the SCF rebase introduced a regression that broke `Import-FrameworkDefinitions` tests and SOC2 scoring in M365-Assess
- **framework-overrides.json**: Adds SOC2 mappings for 6 checks (`CA-SESSION-001`, `ENTRA-TOU-001`, `ENTRA-CA-SESSIONFREQ-001`, `INTUNE-MOBILECODE-001`, `ENTRA-SESSIONAUTH-001`, `INTUNE-WIFI-001`) that lost SOC2 coverage when the pipeline switched from manual mappings to SCF-derived data
- **az-assess-source-checks.json**: Adds `csfFunction` to all 28 AZ-* check `scf` objects using SCF DB lookup (Protect/Detect/Govern/Identify)
- **Build-Registry.py**: Fixes `load_az_assess_source_checks` to propagate `csfFunction` from the source file — it was silently dropped when building the registry output

## Root Causes

These are three independent regressions introduced by the v2.5.0 SCF rebase:

1. `soc2-tsc.json` frameworkId typo — introduced during rebase file restructuring
2. SOC2 override entries missing — the override mechanism (`framework-overrides.json`) existed but entries for these 6 checks were never added
3. AZ-* `csfFunction` gap — two-part bug: source file lacked the field AND `load_az_assess_source_checks` didn't include `csfFunction` in its copy loop

## Test Plan

- [ ] `data/registry.json` — 306 checks, 0 AZ-* checks missing `csfFunction`
- [ ] SOC2 mappings present for all 6 overridden checks
- [ ] `data/frameworks/soc2-tsc.json` — `frameworkId` is `"soc2"`
- [ ] Downstream M365-Assess sync (v2.6.1 tag) passes all Pester tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)