### PR TITLE
ci: add UTF-8 validation gate + fix cmmc/hipaa/stig encoding

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -253,3 +253,21 @@ jobs:
           echo "  OK: data/scf-framework-map.json"
           python -c "import json; json.load(open('data/framework-titles.json'))"
           echo "  OK: data/framework-titles.json"
+
+      - name: Validate all data/ JSON files are valid UTF-8
+        run: |
+          python -c "
+          import glob, json, sys
+          errors = []
+          for f in sorted(glob.glob('data/**/*.json', recursive=True)):
+              try:
+                  json.load(open(f, encoding='utf-8'))
+                  print(f'  OK: {f}')
+              except Exception as e:
+                  errors.append(f'{f}: {e}')
+                  print(f'  FAIL: {f}: {e}')
+          if errors:
+              print(f'::error::{len(errors)} file(s) failed UTF-8 validation')
+              sys.exit(1)
+          print(f'All {len(glob.glob(\"data/**/*.json\", recursive=True))} JSON files are valid UTF-8')
+          "

--- a/data/frameworks/cmmc.json
+++ b/data/frameworks/cmmc.json
@@ -11,17 +11,17 @@
     "method": "maturity-level",
     "maturityLevels": {
       "L1": {
-        "label": "Level 1 — Foundational",
+        "label": "Level 1 â€” Foundational",
         "description": "Basic safeguarding of Federal Contract Information (FCI)",
         "practiceCount": 17
       },
       "L2": {
-        "label": "Level 2 — Advanced",
+        "label": "Level 2 â€” Advanced",
         "description": "Protection of Controlled Unclassified Information (CUI), aligned with NIST SP 800-171 Rev 2",
         "practiceCount": 110
       },
       "L3": {
-        "label": "Level 3 — Expert",
+        "label": "Level 3 â€” Expert",
         "description": "Enhanced protection against Advanced Persistent Threats (APTs), adds NIST SP 800-172 requirements",
         "practiceCount": 134
       }

--- a/data/frameworks/hipaa.json
+++ b/data/frameworks/hipaa.json
@@ -10,23 +10,23 @@
   "scoring": {
     "method": "criteria-coverage",
     "criteria": {
-      "ง164.308": {
+      "ยง164.308": {
         "label": "Administrative Safeguards",
         "description": "Security management, access management, training, and contingency planning"
       },
-      "ง164.310": {
+      "ยง164.310": {
         "label": "Physical Safeguards",
         "description": "Facility access controls, workstation use, and device/media controls"
       },
-      "ง164.312": {
+      "ยง164.312": {
         "label": "Technical Safeguards",
         "description": "Access control, audit controls, integrity, transmission security"
       },
-      "ง164.314": {
+      "ยง164.314": {
         "label": "Organizational Requirements",
         "description": "Business associate contracts and group health plan requirements"
       },
-      "ง164.316": {
+      "ยง164.316": {
         "label": "Policies and Procedures",
         "description": "Documentation requirements and record retention"
       }

--- a/data/frameworks/stig.json
+++ b/data/frameworks/stig.json
@@ -11,15 +11,15 @@
     "method": "severity-coverage",
     "categories": {
       "CAT-I": {
-        "label": "CAT I — High",
+        "label": "CAT I â€” High",
         "description": "Vulnerabilities that allow an attacker to directly gain privileged access or bypass security"
       },
       "CAT-II": {
-        "label": "CAT II — Medium",
+        "label": "CAT II â€” Medium",
         "description": "Vulnerabilities that provide information or capability that could lead to compromise"
       },
       "CAT-III": {
-        "label": "CAT III — Low",
+        "label": "CAT III â€” Low",
         "description": "Vulnerabilities that degrade security measures or provide limited exposure"
       }
     }


### PR DESCRIPTION
Closes #185

## Problem

Windows-1252 bytes have shipped in `cmmc.json`, `hipaa.json`, and `stig.json` twice — in v2.4.0 and again in v2.6.0. M365-Assess added a defensive normalization step in its sync workflow each time, but the root cause was never fixed here.

## Fix

**CI gate** — adds a step to the `python-validate` job that opens every `data/**/*.json` with strict `utf-8` encoding. Any non-UTF-8 byte fails the build before a PR can merge.

**Encoding fix** — re-encodes the same three offending files to UTF-8 so the new gate passes immediately.

## Why the same three files keep regressing

These files contain special characters (em dashes, section signs) that Word/Excel and some editors write as Windows-1252 instead of UTF-8. The gate will catch this at PR time going forward regardless of authoring tool.

## Test Plan

- [ ] CI passes on this PR (all 27 data/ JSONs are valid UTF-8)
- [ ] A test PR introducing a Windows-1252 byte fails the new step

🤖 Generated with [Claude Code](https://claude.com/claude-code)