### PR TITLE
feat: replace M365-Assess NIST column with CIS transitive + SCuBA paths

### DIFF
--- a/data/cis-m365-crosswalk.json
+++ b/data/cis-m365-crosswalk.json
@@ -1,2077 +1,1865 @@
 {
-  "schemaVersion": "1.0.0",
-  "source": "CIS_M365_to_NIST_to_FedRAMP_Crosswalk.csv",
+  "schemaVersion": "1.1.0",
+  "source": "CIS_Microsoft_365_Foundations_Benchmark_v6.0.1.xlsx + CIS_Controls_v8.1_Mapping_to_NIST_SP_800-53_Rev5.csv",
+  "derivation": "CIS M365 recommendation -> CIS Controls v8 safeguard -> NIST 800-53 R5",
   "controls": {
     "1.1.1": {
       "title": "Ensure Administrative accounts are cloud-only",
-      "section": "Microsoft 365 admin center",
+      "section": "Users",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-2",
-        "AC-6(5)"
+      "safeguards": [
+        "5.4"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-6(2)",
+        "AC-6(5)"
+      ]
     },
     "1.1.2": {
       "title": "Ensure two emergency access accounts have been defined",
-      "section": "Microsoft 365 admin center",
+      "section": "Users",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-2",
-        "AC-2(2)"
+      "safeguards": [
+        "5.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-2"
+      ]
     },
     "1.1.3": {
       "title": "Ensure that between two and four global admins are designated",
-      "section": "Microsoft 365 admin center",
+      "section": "Users",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(5)"
+      "safeguards": [
+        "5.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "AC-2"
+      ]
     },
     "1.1.4": {
       "title": "Ensure administrative accounts use licenses with a reduced application footprint",
-      "section": "Microsoft 365 admin center",
+      "section": "Users",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-6",
-        "AC-6(5)"
+      "safeguards": [
+        "5.4"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "AC-6(2)",
+        "AC-6(5)"
+      ]
     },
     "1.2.1": {
       "title": "Ensure that only organizationally managed/approved public groups exist",
-      "section": "Microsoft 365 admin center",
+      "section": "Teams & groups",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(10)",
-        "CM-5"
+      "safeguards": [
+        "3.3"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
     },
     "1.2.2": {
       "title": "Ensure sign-in to shared mailboxes is blocked",
-      "section": "Microsoft 365 admin center",
+      "section": "Teams & groups",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-2",
-        "AC-3"
+      "safeguards": [
+        "0.0"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": []
     },
     "1.3.1": {
       "title": "Ensure the 'Password expiration policy' is set to 'Set passwords to never expire (recommended)'",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L1",
       "license": "E3",
+      "safeguards": [
+        "5.2"
+      ],
       "nist800_53": [
         "IA-5(1)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      ]
     },
     "1.3.2": {
       "title": "Ensure 'Idle session timeout'  is set to '3 hours (or less)' for unmanaged devices",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-11",
-        "AC-12"
+      "safeguards": [
+        "4.3"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "AC-2(5)",
+        "AC-11",
+        "AC-11(1)",
+        "AC-12"
+      ]
     },
     "1.3.3": {
       "title": "Ensure 'External sharing' of calendars is not available",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "SC-7(10)"
+      "safeguards": [
+        "4.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
     },
     "1.3.4": {
       "title": "Ensure 'User owned apps and services' is restricted",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "CM-11",
-        "CM-7"
+      "safeguards": [
+        "4.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
     },
     "1.3.5": {
       "title": "Ensure internal phishing protection for Forms is enabled",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "SI-8"
+      "safeguards": [
+        "10.1",
+        "14.2"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "SI-3",
+        "AT-2(3)"
+      ]
     },
     "1.3.6": {
       "title": "Ensure the customer lockbox feature is enabled",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L2",
       "license": "E5",
-      "nist800_53": [
-        "AC-3",
-        "AC-6"
+      "safeguards": [
+        "0.0"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": []
     },
     "1.3.7": {
       "title": "Ensure 'third-party storage services' are restricted in 'Microsoft 365 on the web'",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SC-7(10)"
+      "safeguards": [
+        "3.3"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
     },
     "1.3.8": {
       "title": "Ensure that Sways cannot be shared with people outside of your organization",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "SC-7(10)"
+      "safeguards": [
+        "4.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
     },
     "1.3.9": {
       "title": "Ensure shared bookings pages are restricted to select users",
-      "section": "Microsoft 365 admin center",
+      "section": "Settings",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "AC-6"
+      "safeguards": [
+        "6.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-2",
+        "AC-5",
+        "AC-6",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
     },
     "2.1.1": {
       "title": "Ensure Safe Links for Office Applications is Enabled",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L2",
       "license": "E5",
-      "nist800_53": [
-        "CM-6",
-        "SI-3",
-        "SI-8"
+      "safeguards": [
+        "10.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "SI-3"
+      ]
     },
     "2.1.2": {
       "title": "Ensure the Common Attachment Types Filter is enabled",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
+      "safeguards": [
+        "9.6"
+      ],
       "nist800_53": [
-        "CM-6",
         "SI-3",
         "SI-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      ]
     },
     "2.1.3": {
       "title": "Ensure notifications for internal users sending malware is Enabled",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "SI-3",
-        "SI-4(5)"
+      "safeguards": [
+        "17.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "IR-1",
+        "IR-8"
+      ]
     },
     "2.1.4": {
       "title": "Ensure Safe Attachments policy is enabled",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L2",
       "license": "E5",
+      "safeguards": [
+        "9.7"
+      ],
       "nist800_53": [
-        "CM-6",
         "SI-3",
         "SI-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      ]
     },
     "2.1.5": {
       "title": "Ensure Safe Attachments for SharePoint, OneDrive, and Microsoft Teams is Enabled",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L2",
       "license": "E5",
-      "nist800_53": [
-        "SI-3"
+      "safeguards": [
+        "9.7",
+        "10.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-8"
+      ]
     },
     "2.1.6": {
       "title": "Ensure Exchange Online Spam Policies are set to notify administrators",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "CM-6",
-        "SI-3",
-        "SI-8"
+      "safeguards": [
+        "17.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "IR-1",
+        "IR-8"
+      ]
     },
     "2.1.7": {
       "title": "Ensure that an anti-phishing policy has been created",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L2",
       "license": "E5",
-      "nist800_53": [
-        "SI-8"
+      "safeguards": [
+        "9.7"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-8"
+      ]
     },
     "2.1.8": {
       "title": "Ensure that SPF records are published for all Exchange Domains",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-2",
-        "SI-8"
+      "safeguards": [
+        "9.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "SC-7"
+      ]
     },
     "2.1.9": {
       "title": "Ensure that DKIM is enabled for all Exchange Online Domains",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "SC-8"
+      "safeguards": [
+        "9.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "SC-7"
+      ]
     },
     "2.1.10": {
       "title": "Ensure DMARC Records for all Exchange Online domains are published",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "SI-4(5)",
-        "SI-8"
+      "safeguards": [
+        "9.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "SC-7"
+      ]
     },
     "2.1.11": {
       "title": "Ensure comprehensive attachment filtering is applied",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "CM-6",
-        "SI-3"
+      "safeguards": [
+        "9.6"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-8"
+      ]
     },
     "2.1.12": {
       "title": "Ensure the connection filter IP allow list is not used",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-4",
-        "SI-8"
+      "safeguards": [
+        "9.7"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-8"
+      ]
     },
     "2.1.13": {
       "title": "Ensure the connection filter safe list is off",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-4",
-        "SI-8"
+      "safeguards": [
+        "9.7"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-8"
+      ]
     },
     "2.1.14": {
       "title": "Ensure inbound anti-spam policies do not contain allowed domains",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "SI-8"
+      "safeguards": [
+        "9.7"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-8"
+      ]
     },
     "2.1.15": {
       "title": "Ensure outbound anti-spam message limits are in place",
-      "section": "Microsoft 365 Defender",
+      "section": "Email & collaboration",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "CM-6",
-        "SI-8"
+      "safeguards": [
+        "9.7"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-8"
+      ]
     },
     "2.2.1": {
       "title": "Ensure emergency access account activity is monitored",
-      "section": "Microsoft 365 Defender",
+      "section": "Cloud apps",
       "level": "L1",
       "license": "E5",
-      "nist800_53": [
-        "AU-12",
-        "AU-2",
-        "AU-7"
+      "safeguards": [
+        "8.2"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AU-2",
+        "AU-7",
+        "AU-12"
+      ]
     },
     "2.4.1": {
       "title": "Ensure Priority account protection is enabled and configured",
-      "section": "Microsoft 365 Defender",
+      "section": "System",
       "level": "L1",
       "license": "E5",
+      "safeguards": [
+        "9.7"
+      ],
       "nist800_53": [
-        "CM-6",
         "SI-3",
         "SI-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      ]
     },
     "2.4.2": {
       "title": "Ensure Priority accounts have 'Strict protection' presets applied",
-      "section": "Microsoft 365 Defender",
+      "section": "System",
       "level": "L1",
       "license": "E5",
-      "nist800_53": [
-        "CM-6",
-        "SI-3",
-        "SI-8"
+      "safeguards": [
+        "9.7",
+        "10.7"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-8",
+        "SI-4"
+      ]
     },
     "2.4.3": {
       "title": "Ensure Microsoft Defender for Cloud Apps is enabled and configured",
-      "section": "Microsoft 365 Defender",
+      "section": "System",
       "level": "L2",
       "license": "E5",
-      "nist800_53": [
-        "SI-4(5)"
+      "safeguards": [
+        "10.1",
+        "10.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "SI-3",
+        "SI-16"
+      ]
     },
     "2.4.4": {
       "title": "Ensure Zero-hour auto purge for Microsoft Teams is on",
-      "section": "Microsoft 365 Defender",
+      "section": "System",
       "level": "L1",
       "license": "E5",
-      "nist800_53": [
-        "SI-3",
-        "SI-8"
+      "safeguards": [
+        "10.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "SI-3"
+      ]
     },
     "3.1.1": {
       "title": "Ensure Microsoft 365 audit log search is Enabled",
-      "section": "Microsoft Purview",
+      "section": "Audit",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AU-12"
+      "safeguards": [
+        "8.2"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AU-2",
+        "AU-7",
+        "AU-12"
+      ]
     },
     "3.2.1": {
       "title": "Ensure DLP policies are enabled",
-      "section": "Microsoft Purview",
+      "section": "Data loss protection",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "SC-7(10)"
+      "safeguards": [
+        "3.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": false,
-        "low": false
-      }
+      "nist800_53": [
+        "AU-11",
+        "CM-12",
+        "SI-12"
+      ]
     },
     "3.2.2": {
       "title": "Ensure DLP policies are enabled for Microsoft Teams",
-      "section": "Microsoft Purview",
+      "section": "Data loss protection",
       "level": "L1",
       "license": "E5",
-      "nist800_53": [
-        "SC-7(10)"
+      "safeguards": [
+        "3.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": false,
-        "low": false
-      }
+      "nist800_53": [
+        "AU-11",
+        "CM-12",
+        "SI-12"
+      ]
     },
     "3.3.1": {
       "title": "Ensure Information Protection sensitivity label policies are published",
-      "section": "Microsoft Purview",
+      "section": "Information Protection",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "SC-7(10)"
+      "safeguards": [
+        "3.7"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "RA-2"
+      ]
     },
     "4.1": {
       "title": "Ensure devices without a compliance policy are marked 'not compliant'",
       "section": "Microsoft Intune admin center",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "CM-6",
-        "CM-8"
+      "safeguards": [
+        "0.0"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": []
     },
     "4.2": {
       "title": "Ensure device enrollment for personally owned devices is blocked by default",
       "section": "Microsoft Intune admin center",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-19",
-        "CM-7"
+      "safeguards": [
+        "4.12",
+        "4.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-19(5)",
+        "SC-39",
+        "CM-6",
+        "CM-7"
+      ]
     },
     "5.1.2.1": {
       "title": "Ensure 'Per-user MFA' is disabled",
-      "section": "Microsoft Entra admin center",
+      "section": "Users",
       "level": "L1",
       "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
       "nist800_53": [
-        "CM-6",
         "IA-2(1)",
         "IA-2(2)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      ]
     },
     "5.1.2.2": {
       "title": "Ensure third party integrated applications are not allowed",
-      "section": "Microsoft Entra admin center",
+      "section": "Users",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(10)",
-        "CM-5"
+      "safeguards": [
+        "2.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "CM-7(5)",
+        "CM-10"
+      ]
     },
     "5.1.2.3": {
       "title": "Ensure 'Restrict non-admin users from creating tenants' is set to 'Yes'",
-      "section": "Microsoft Entra admin center",
+      "section": "Users",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(10)",
-        "CM-5"
+      "safeguards": [
+        "0.0"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": []
     },
     "5.1.2.4": {
       "title": "Ensure access to the Entra admin center is restricted",
-      "section": "Microsoft Entra admin center",
+      "section": "Users",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "AC-6(5)"
+      "safeguards": [
+        "0.0"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": []
     },
     "5.1.2.5": {
       "title": "Ensure the option to remain signed in is hidden",
-      "section": "Microsoft Entra admin center",
+      "section": "Users",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-11",
-        "AC-12"
+      "safeguards": [
+        "4.3"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "AC-2(5)",
+        "AC-11",
+        "AC-11(1)",
+        "AC-12"
+      ]
     },
     "5.1.2.6": {
       "title": "Ensure 'LinkedIn account connections' is disabled",
-      "section": "Microsoft Entra admin center",
+      "section": "Users",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "CM-7"
+      "safeguards": [
+        "4.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
     },
     "5.1.3.1": {
       "title": "Ensure a dynamic group for guest users is created",
-      "section": "Microsoft Entra admin center",
+      "section": "Groups",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-2",
-        "AC-6"
+      "safeguards": [
+        "3.3"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
     },
     "5.1.3.2": {
       "title": "Ensure users cannot create security groups",
-      "section": "Microsoft Entra admin center",
+      "section": "Groups",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(10)",
-        "CM-5"
+      "safeguards": [
+        "3.3"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
     },
     "5.1.4.1": {
       "title": "Ensure the ability to join devices to Entra is restricted",
-      "section": "Microsoft Entra admin center",
+      "section": "Devices",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "CM-7"
+      "safeguards": [
+        "6.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-2",
+        "AC-5",
+        "AC-6",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
     },
     "5.1.4.2": {
       "title": "Ensure the maximum number of devices per user is limited",
-      "section": "Microsoft Entra admin center",
+      "section": "Devices",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-19",
-        "CM-8"
+      "safeguards": [
+        "6.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-2",
+        "AC-5",
+        "AC-6",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
     },
     "5.1.4.3": {
       "title": "Ensure the GA role is not added as a local administrator during Entra join",
-      "section": "Microsoft Entra admin center",
+      "section": "Devices",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(5)",
-        "CM-6"
+      "safeguards": [
+        "6.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-2",
+        "AC-5",
+        "AC-6",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
     },
     "5.1.4.4": {
       "title": "Ensure local administrator assignment is limited during Entra join",
-      "section": "Microsoft Entra admin center",
+      "section": "Devices",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(5)",
-        "CM-6"
+      "safeguards": [
+        "6.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-2",
+        "AC-5",
+        "AC-6",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
     },
     "5.1.4.5": {
       "title": "Ensure Local Administrator Password Solution is enabled",
-      "section": "Microsoft Entra admin center",
+      "section": "Devices",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "CM-6",
-        "IA-5"
+      "safeguards": [
+        "5.2"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "IA-5(1)"
+      ]
     },
     "5.1.4.6": {
       "title": "Ensure users are restricted from recovering BitLocker keys",
-      "section": "Microsoft Entra admin center",
+      "section": "Devices",
       "level": "L2",
       "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
       "nist800_53": [
         "AC-3",
-        "AC-6"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
     },
     "5.1.5.1": {
       "title": "Ensure user consent to apps accessing company data on their behalf is not allowed",
-      "section": "Microsoft Entra admin center",
+      "section": "Applications",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(10)",
-        "CM-5"
+      "safeguards": [
+        "3.3"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
     },
     "5.1.5.2": {
       "title": "Ensure the admin consent workflow is enabled",
-      "section": "Microsoft Entra admin center",
+      "section": "Applications",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(10)",
-        "CM-4"
+      "safeguards": [
+        "2.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "CM-7(5)",
+        "CM-10"
+      ]
     },
     "5.1.6.1": {
       "title": "Ensure that collaboration invitations are sent to allowed domains only",
-      "section": "Microsoft Entra admin center",
+      "section": "External Identities",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-3"
+      "safeguards": [
+        "6.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "IA-4",
+        "IA-5",
+        "AC-1",
+        "AC-2",
+        "AC-2(1)"
+      ]
     },
     "5.1.6.2": {
       "title": "Ensure that guest user access is restricted",
-      "section": "Microsoft Entra admin center",
+      "section": "External Identities",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "AC-6"
+      "safeguards": [
+        "6.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "IA-4",
+        "IA-5",
+        "AC-1",
+        "AC-2",
+        "AC-2(1)"
+      ]
     },
     "5.1.6.3": {
       "title": "Ensure guest user invitations are limited to the Guest Inviter role",
-      "section": "Microsoft Entra admin center",
+      "section": "External Identities",
       "level": "L2",
       "license": "E3",
-      "nist800_53": [
-        "AC-6(10)"
+      "safeguards": [
+        "6.1"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
+      "nist800_53": [
+        "IA-4",
+        "IA-5",
+        "AC-1",
+        "AC-2",
+        "AC-2(1)"
+      ]
     },
     "5.1.8.1": {
       "title": "Ensure that password hash sync is enabled for hybrid deployments",
-      "section": "Microsoft Entra admin center",
+      "section": "Hybrid management",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "IA-5"
+      "safeguards": [
+        "6.7"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-2(1)",
+        "AC-3"
+      ]
     },
     "5.2.2.1": {
       "title": "Ensure multifactor authentication is enabled for all users in administrative roles",
-      "section": "Microsoft Entra admin center",
+      "section": "Risk-based Conditional Access",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "IA-2(1)",
-        "IA-2(2)"
+      "safeguards": [
+        "6.5"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "IA-2(1)"
+      ]
     },
     "5.2.2.2": {
       "title": "Ensure multifactor authentication is enabled for all users",
-      "section": "Microsoft Entra admin center",
+      "section": "Risk-based Conditional Access",
       "level": "L1",
       "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
       "nist800_53": [
         "IA-2(1)",
         "IA-2(2)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      ]
     },
     "5.2.2.3": {
       "title": "Enable Conditional Access policies to block legacy authentication",
-      "section": "Microsoft Entra admin center",
+      "section": "Risk-based Conditional Access",
       "level": "L1",
       "license": "E3",
-      "nist800_53": [
-        "CM-7"
+      "safeguards": [
+        "4.8"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.2.4": {
-      "title": "Ensure Sign-in frequency is enabled and browser sessions are not persistent for Administrative users",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-11",
-        "AC-12"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "5.2.2.5": {
-      "title": "Ensure 'Phishing-resistant MFA strength' is required for Administrators",
-      "section": "Microsoft Entra admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "IA-2(1)",
-        "IA-2(8)",
-        "IA-5"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.2.6": {
-      "title": "Enable Identity Protection user risk policies",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E5",
-      "nist800_53": [
-        "AC-2(12)",
-        "AC-2(13)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "5.2.2.7": {
-      "title": "Enable Identity Protection sign-in risk policies",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E5",
-      "nist800_53": [
-        "AC-2(12)",
-        "AC-2(13)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "5.2.2.8": {
-      "title": "Ensure 'sign-in risk' is blocked for medium and high risk",
-      "section": "Microsoft Entra admin center",
-      "level": "L2",
-      "license": "E5",
-      "nist800_53": [
-        "AC-2(12)",
-        "AC-2(13)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "5.2.2.9": {
-      "title": "Ensure a managed device is required for authentication",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-20",
-        "IA-3"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.2.10": {
-      "title": "Ensure a managed device is required to register security information",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-20",
-        "IA-3"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.2.11": {
-      "title": "Ensure sign-in frequency for Intune Enrollment is set to 'Every time'",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-11",
-        "IA-2(1)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.2.12": {
-      "title": "Ensure the device code sign-in flow is blocked",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.3.1": {
-      "title": "Ensure Microsoft Authenticator is configured to protect against MFA fatigue",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "IA-2(1)",
-        "IA-2(13)",
-        "IA-2(2)",
-        "IA-2(8)",
-        "IA-5"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.3.2": {
-      "title": "Ensure custom banned passwords lists are used",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "IA-5(1)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.3.3": {
-      "title": "Ensure password protection is enabled for on-prem Active Directory",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "IA-5(1)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.3.4": {
-      "title": "Ensure all member users are 'MFA capable'",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "IA-2(1)",
-        "IA-2(2)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.3.5": {
-      "title": "Ensure weak authentication methods are disabled",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "IA-5"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.3.6": {
-      "title": "Ensure system-preferred multifactor authentication is enabled",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "IA-2(1)",
-        "IA-2(2)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.3.7": {
-      "title": "Ensure the email OTP authentication method is disabled",
-      "section": "Microsoft Entra admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "IA-5"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.2.4.1": {
-      "title": "Ensure 'Self service password reset enabled' is set to 'All'",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "IA-5(1)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.3.1": {
-      "title": "Ensure 'Privileged Identity Management' is used to manage roles",
-      "section": "Microsoft Entra admin center",
-      "level": "L2",
-      "license": "E5",
-      "nist800_53": [
-        "AC-2",
-        "AC-6(1)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "5.3.2": {
-      "title": "Ensure 'Access reviews' for Guest Users are configured",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E5",
-      "nist800_53": [
-        "AC-2(1)",
-        "AC-2(3)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "5.3.3": {
-      "title": "Ensure 'Access reviews' for privileged roles are configured",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E5",
-      "nist800_53": [
-        "AC-2(1)",
-        "AC-2(3)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "5.3.4": {
-      "title": "Ensure approval is required for Global Administrator role activation",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E5",
-      "nist800_53": [
-        "AC-6(1)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "5.3.5": {
-      "title": "Ensure approval is required for Privileged Role Administrator activation",
-      "section": "Microsoft Entra admin center",
-      "level": "L1",
-      "license": "E5",
-      "nist800_53": [
-        "AC-6(1)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "6.1.1": {
-      "title": "Ensure 'AuditDisabled' organizationally is set to 'False'",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AU-12"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "6.1.2": {
-      "title": "Ensure mailbox audit actions are configured",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AU-12"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "6.1.3": {
-      "title": "Ensure 'AuditBypassEnabled' is not enabled on mailboxes",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AU-12"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "6.2.1": {
-      "title": "Ensure all forms of mail forwarding are blocked and/or disabled",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-4"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "6.2.2": {
-      "title": "Ensure mail transport rules do not whitelist specific domains",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "SI-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "6.2.3": {
-      "title": "Ensure email from external senders is identified",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "SI-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "6.3.1": {
-      "title": "Ensure users installing Outlook add-ins is not allowed",
-      "section": "Exchange admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "CM-11",
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "6.5.1": {
-      "title": "Ensure modern authentication for Exchange Online is enabled",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "6.5.2": {
-      "title": "Ensure MailTips are enabled for end users",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AT-2"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "6.5.3": {
-      "title": "Ensure additional storage providers are restricted in Outlook on the web",
-      "section": "Exchange admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SC-7(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "6.5.4": {
-      "title": "Ensure SMTP AUTH is disabled",
-      "section": "Exchange admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "6.5.5": {
-      "title": "Ensure Direct Send submissions are rejected",
-      "section": "Exchange admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-18",
-        "SC-23"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.1": {
-      "title": "Ensure modern authentication for SharePoint applications is required",
-      "section": "SharePoint admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "IA-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.2": {
-      "title": "Ensure SharePoint and OneDrive integration with Azure AD B2B is enabled",
-      "section": "SharePoint admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-2",
-        "IA-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.3": {
-      "title": "Ensure external content sharing is restricted",
-      "section": "SharePoint admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-2",
-        "AC-3",
-        "IA-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.4": {
-      "title": "Ensure OneDrive content sharing is restricted",
-      "section": "SharePoint admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-2",
-        "AC-3",
-        "IA-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.5": {
-      "title": "Ensure that SharePoint guest users cannot share items they don't own",
-      "section": "SharePoint admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "AC-6(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.6": {
-      "title": "Ensure SharePoint external sharing is restricted",
-      "section": "SharePoint admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "AC-6(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.7": {
-      "title": "Ensure link sharing is restricted in SharePoint and OneDrive",
-      "section": "SharePoint admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-6"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "7.2.8": {
-      "title": "Ensure external sharing is restricted by security group",
-      "section": "SharePoint admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "AC-6(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.9": {
-      "title": "Ensure guest access to a site or OneDrive will expire automatically",
-      "section": "SharePoint admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-21",
-        "AC-3"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.10": {
-      "title": "Ensure reauthentication with verification code is restricted",
-      "section": "SharePoint admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "IA-11"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.2.11": {
-      "title": "Ensure the SharePoint default sharing link permission is set",
-      "section": "SharePoint admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-6"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "7.3.1": {
-      "title": "Ensure Office 365 SharePoint infected files are disallowed for download",
-      "section": "SharePoint admin center",
-      "level": "L2",
-      "license": "E5",
-      "nist800_53": [
-        "SI-3"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "7.3.2": {
-      "title": "Ensure OneDrive sync is restricted for unmanaged devices",
-      "section": "SharePoint admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-19",
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.1.1": {
-      "title": "Ensure external file sharing in Teams is enabled for only approved cloud storage services",
-      "section": "Microsoft Teams admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SC-7(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.1.2": {
-      "title": "Ensure users can't send emails to a channel email address",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-4",
-        "SC-7(10)",
-        "SI-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "8.2.1": {
-      "title": "Ensure external domains are restricted in the Teams admin center",
-      "section": "Microsoft Teams admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-3"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.2.2": {
-      "title": "Ensure communication with unmanaged Teams users is disabled",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SC-7(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.2.3": {
-      "title": "Ensure external Teams users cannot initiate conversations",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SI-8"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.2.4": {
-      "title": "Ensure the organization cannot communicate with accounts in trial Teams tenants",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.4.1": {
-      "title": "Ensure app permission policies are configured",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-11"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.1": {
-      "title": "Ensure anonymous users can't join a meeting",
-      "section": "Microsoft Teams admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "SC-15"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.2": {
-      "title": "Ensure anonymous users and dial-in callers can't start a meeting",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "SC-15"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.3": {
-      "title": "Ensure only people in my org can bypass the lobby",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-3"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.4": {
-      "title": "Ensure users dialing in can't bypass the lobby",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "SC-15"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.5": {
-      "title": "Ensure meeting chat does not allow anonymous users",
-      "section": "Microsoft Teams admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "SC-15"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.6": {
-      "title": "Ensure only organizers and co-organizers can present",
-      "section": "Microsoft Teams admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "AC-21",
-        "AC-3"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.7": {
-      "title": "Ensure external participants can't give or request control",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-17"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.8": {
-      "title": "Ensure external meeting chat is off",
-      "section": "Microsoft Teams admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SC-7(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.5.9": {
-      "title": "Ensure meeting recording is off by default",
-      "section": "Microsoft Teams admin center",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "8.6.1": {
-      "title": "Ensure users can report security concerns in Teams",
-      "section": "Microsoft Teams admin center",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "SI-4(12)",
-        "SI-4(5)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "9.1.1": {
-      "title": "Ensure guest user access is restricted",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-6",
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "9.1.2": {
-      "title": "Ensure external user invitations are restricted",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-6",
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "9.1.3": {
-      "title": "Ensure guest access to content is restricted",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-6",
-        "CM-7"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "9.1.4": {
-      "title": "Ensure 'Publish to web' is restricted",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SC-7(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "9.1.5": {
-      "title": "Ensure 'Interact with and share R and Python' visuals is 'Disabled'",
-      "section": "Microsoft Fabric",
-      "level": "L2",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SI-3"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "9.1.6": {
-      "title": "Ensure 'Allow users to apply sensitivity labels for content' is 'Enabled'",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-3",
-        "SC-7(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "9.1.7": {
-      "title": "Ensure shareable links are restricted",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-21",
-        "SC-7(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "9.1.8": {
-      "title": "Ensure enabling of external data sharing is restricted",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "SC-7(10)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "9.1.9": {
-      "title": "Ensure 'Block ResourceKey Authentication' is 'Enabled'",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "CM-7",
-        "IA-5"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
-    },
-    "9.1.10": {
-      "title": "Ensure access to APIs by service principals is restricted",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-4",
-        "AC-6(5)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "9.1.11": {
-      "title": "Ensure service principals cannot create and use profiles",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
-      "nist800_53": [
-        "AC-4",
-        "AC-6(5)"
-      ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": false
-      }
-    },
-    "9.1.12": {
-      "title": "Ensure service principals ability to create workspaces, connections and deployment pipelines is restricted",
-      "section": "Microsoft Fabric",
-      "level": "L1",
-      "license": "E3",
       "nist800_53": [
         "CM-6",
         "CM-7"
+      ]
+    },
+    "5.2.2.4": {
+      "title": "Ensure Sign-in frequency is enabled and browser sessions are not persistent for Administrative users",
+      "section": "Risk-based Conditional Access",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "4.3"
       ],
-      "fedramp": {
-        "high": true,
-        "moderate": true,
-        "low": true
-      }
+      "nist800_53": [
+        "AC-2(5)",
+        "AC-11",
+        "AC-11(1)",
+        "AC-12"
+      ]
+    },
+    "5.2.2.5": {
+      "title": "Ensure 'Phishing-resistant MFA strength' is required for Administrators",
+      "section": "Risk-based Conditional Access",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "6.5"
+      ],
+      "nist800_53": [
+        "IA-2(1)"
+      ]
+    },
+    "5.2.2.6": {
+      "title": "Enable Identity Protection user risk policies",
+      "section": "Risk-based Conditional Access",
+      "level": "L1",
+      "license": "E5",
+      "safeguards": [
+        "13.3"
+      ],
+      "nist800_53": [
+        "SI-4",
+        "SI-4(4)"
+      ]
+    },
+    "5.2.2.7": {
+      "title": "Enable Identity Protection sign-in risk policies",
+      "section": "Risk-based Conditional Access",
+      "level": "L1",
+      "license": "E5",
+      "safeguards": [
+        "13.3"
+      ],
+      "nist800_53": [
+        "SI-4",
+        "SI-4(4)"
+      ]
+    },
+    "5.2.2.8": {
+      "title": "Ensure 'sign-in risk' is blocked for medium and high risk",
+      "section": "Risk-based Conditional Access",
+      "level": "L2",
+      "license": "E5",
+      "safeguards": [
+        "13.3"
+      ],
+      "nist800_53": [
+        "SI-4",
+        "SI-4(4)"
+      ]
+    },
+    "5.2.2.9": {
+      "title": "Ensure a managed device is required for authentication",
+      "section": "Risk-based Conditional Access",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
+      "nist800_53": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ]
+    },
+    "5.2.2.10": {
+      "title": "Ensure a managed device is required to register security information",
+      "section": "Risk-based Conditional Access",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
+      "nist800_53": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ]
+    },
+    "5.2.2.11": {
+      "title": "Ensure sign-in frequency for Intune Enrollment is set to 'Every time'",
+      "section": "Risk-based Conditional Access",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
+      "nist800_53": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ]
+    },
+    "5.2.2.12": {
+      "title": "Ensure the device code sign-in flow is blocked",
+      "section": "Risk-based Conditional Access",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "16.7"
+      ],
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
+    },
+    "5.2.3.1": {
+      "title": "Ensure Microsoft Authenticator is configured to protect against MFA fatigue",
+      "section": "Authentication Methods",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.4"
+      ],
+      "nist800_53": [
+        "AC-19",
+        "IA-2(1)",
+        "IA-2(2)"
+      ]
+    },
+    "5.2.3.2": {
+      "title": "Ensure custom banned passwords lists are used",
+      "section": "Authentication Methods",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "5.2"
+      ],
+      "nist800_53": [
+        "IA-5(1)"
+      ]
+    },
+    "5.2.3.3": {
+      "title": "Ensure password protection is enabled for on-prem Active Directory",
+      "section": "Authentication Methods",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "5.2"
+      ],
+      "nist800_53": [
+        "IA-5(1)"
+      ]
+    },
+    "5.2.3.4": {
+      "title": "Ensure all member users are 'MFA capable'",
+      "section": "Authentication Methods",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
+      "nist800_53": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ]
+    },
+    "5.2.3.5": {
+      "title": "Ensure weak authentication methods are disabled",
+      "section": "Authentication Methods",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
+      "nist800_53": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ]
+    },
+    "5.2.3.6": {
+      "title": "Ensure system-preferred multifactor authentication is enabled",
+      "section": "Authentication Methods",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
+      "nist800_53": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ]
+    },
+    "5.2.3.7": {
+      "title": "Ensure the email OTP authentication method is disabled",
+      "section": "Authentication Methods",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "6.3"
+      ],
+      "nist800_53": [
+        "IA-2(1)",
+        "IA-2(2)"
+      ]
+    },
+    "5.2.4.1": {
+      "title": "Ensure 'Self service password reset enabled' is set to 'All'",
+      "section": "Password reset",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "5.3.1": {
+      "title": "Ensure 'Privileged Identity Management' is used to manage roles",
+      "section": "ID Governance",
+      "level": "L2",
+      "license": "E5",
+      "safeguards": [
+        "6.1",
+        "6.2"
+      ],
+      "nist800_53": [
+        "IA-4",
+        "IA-5",
+        "AC-1",
+        "AC-2",
+        "AC-2(1)"
+      ]
+    },
+    "5.3.2": {
+      "title": "Ensure 'Access reviews' for Guest Users are configured",
+      "section": "ID Governance",
+      "level": "L1",
+      "license": "E5",
+      "safeguards": [
+        "5.1",
+        "5.3"
+      ],
+      "nist800_53": [
+        "AC-2",
+        "AC-2(3)"
+      ]
+    },
+    "5.3.3": {
+      "title": "Ensure 'Access reviews' for privileged roles are configured",
+      "section": "ID Governance",
+      "level": "L1",
+      "license": "E5",
+      "safeguards": [
+        "5.1",
+        "5.3"
+      ],
+      "nist800_53": [
+        "AC-2",
+        "AC-2(3)"
+      ]
+    },
+    "5.3.4": {
+      "title": "Ensure approval is required for Global Administrator role activation",
+      "section": "ID Governance",
+      "level": "L1",
+      "license": "E5",
+      "safeguards": [
+        "6.1",
+        "6.2"
+      ],
+      "nist800_53": [
+        "IA-4",
+        "IA-5",
+        "AC-1",
+        "AC-2",
+        "AC-2(1)"
+      ]
+    },
+    "5.3.5": {
+      "title": "Ensure approval is required for Privileged Role Administrator activation",
+      "section": "ID Governance",
+      "level": "L1",
+      "license": "E5",
+      "safeguards": [
+        "6.1",
+        "6.2"
+      ],
+      "nist800_53": [
+        "IA-4",
+        "IA-5",
+        "AC-1",
+        "AC-2",
+        "AC-2(1)"
+      ]
+    },
+    "6.1.1": {
+      "title": "Ensure 'AuditDisabled' organizationally is set to 'False'",
+      "section": "Audit",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "8.2"
+      ],
+      "nist800_53": [
+        "AU-2",
+        "AU-7",
+        "AU-12"
+      ]
+    },
+    "6.1.2": {
+      "title": "Ensure mailbox audit actions are configured",
+      "section": "Audit",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "8.2"
+      ],
+      "nist800_53": [
+        "AU-2",
+        "AU-7",
+        "AU-12"
+      ]
+    },
+    "6.1.3": {
+      "title": "Ensure 'AuditBypassEnabled' is not enabled on mailboxes",
+      "section": "Audit",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "8.5"
+      ],
+      "nist800_53": [
+        "AU-3",
+        "AU-3(1)",
+        "AU-7",
+        "AU-12"
+      ]
+    },
+    "6.2.1": {
+      "title": "Ensure all forms of mail forwarding are blocked and/or disabled",
+      "section": "Mail flow",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "6.2.2": {
+      "title": "Ensure mail transport rules do not whitelist specific domains",
+      "section": "Mail flow",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "9.7"
+      ],
+      "nist800_53": [
+        "SI-3",
+        "SI-8"
+      ]
+    },
+    "6.2.3": {
+      "title": "Ensure email from external senders is identified",
+      "section": "Mail flow",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "6.3.1": {
+      "title": "Ensure users installing Outlook add-ins is not allowed",
+      "section": "Roles",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "9.4"
+      ],
+      "nist800_53": [
+        "CM-10",
+        "CM-11",
+        "SC-18"
+      ]
+    },
+    "6.5.1": {
+      "title": "Ensure modern authentication for Exchange Online is enabled",
+      "section": "Settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.10"
+      ],
+      "nist800_53": [
+        "AC-17(2)",
+        "IA-5",
+        "IA-5(1)",
+        "SC-8",
+        "SC-8(1)"
+      ]
+    },
+    "6.5.2": {
+      "title": "Ensure MailTips are enabled for end users",
+      "section": "Settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "6.5.3": {
+      "title": "Ensure additional storage providers are restricted in Outlook on the web",
+      "section": "Settings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "6.5.4": {
+      "title": "Ensure SMTP AUTH is disabled",
+      "section": "Settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "12.6"
+      ],
+      "nist800_53": [
+        "AC-18",
+        "SC-23"
+      ]
+    },
+    "6.5.5": {
+      "title": "Ensure Direct Send submissions are rejected",
+      "section": "Settings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "12.6"
+      ],
+      "nist800_53": [
+        "AC-18",
+        "SC-23"
+      ]
+    },
+    "7.2.1": {
+      "title": "Ensure modern authentication for SharePoint applications is required",
+      "section": "Policies",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.10"
+      ],
+      "nist800_53": [
+        "AC-17(2)",
+        "IA-5",
+        "IA-5(1)",
+        "SC-8",
+        "SC-8(1)"
+      ]
+    },
+    "7.2.2": {
+      "title": "Ensure SharePoint and OneDrive integration with Azure AD B2B is enabled",
+      "section": "Policies",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "7.2.3": {
+      "title": "Ensure external content sharing is restricted",
+      "section": "Policies",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "7.2.4": {
+      "title": "Ensure OneDrive content sharing is restricted",
+      "section": "Policies",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "7.2.5": {
+      "title": "Ensure that SharePoint guest users cannot share items they don't own",
+      "section": "Policies",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "7.2.6": {
+      "title": "Ensure SharePoint external sharing is restricted",
+      "section": "Policies",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "7.2.7": {
+      "title": "Ensure link sharing is restricted in SharePoint and OneDrive",
+      "section": "Policies",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "7.2.8": {
+      "title": "Ensure external sharing is restricted by security group",
+      "section": "Policies",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "6.8"
+      ],
+      "nist800_53": [
+        "AC-2",
+        "AC-5",
+        "AC-6",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
+    },
+    "7.2.9": {
+      "title": "Ensure guest access to a site or OneDrive will expire automatically",
+      "section": "Policies",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "7.2.10": {
+      "title": "Ensure reauthentication with verification code is restricted",
+      "section": "Policies",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "7.2.11": {
+      "title": "Ensure the SharePoint default sharing link permission is set",
+      "section": "Policies",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "7.3.1": {
+      "title": "Ensure Office 365 SharePoint infected files are disallowed for download",
+      "section": "Settings",
+      "level": "L2",
+      "license": "E5",
+      "safeguards": [
+        "10.1"
+      ],
+      "nist800_53": [
+        "SI-3"
+      ]
+    },
+    "7.3.2": {
+      "title": "Ensure OneDrive sync is restricted for unmanaged devices",
+      "section": "Settings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.1.1": {
+      "title": "Ensure external file sharing in Teams is enabled for only approved cloud storage services",
+      "section": "Teams",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "8.1.2": {
+      "title": "Ensure users can't send emails to a channel email address",
+      "section": "Teams",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.2.1": {
+      "title": "Ensure external domains are restricted in the Teams admin center",
+      "section": "Users",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.2.2": {
+      "title": "Ensure communication with unmanaged Teams users is disabled",
+      "section": "Users",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.2.3": {
+      "title": "Ensure external Teams users cannot initiate conversations",
+      "section": "Users",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.2.4": {
+      "title": "Ensure the organization cannot communicate with accounts in trial Teams tenants",
+      "section": "Users",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.4.1": {
+      "title": "Ensure app permission policies are configured",
+      "section": "Teams apps",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "2.5"
+      ],
+      "nist800_53": [
+        "CM-7(5)",
+        "CM-10"
+      ]
+    },
+    "8.5.1": {
+      "title": "Ensure anonymous users can't join a meeting",
+      "section": "Meetings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.5.2": {
+      "title": "Ensure anonymous users and dial-in callers can't start a meeting",
+      "section": "Meetings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.5.3": {
+      "title": "Ensure only people in my org can bypass the lobby",
+      "section": "Meetings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.8"
+      ],
+      "nist800_53": [
+        "AC-2",
+        "AC-5",
+        "AC-6",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
+    },
+    "8.5.4": {
+      "title": "Ensure users dialing in can't bypass the lobby",
+      "section": "Meetings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.5.5": {
+      "title": "Ensure meeting chat does not allow anonymous users",
+      "section": "Meetings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.5.6": {
+      "title": "Ensure only organizers and co-organizers can present",
+      "section": "Meetings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.5.7": {
+      "title": "Ensure external participants can't give or request control",
+      "section": "Meetings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "8.5.8": {
+      "title": "Ensure external meeting chat is off",
+      "section": "Meetings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "16.10"
+      ],
+      "nist800_53": [
+        "PL-8",
+        "SA-8"
+      ]
+    },
+    "8.5.9": {
+      "title": "Ensure meeting recording is off by default",
+      "section": "Meetings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "16.10"
+      ],
+      "nist800_53": [
+        "PL-8",
+        "SA-8"
+      ]
+    },
+    "8.6.1": {
+      "title": "Ensure users can report security concerns in Teams",
+      "section": "Messaging",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "0.0"
+      ],
+      "nist800_53": []
+    },
+    "9.1.1": {
+      "title": "Ensure guest user access is restricted",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.3",
+        "6.8"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2",
+        "AC-2",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
+    },
+    "9.1.2": {
+      "title": "Ensure external user invitations are restricted",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "6.8"
+      ],
+      "nist800_53": [
+        "AC-2",
+        "AC-5",
+        "AC-6",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
+    },
+    "9.1.3": {
+      "title": "Ensure guest access to content is restricted",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "9.1.4": {
+      "title": "Ensure 'Publish to web' is restricted",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "16.10"
+      ],
+      "nist800_53": [
+        "PL-8",
+        "SA-8"
+      ]
+    },
+    "9.1.5": {
+      "title": "Ensure 'Interact with and share R and Python' visuals is 'Disabled'",
+      "section": "Tenant settings",
+      "level": "L2",
+      "license": "E3",
+      "safeguards": [
+        "4.8"
+      ],
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
+    },
+    "9.1.6": {
+      "title": "Ensure 'Allow users to apply sensitivity labels for content' is 'Enabled'",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.2",
+        "3.7"
+      ],
+      "nist800_53": [
+        "CM-12",
+        "PM-5(1)",
+        "RA-2"
+      ]
+    },
+    "9.1.7": {
+      "title": "Ensure shareable links are restricted",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.3"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2"
+      ]
+    },
+    "9.1.8": {
+      "title": "Ensure enabling of external data sharing is restricted",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "3.3",
+        "6.8"
+      ],
+      "nist800_53": [
+        "AC-3",
+        "AC-5",
+        "AC-6",
+        "MP-2",
+        "AC-2",
+        "AC-6(1)",
+        "AC-6(7)",
+        "AU-9(4)"
+      ]
+    },
+    "9.1.9": {
+      "title": "Ensure 'Block ResourceKey Authentication' is 'Enabled'",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "4.8"
+      ],
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
+    },
+    "9.1.10": {
+      "title": "Ensure access to APIs by service principals is restricted",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "4.8"
+      ],
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
+    },
+    "9.1.11": {
+      "title": "Ensure service principals cannot create and use profiles",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "4.8"
+      ],
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
+    },
+    "9.1.12": {
+      "title": "Ensure service principals ability to create workspaces, connections and deployment pipelines is restricted",
+      "section": "Tenant settings",
+      "level": "L1",
+      "license": "E3",
+      "safeguards": [
+        "4.8"
+      ],
+      "nist800_53": [
+        "CM-6",
+        "CM-7"
+      ]
     }
   }
 }

--- a/data/registry.json
+++ b/data/registry.json
@@ -854,8 +854,8 @@
           "controlId": "3.1.1;3.1.2;3.5.1;3.5.2"
         },
         "nist-800-53": {
-          "controlId": "AC-02;AC-03;AC-05;IA-02;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Information Input Validation",
+          "controlId": "CM-7;AC-02;AC-03;AC-05;IA-02;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Least Functionality; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -1221,12 +1221,7 @@
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
         },
         "fedramp": {
-          "controlId": "IA-02;IA-02(01);IA-02(02);IA-02(08);IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-02;IA-02(01);IA-02(02);IA-02(08);IA-05;IA-05(01)"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(i)"
@@ -1247,14 +1242,14 @@
           "controlId": "3.1.1;3.5.1;3.5.2;3.5.3;3.5.4;3.5.8;3.5.9;3.7.5"
         },
         "nist-800-53": {
-          "controlId": "IA-2(1);IA-2(8);IA-5;IA-02;IA-02(01);IA-02(02);IA-02(08);IA-05;IA-05(01)",
+          "controlId": "IA-2(1);IA-2(2);IA-5;IA-2(8);IA-02;IA-02(01);IA-02(02);IA-02(08);IA-05;IA-05(01)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Multi-factor Authentication to Privileged Accounts; Access to Accounts — Replay Resistant; Authenticator Management"
+          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts; Authenticator Management; Access to Accounts — Replay Resistant"
         },
         "nist-csf": {
           "controlId": "PR.AA-01;PR.AA-03;PR.AA-04;PR.AA-05",
@@ -1418,12 +1413,7 @@
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
         },
         "fedramp": {
-          "controlId": "IA-02;IA-02(01);IA-02(02);IA-02(08);IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-02;IA-02(01);IA-02(02);IA-02(08);IA-05;IA-05(01)"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(i)"
@@ -1444,14 +1434,14 @@
           "controlId": "3.1.1;3.5.1;3.5.2;3.5.3;3.5.4;3.5.8;3.5.9;3.7.5"
         },
         "nist-800-53": {
-          "controlId": "IA-2(1);IA-2(13);IA-2(2);IA-2(8);IA-5;IA-02;IA-02(01);IA-02(02);IA-02(08);IA-02(13);IA-05;IA-05(01)",
+          "controlId": "CM-7;IA-5;AC-19;IA-2(1);IA-2(2);IA-02;IA-02(01);IA-02(02);IA-02(08);IA-02(13);IA-05;IA-05(01)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Multi-factor Authentication to Privileged Accounts; Out-of-band Authentication; Multi-factor Authentication to Non-privileged Accounts; Access to Accounts — Replay Resistant; Authenticator Management"
+          "title": "Least Functionality; Authenticator Management; Access Control for Mobile Devices; Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts"
         },
         "nist-csf": {
           "controlId": "PR.AA-01;PR.AA-03;PR.AA-04;PR.AA-05",
@@ -1601,12 +1591,7 @@
           "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii)"
@@ -1624,8 +1609,8 @@
           "controlId": "3.1.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2;IA-8;AC-02;AC-03;AC-05;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Identification and Authentication (Non-organizational Users); Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -1779,12 +1764,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii)"
@@ -1802,8 +1782,8 @@
           "controlId": "3.1.1;3.1.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2;AC-3;IA-8;AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Access Enforcement; Identification and Authentication (Non-organizational Users); Information Input Validation",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -1957,12 +1937,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii)"
@@ -1980,8 +1955,8 @@
           "controlId": "3.1.1;3.1.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2;AC-3;IA-8;AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Access Enforcement; Identification and Authentication (Non-organizational Users); Information Input Validation",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -2375,12 +2350,7 @@
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
         },
         "fedramp": {
-          "controlId": "IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -2398,14 +2368,14 @@
           "controlId": "3.5.3;3.5.8;3.5.9;3.7.5"
         },
         "nist-800-53": {
-          "controlId": "IA-2(1);IA-2(2);IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)",
+          "controlId": "IA-2(1);IA-2(2);IA-5;IA-2(8);IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts"
+          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts; Authenticator Management; Access to Accounts — Replay Resistant"
         },
         "pci-dss": {
           "controlId": "8.2.3;8.2.4;8.3;8.3.1;8.3.10.1;8.3.11;8.3.3;8.3.5;8.3.7;8.3.9;8.4;8.4.1;8.4.2;8.4.3;8.5.1;8.6.3"
@@ -2565,12 +2535,7 @@
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
         },
         "fedramp": {
-          "controlId": "IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -2588,14 +2553,14 @@
           "controlId": "3.5.3;3.5.8;3.5.9;3.7.5"
         },
         "nist-800-53": {
-          "controlId": "IA-2(1);IA-2(2);IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)",
+          "controlId": "IA-2(1);IA-2(2);IA-5;IA-2(8);IA-2(13);IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts"
+          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts; Authenticator Management; Access to Accounts — Replay Resistant; Out-of-band Authentication"
         },
         "pci-dss": {
           "controlId": "8.2.3;8.2.4;8.3;8.3.1;8.3.10.1;8.3.11;8.3.3;8.3.5;8.3.7;8.3.9;8.4;8.4.1;8.4.2;8.4.3;8.5.1;8.6.3"
@@ -2755,12 +2720,7 @@
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
         },
         "fedramp": {
-          "controlId": "AC-02(05);AC-11;IA-02(01);IA-02(02);IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02(05);AC-11;IA-02(01);IA-02(02);IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -2778,8 +2738,8 @@
           "controlId": "3.1.10;3.5.3;3.5.8;3.5.9;3.7.5"
         },
         "nist-800-53": {
-          "controlId": "AC-11;IA-2(1);AC-02(05);IA-02(01);IA-02(02);IA-05;IA-05(01)",
-          "title": "Device Lock; Multi-factor Authentication to Privileged Accounts",
+          "controlId": "AC-20;IA-3;IA-2(1);IA-2(2);AC-02(05);AC-11;IA-02(01);IA-02(02);IA-05;IA-05(01)",
+          "title": "Use of External Systems; Device Identification and Authentication; Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts; Device Lock",
           "profiles": [
             "Low",
             "Moderate",
@@ -2942,12 +2902,7 @@
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
         },
         "fedramp": {
-          "controlId": "IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -3126,12 +3081,7 @@
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
         },
         "fedramp": {
-          "controlId": "IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-02(01);IA-02(02);IA-02(06);IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -4201,11 +4151,12 @@
           "controlId": "3.1.1;3.1.2;3.1.3"
         },
         "nist-800-53": {
-          "controlId": "AC-02(07);AC-06(07)",
+          "controlId": "AC-5;AC-02(07);AC-06(07)",
           "profiles": [
             "Moderate",
             "High"
-          ]
+          ],
+          "title": "Separation of Duties"
         },
         "nist-csf": {
           "controlId": "PR.AA-05",
@@ -4370,12 +4321,7 @@
           "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -4576,12 +4522,7 @@
           "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -4779,12 +4720,7 @@
           "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -4982,12 +4918,7 @@
           "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -5002,14 +4933,13 @@
           "controlId": "3.5.7;3.5.8;3.5.9"
         },
         "nist-800-53": {
-          "controlId": "IA-5(1);IA-05;IA-05(01)",
+          "controlId": "IA-05;IA-05(01)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
-          ],
-          "title": "Password-based Authentication"
+          ]
         },
         "pci-dss": {
           "controlId": "8.2.4;8.3;8.3.1;8.3.10.1;8.3.11;8.3.3;8.3.5;8.3.6;8.3.7;8.3.9;8.6.3"
@@ -5296,12 +5226,7 @@
           "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18"
@@ -5316,14 +5241,14 @@
           "controlId": "3.5.8;3.5.9"
         },
         "nist-800-53": {
-          "controlId": "IA-5;IA-05;IA-05(01);IA-05(05)",
+          "controlId": "AC-2(1);AC-3;IA-05;IA-05(01);IA-05(05)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Authenticator Management"
+          "title": "Automated System Account Management; Access Enforcement"
         },
         "pci-dss": {
           "controlId": "2.2.2;2.3.1;6.5.2;8.2.4;8.3;8.3.1;8.3.10.1;8.3.11;8.3.3;8.3.5;8.3.7;8.3.9;8.6.3"
@@ -5753,12 +5678,7 @@
       },
       "frameworks": {
         "fedramp": {
-          "controlId": "IA-11",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "IA-11"
         },
         "mitre-attack": {
           "controlId": "T1110;T1110.001;T1110.002;T1110.003;T1110.004;T1556.006;T1556.007"
@@ -6348,12 +6268,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii)"
@@ -6371,8 +6286,8 @@
           "controlId": "3.1.1;3.1.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2;AC-3;AC-02;AC-03;AC-05;AC-06;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Access Enforcement; Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -6733,12 +6648,7 @@
           "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-08;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-08;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii)"
@@ -6756,8 +6666,8 @@
           "controlId": "3.1.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2;SI-8;AC-02;AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-08;SI-10",
-          "title": "Account Management; Spam Protection; Information Input Validation",
+          "controlId": "SC-8;SC-7;AC-02;AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-08;SI-10",
+          "title": "Transmission Confidentiality and Integrity; Boundary Protection; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -7125,12 +7035,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.308(a)(3)(ii)(C);164.312(a)(1);164.312(a)(2)(ii)"
@@ -7148,8 +7053,8 @@
           "controlId": "3.1.1;3.1.2;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-2;AC-6;AC-02;AC-03;AC-05;AC-06;IA-12(04);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Least Privilege; Information Input Validation",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-02;AC-03;AC-05;AC-06;IA-12(04);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -7513,12 +7418,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(01);IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(01);IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.308(a)(3)(ii)(C);164.312(a)(1);164.312(a)(2)(ii)"
@@ -7536,8 +7436,8 @@
           "controlId": "3.1.2;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-2;AC-6(1);AC-02;AC-03;AC-05;AC-06;AC-06(01);IA-12(04);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Authorize Access to Security Functions; Information Input Validation",
+          "controlId": "AC-2;AC-2(1);IA-4;IA-5;AC-1;AC-02;AC-03;AC-05;AC-06;AC-06(01);IA-12(04);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Automated System Account Management; Identifier Management; Authenticator Management; Policy and Procedures; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -7924,8 +7824,8 @@
           "controlId": "3.1.2;3.5.6"
         },
         "nist-800-53": {
-          "controlId": "AC-02;AC-02(03);AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Information Input Validation",
+          "controlId": "AC-2;AC-02;AC-02(03);AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -9127,11 +9027,7 @@
           "controlId": "ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-02(01);AC-02(03)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-02(01);AC-02(03)"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(ii)"
@@ -9149,14 +9045,14 @@
           "controlId": "3.1.1;3.1.2;3.5.1;3.5.2;3.5.6"
         },
         "nist-800-53": {
-          "controlId": "AC-2(1);AC-2(3);AC-02;AC-02(01);AC-02(03)",
+          "controlId": "AC-6(5);AC-2;AC-2(3);AC-02;AC-02(01);AC-02(03)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Automated System Account Management; Disable Accounts"
+          "title": "Privileged Accounts; Account Management; Disable Accounts"
         },
         "pci-dss": {
           "controlId": "8.2.4;8.2.6;8.3.10;8.6;8.6.1"
@@ -9291,11 +9187,7 @@
           "controlId": "ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-02(01);AC-02(03)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-02(01);AC-02(03)"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(ii)"
@@ -9313,14 +9205,14 @@
           "controlId": "3.1.1;3.1.2;3.5.1;3.5.2;3.5.6"
         },
         "nist-800-53": {
-          "controlId": "AC-2(1);AC-2(3);AC-02;AC-02(01);AC-02(03)",
+          "controlId": "AC-6(5);AC-2;AC-2(3);AC-02;AC-02(01);AC-02(03)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Automated System Account Management; Disable Accounts"
+          "title": "Privileged Accounts; Account Management; Disable Accounts"
         },
         "pci-dss": {
           "controlId": "8.2.4;8.2.6;8.3.10;8.6;8.6.1"
@@ -9473,12 +9365,7 @@
           "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-02(02);AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-02(02);AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii)"
@@ -9496,8 +9383,8 @@
           "controlId": "3.1.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2;AC-2(2);AC-02;AC-02(02);AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Automated Temporary and Emergency Account Management; Information Input Validation",
+          "controlId": "AC-2;AC-02;AC-02(02);AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -9664,11 +9551,7 @@
           "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-02(02);CP-01;CP-02;CP-10;IR-04(03);PM-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-02(02);CP-01;CP-02;CP-10;IR-04(03);PM-08"
         },
         "gdpr": {
           "controlId": "Article 32.1(c)"
@@ -9692,8 +9575,8 @@
           "controlId": "3.1.2"
         },
         "nist-800-53": {
-          "controlId": "AC-6;AC-6(5);AC-02;AC-02(02);CP-01;CP-02;CP-10;IR-04(03);PM-08",
-          "title": "Least Privilege; Privileged Accounts; System Recovery and Reconstitution",
+          "controlId": "CM-7;AC-6(2);AC-6(5);AC-02;AC-02(02);CP-01;CP-02;CP-10;IR-04(03);PM-08",
+          "title": "Least Functionality; Non-privileged Access for Nonsecurity Functions; Privileged Accounts; System Recovery and Reconstitution",
           "profiles": [
             "Low",
             "Moderate",
@@ -10865,12 +10748,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18"
@@ -10885,8 +10763,8 @@
           "controlId": "3.1.1"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Information Input Validation",
+          "controlId": "AC-6(10);IA-4;IA-5;AC-1;AC-2;AC-2(1);AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Identifier Management; Authenticator Management; Policy and Procedures; Account Management; Automated System Account Management; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -11276,12 +11154,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18"
@@ -11296,8 +11169,8 @@
           "controlId": "3.1.1"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -11684,12 +11557,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18"
@@ -11704,8 +11572,8 @@
           "controlId": "3.1.1"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Information Input Validation",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -12262,12 +12130,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -12285,8 +12148,8 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-6;AC-02;AC-03;AC-05;AC-06;SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Least Privilege; Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -12468,12 +12331,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -12491,8 +12349,8 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-6;AC-02;AC-03;AC-05;AC-06;SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Least Privilege; Information Input Validation",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-02;AC-03;AC-05;AC-06;SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -12675,12 +12533,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -12698,8 +12551,8 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "CM-6;IA-2(1);IA-2(2);AC-02;AC-03;AC-05;AC-06;SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Configuration Settings; Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts; Information Input Validation",
+          "controlId": "IA-2(1);IA-2(2);IA-5;IA-2(8);AC-02;AC-03;AC-05;AC-06;SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts; Authenticator Management; Access to Accounts — Replay Resistant; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -12879,12 +12732,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -12902,8 +12750,8 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-6;AC-02;AC-03;AC-05;AC-06;SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Least Privilege; Information Input Validation",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-02;AC-03;AC-05;AC-06;SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -13067,11 +12915,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -13089,14 +12933,14 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-6;AC-03;AC-06;SA-08(14)",
+          "controlId": "AC-6;IA-4;IA-5;AC-1;AC-2;AC-2(1);AC-03;AC-06;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege"
+          "title": "Least Privilege; Identifier Management; Authenticator Management; Policy and Procedures; Account Management; Automated System Account Management"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -13260,11 +13104,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -13282,14 +13122,14 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-6;AC-03;AC-06;SA-08(14)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-03;AC-06;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -13447,11 +13287,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -13469,14 +13305,13 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-6;AC-03;AC-06;SA-08(14)",
+          "controlId": "AC-03;AC-06;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
-          ],
-          "title": "Least Privilege"
+          ]
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -13635,11 +13470,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(01)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(01)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -13657,13 +13488,13 @@
           "controlId": "3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-6(1);AC-06;AC-06(01);SA-08(14)",
+          "controlId": "AC-6(9);IA-4;IA-5;AC-1;AC-2;AC-2(1);AC-06;AC-06(01);SA-08(14)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Authorize Access to Security Functions"
+          "title": "Log Use of Privileged Functions; Identifier Management; Authenticator Management; Policy and Procedures; Account Management; Automated System Account Management"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -13824,11 +13655,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(01)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(01)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -13846,13 +13673,13 @@
           "controlId": "3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-6(1);AC-06;AC-06(01);SA-08(14)",
+          "controlId": "AC-6(9);IA-4;IA-5;AC-1;AC-2;AC-2(1);AC-06;AC-06(01);SA-08(14)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Authorize Access to Security Functions"
+          "title": "Log Use of Privileged Functions; Identifier Management; Authenticator Management; Policy and Procedures; Account Management; Automated System Account Management"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -15623,12 +15450,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(05);IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(05);IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.308(a)(3)(ii)(C);164.312(a)(1);164.312(a)(2)(ii)"
@@ -15646,8 +15468,8 @@
           "controlId": "3.1.2;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-2;AC-6(5);AC-02;AC-03;AC-05;AC-06;AC-06(05);IA-12(04);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Privileged Accounts; Information Input Validation",
+          "controlId": "AC-2;AC-6(2);AC-6(5);AC-02;AC-03;AC-05;AC-06;AC-06(05);IA-12(04);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Non-privileged Access for Nonsecurity Functions; Privileged Accounts; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -15813,12 +15635,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(05);IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(05);IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.308(a)(3)(ii)(C);164.312(a)(1);164.312(a)(2)(ii)"
@@ -15836,8 +15653,8 @@
           "controlId": "3.1.2;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-2;AC-6(5);AC-02;AC-03;AC-05;AC-06;AC-06(05);IA-12(04);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Account Management; Privileged Accounts; Information Input Validation",
+          "controlId": "AC-2;AC-6(2);AC-6(5);AC-02;AC-03;AC-05;AC-06;AC-06(05);IA-12(04);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Non-privileged Access for Nonsecurity Functions; Privileged Accounts; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -15971,11 +15788,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(05)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -15993,13 +15806,13 @@
           "controlId": "3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-6(5);AC-06;AC-06(05);SA-08(14)",
+          "controlId": "AC-6(5);AC-2;AC-06;AC-06(05);SA-08(14)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Privileged Accounts"
+          "title": "Privileged Accounts; Account Management"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -16140,11 +15953,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06;AC-06(05)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06;AC-06(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -16162,14 +15971,14 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-6;AC-6(5);AC-03;AC-06;AC-06(05);SA-08(14)",
+          "controlId": "AC-6(2);AC-6(5);AC-03;AC-06;AC-06(05);SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege; Privileged Accounts"
+          "title": "Non-privileged Access for Nonsecurity Functions; Privileged Accounts"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -16322,12 +16131,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(05);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(05);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -16345,8 +16149,8 @@
           "controlId": "3.1.1;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-6(5);AC-02;AC-03;AC-05;AC-06;AC-06(05);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Privileged Accounts; Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(05);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -16488,12 +16292,7 @@
           "controlId": "ML1-P4;ML1-P6;ML1-P7;ML2-P4;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(05);CM-02;CM-06;PL-10;SA-08;SA-15(05)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(05);CM-02;CM-06;PL-10;SA-08;SA-15(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1);164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -16514,8 +16313,8 @@
           "controlId": "3.1.5;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "AC-6(5);CM-6;AC-06;AC-06(05);CM-02;CM-06;PL-10;SA-08;SA-08(14);SA-15(05)",
-          "title": "Privileged Accounts; Configuration Settings; Baseline Selection",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-06;AC-06(05);CM-02;CM-06;PL-10;SA-08;SA-08(14);SA-15(05)",
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -16657,12 +16456,7 @@
           "controlId": "ML1-P4;ML1-P6;ML1-P7;ML2-P4;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(05);CM-02;CM-06;PL-10;SA-08;SA-15(05)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(05);CM-02;CM-06;PL-10;SA-08;SA-15(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1);164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -16683,8 +16477,8 @@
           "controlId": "3.1.5;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "AC-6(5);CM-6;AC-06;AC-06(05);CM-02;CM-06;PL-10;SA-08;SA-08(14);SA-15(05)",
-          "title": "Privileged Accounts; Configuration Settings; Baseline Selection",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-06;AC-06(05);CM-02;CM-06;PL-10;SA-08;SA-08(14);SA-15(05)",
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -16825,11 +16619,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-04;AC-06;AC-06(05)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-04;AC-06;AC-06(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -16847,13 +16637,13 @@
           "controlId": "3.1.3;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-4;AC-6(5);AC-04;AC-06;AC-06(05);SA-08(14)",
+          "controlId": "CM-6;CM-7;AC-04;AC-06;AC-06(05);SA-08(14)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Information Flow Enforcement; Privileged Accounts"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -16987,11 +16777,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-04;AC-06;AC-06(05)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-04;AC-06;AC-06(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -17009,13 +16795,13 @@
           "controlId": "3.1.3;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-4;AC-6(5);AC-04;AC-06;AC-06(05);SA-08(14)",
+          "controlId": "CM-6;CM-7;AC-04;AC-06;AC-06(05);SA-08(14)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Information Flow Enforcement; Privileged Accounts"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -17145,11 +16931,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-04;AC-06;AC-06(05)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-04;AC-06;AC-06(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -17167,13 +16949,13 @@
           "controlId": "3.1.3;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-4;AC-6(5);AC-04;AC-06;AC-06(05);SA-08(14)",
+          "controlId": "CM-6;CM-7;AC-04;AC-06;AC-06(05);SA-08(14)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Information Flow Enforcement; Privileged Accounts"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -17303,11 +17085,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-04;AC-06;AC-06(05)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-04;AC-06;AC-06(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -17325,13 +17103,13 @@
           "controlId": "3.1.3;3.1.5"
         },
         "nist-800-53": {
-          "controlId": "AC-4;AC-6(5);AC-04;AC-06;AC-06(05);SA-08(14)",
+          "controlId": "CM-6;CM-7;AC-04;AC-06;AC-06(05);SA-08(14)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Information Flow Enforcement; Privileged Accounts"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -18604,11 +18382,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(10)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(10)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -18626,13 +18400,13 @@
           "controlId": "3.1.5;3.1.7"
         },
         "nist-800-53": {
-          "controlId": "AC-6(10);AC-06;AC-06(10);SA-08(14)",
+          "controlId": "AC-3;IA-4;IA-5;AC-1;AC-2;AC-2(1);AC-06;AC-06(10);SA-08(14)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Prohibit Non-privileged Users from Executing Privileged Functions"
+          "title": "Access Enforcement; Identifier Management; Authenticator Management; Policy and Procedures; Account Management; Automated System Account Management"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10",
@@ -18796,12 +18570,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(10);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(10);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -18819,8 +18588,8 @@
           "controlId": "3.1.1;3.1.5;3.1.7"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-6(10);AC-02;AC-03;AC-05;AC-06;AC-06(10);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Prohibit Non-privileged Users from Executing Privileged Functions; Information Input Validation",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-02;AC-03;AC-05;AC-06;AC-06(10);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -18987,12 +18756,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(10);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(10);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -19010,8 +18774,8 @@
           "controlId": "3.1.1;3.1.5;3.1.7"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-6(10);AC-02;AC-03;AC-05;AC-06;AC-06(10);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Prohibit Non-privileged Users from Executing Privileged Functions; Information Input Validation",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-02;AC-03;AC-05;AC-06;AC-06(10);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -19178,12 +18942,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(10);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-06(10);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -19201,8 +18960,8 @@
           "controlId": "3.1.1;3.1.5;3.1.7"
         },
         "nist-800-53": {
-          "controlId": "AC-3;AC-6(10);AC-02;AC-03;AC-05;AC-06;AC-06(10);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Prohibit Non-privileged Users from Executing Privileged Functions; Information Input Validation",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-02;AC-03;AC-05;AC-06;AC-06(10);SA-08(14);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -19370,13 +19129,14 @@
           "controlId": "3.1.5;3.1.7;3.4.6;3.4.8"
         },
         "nist-800-53": {
-          "controlId": "AC-06;AC-06(10);CM-07;CM-07(04);CM-07(05);SA-08(14);SC-18(04)",
+          "controlId": "IA-5(1);AC-06;AC-06(10);CM-07;CM-07(04);CM-07(05);SA-08(14);SC-18(04)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
-          ]
+          ],
+          "title": "Password-based Authentication"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
@@ -19886,11 +19646,7 @@
           "controlId": "ACL2.-3.1.10;ACL2.-3.1.11"
         },
         "fedramp": {
-          "controlId": "AC-02(05);AC-11;AC-12",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02(05);AC-11;AC-12"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii)"
@@ -19902,8 +19658,8 @@
           "controlId": "3.1.10;3.1.11"
         },
         "nist-800-53": {
-          "controlId": "AC-11;AC-12;AC-02(05)",
-          "title": "Device Lock; Session Termination",
+          "controlId": "AC-2(5);AC-11;AC-11(1);AC-12;AC-02(05)",
+          "title": "Inactivity Logout; Device Lock; Pattern-hiding Displays; Session Termination",
           "profiles": [
             "Moderate",
             "High"
@@ -20062,11 +19818,7 @@
           "controlId": "ACL2.-3.1.10;ACL2.-3.1.11"
         },
         "fedramp": {
-          "controlId": "AC-02(05);AC-11;AC-12",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02(05);AC-11;AC-12"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii)"
@@ -20078,8 +19830,8 @@
           "controlId": "3.1.10;3.1.11"
         },
         "nist-800-53": {
-          "controlId": "AC-11;AC-12;AC-02(05)",
-          "title": "Device Lock; Session Termination",
+          "controlId": "AC-2(5);AC-11;AC-11(1);AC-12;AC-02(05)",
+          "title": "Inactivity Logout; Device Lock; Pattern-hiding Displays; Session Termination",
           "profiles": [
             "Moderate",
             "High"
@@ -20237,11 +19989,7 @@
           "controlId": "ACL2.-3.1.10;ACL2.-3.1.11"
         },
         "fedramp": {
-          "controlId": "AC-02(05);AC-11;AC-12",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02(05);AC-11;AC-12"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii)"
@@ -20253,8 +20001,8 @@
           "controlId": "3.1.10;3.1.11"
         },
         "nist-800-53": {
-          "controlId": "AC-11;AC-12;AC-02(05)",
-          "title": "Device Lock; Session Termination",
+          "controlId": "AC-6(1);AC-2(5);AC-11;AC-11(1);AC-12;AC-02(05)",
+          "title": "Authorize Access to Security Functions; Inactivity Logout; Device Lock; Pattern-hiding Displays; Session Termination",
           "profiles": [
             "Moderate",
             "High"
@@ -20428,11 +20176,7 @@
           "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii);164.312(b);164.312(c)(2)"
@@ -20450,14 +20194,14 @@
           "controlId": "3.1.2;3.14.7;3.9.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2(12);AC-2(13);AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
+          "controlId": "AC-2(12);AC-2(13);SI-4;SI-4(4);AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Account Monitoring for Atypical Usage; Disable Accounts for High-risk Individuals"
+          "title": "Account Monitoring for Atypical Usage; Disable Accounts for High-risk Individuals; System Monitoring; Inbound and Outbound Communications Traffic"
         },
         "nist-csf": {
           "controlId": "DE.CM;DE.CM-03",
@@ -20629,11 +20373,7 @@
           "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii);164.312(b);164.312(c)(2)"
@@ -20651,14 +20391,14 @@
           "controlId": "3.1.2;3.14.7;3.9.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2(12);AC-2(13);AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
+          "controlId": "AC-2(12);AC-2(13);SI-4;SI-4(4);AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Account Monitoring for Atypical Usage; Disable Accounts for High-risk Individuals"
+          "title": "Account Monitoring for Atypical Usage; Disable Accounts for High-risk Individuals; System Monitoring; Inbound and Outbound Communications Traffic"
         },
         "nist-csf": {
           "controlId": "DE.CM;DE.CM-03",
@@ -20830,11 +20570,7 @@
           "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(ii)(C);164.312(a)(2)(ii);164.312(b);164.312(c)(2)"
@@ -20852,14 +20588,14 @@
           "controlId": "3.1.2;3.14.7;3.9.2"
         },
         "nist-800-53": {
-          "controlId": "AC-2(12);AC-2(13);AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
+          "controlId": "AC-2(12);AC-2(13);SI-4;SI-4(4);AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Account Monitoring for Atypical Usage; Disable Accounts for High-risk Individuals"
+          "title": "Account Monitoring for Atypical Usage; Disable Accounts for High-risk Individuals; System Monitoring; Inbound and Outbound Communications Traffic"
         },
         "nist-csf": {
           "controlId": "DE.CM;DE.CM-03",
@@ -21224,12 +20960,7 @@
           "controlId": "ATL2.-3.2.1"
         },
         "fedramp": {
-          "controlId": "AT-02",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AT-02"
         },
         "hipaa": {
           "controlId": "164.308(a)(5)(i);164.530(b)(2)(i);164.530(b)(2)(i)(A);164.530(b)(2)(i)(B);164.530(b)(2)(i)(C);164.530(b)(2)(ii)"
@@ -21241,14 +20972,13 @@
           "controlId": "3.2.1"
         },
         "nist-800-53": {
-          "controlId": "AT-2;AT-02",
+          "controlId": "AT-02",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
-          ],
-          "title": "Literacy Training and Awareness"
+          ]
         },
         "nist-csf": {
           "controlId": "PR.AT;PR.AT-01",
@@ -21412,12 +21142,7 @@
           "controlId": "ML1-P1;ML1-P2;ML1-P6;ML1-P7;ML2-P1;ML2-P2;ML2-P5;ML2-P6;ML2-P7;ML3-P1;ML3-P2;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;CM-08;PL-10;PM-05;SA-08;SA-15(05)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;CM-08;PL-10;PM-05;SA-08;SA-15(05)"
         },
         "hipaa": {
           "controlId": "164.310(d)(2)(iii);164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -21438,8 +21163,8 @@
           "controlId": "3.3.3;3.4.1;3.4.2;NFO - CM-8(5)"
         },
         "nist-800-53": {
-          "controlId": "CM-6;CM-8;CM-02;CM-06;CM-08;PL-10;PM-05;SA-08;SA-15(05)",
-          "title": "Configuration Settings; System Component Inventory; Baseline Selection",
+          "controlId": "CM-02;CM-06;CM-08;PL-10;PM-05;SA-08;SA-15(05)",
+          "title": "Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -23186,12 +22911,7 @@
           "controlId": "AC.L1-B.1.III;AC.L1-B.1.III[a];AC.L1-B.1.III[b];AC.L1-B.1.III[c];AC.L1-B.1.III[d];AC.L1-B.1.III[e];AC.L1-B.1.III[f];ACL2.-3.1.20;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2"
         },
         "fedramp": {
-          "controlId": "AC-20;IA-03;IA-03(04)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-20;IA-03;IA-03(04)"
         },
         "iso-27001": {
           "controlId": "5.16"
@@ -23203,8 +22923,8 @@
           "controlId": "3.1.20;3.5.1;3.5.2"
         },
         "nist-800-53": {
-          "controlId": "AC-20;IA-3;IA-03;IA-03(01);IA-03(04)",
-          "title": "Use of External Systems; Device Identification and Authentication",
+          "controlId": "IA-2(1);IA-5;IA-2(8);IA-2(2);AC-20;IA-03;IA-03(01);IA-03(04)",
+          "title": "Multi-factor Authentication to Privileged Accounts; Authenticator Management; Access to Accounts — Replay Resistant; Multi-factor Authentication to Non-privileged Accounts; Use of External Systems",
           "profiles": [
             "Low",
             "Moderate",
@@ -23418,12 +23138,7 @@
           "controlId": "AC.L1-B.1.III;AC.L1-B.1.III[a];AC.L1-B.1.III[b];AC.L1-B.1.III[c];AC.L1-B.1.III[d];AC.L1-B.1.III[e];AC.L1-B.1.III[f];ACL2.-3.1.20;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2"
         },
         "fedramp": {
-          "controlId": "AC-20;IA-03;IA-03(04)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-20;IA-03;IA-03(04)"
         },
         "iso-27001": {
           "controlId": "5.16"
@@ -23435,8 +23150,8 @@
           "controlId": "3.1.20;3.5.1;3.5.2"
         },
         "nist-800-53": {
-          "controlId": "AC-20;IA-3;IA-03;IA-03(01);IA-03(04)",
-          "title": "Use of External Systems; Device Identification and Authentication",
+          "controlId": "AC-20;IA-3;IA-2(1);IA-2(2);IA-03;IA-03(01);IA-03(04)",
+          "title": "Use of External Systems; Device Identification and Authentication; Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts",
           "profiles": [
             "Low",
             "Moderate",
@@ -23750,12 +23465,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-21;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-21;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.506(c)(1);164.506(c)(2);164.506(c)(3);164.506(c)(4);164.508(a)(1);164.508(a)(4)(i)"
@@ -23773,8 +23483,8 @@
           "controlId": "3.1.1"
         },
         "nist-800-53": {
-          "controlId": "AC-21;AC-3;AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Information Sharing; Access Enforcement; Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-21;SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Information Sharing; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -23935,12 +23645,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-21;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-21;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "hipaa": {
           "controlId": "164.506(c)(1);164.506(c)(2);164.506(c)(3);164.506(c)(4);164.508(a)(1);164.508(a)(4)(i)"
@@ -23958,8 +23663,8 @@
           "controlId": "3.1.1"
         },
         "nist-800-53": {
-          "controlId": "AC-21;AC-3;AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Information Sharing; Access Enforcement; Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;AC-06;AC-21;SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Information Sharing; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -25452,12 +25157,7 @@
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-08"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -25478,8 +25178,8 @@
           "controlId": "3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "CM-6;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-08",
-          "title": "Configuration Settings; Spam Protection; Baseline Selection",
+          "controlId": "SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-08",
+          "title": "Malicious Code Protection; Spam Protection; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -25664,12 +25364,7 @@
           "controlId": "ML1-P3;ML1-P6;ML1-P7;ML2-P3;ML2-P5;ML2-P6;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;IA-02(01);IA-02(02);IA-05;IA-05(01);PL-10;SA-08;SA-15(05)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;IA-02(01);IA-02(02);IA-05;IA-05(01);PL-10;SA-08;SA-15(05)"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -25690,8 +25385,8 @@
           "controlId": "3.3.3;3.4.1;3.4.2;3.5.3;3.5.8;3.5.9;3.7.5"
         },
         "nist-800-53": {
-          "controlId": "CM-6;IA-2(1);IA-2(2);CM-02;CM-06;IA-02(01);IA-02(02);IA-05;IA-05(01);PL-10;SA-08;SA-15(05)",
-          "title": "Configuration Settings; Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts; Baseline Selection",
+          "controlId": "IA-2(1);IA-2(2);CM-02;CM-06;IA-02(01);IA-02(02);IA-05;IA-05(01);PL-10;SA-08;SA-15(05)",
+          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -25858,12 +25553,7 @@
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;IA-05;IA-05(01);PL-10;SA-08;SA-15(05)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;IA-05;IA-05(01);PL-10;SA-08;SA-15(05)"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -25884,8 +25574,8 @@
           "controlId": "3.3.3;3.4.1;3.4.2;3.5.8;3.5.9"
         },
         "nist-800-53": {
-          "controlId": "CM-6;IA-5;CM-02;CM-06;IA-05;IA-05(01);IA-05(05);PL-10;SA-08;SA-15(05)",
-          "title": "Configuration Settings; Authenticator Management; Baseline Selection",
+          "controlId": "IA-5(1);CM-02;CM-06;IA-05;IA-05(01);IA-05(05);PL-10;SA-08;SA-15(05)",
+          "title": "Password-based Authentication; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -26786,12 +26476,7 @@
           "controlId": "CML2.-3.4.6;CML2.-3.4.9"
         },
         "fedramp": {
-          "controlId": "CM-07;CM-11;CM-11(02)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;CM-11;CM-11(02)"
         },
         "iso-27001": {
           "controlId": "8.12;8.19;8.3;8.9"
@@ -26806,8 +26491,8 @@
           "controlId": "3.4.6;3.4.9"
         },
         "nist-800-53": {
-          "controlId": "CM-11;CM-7;CM-07;CM-11(02)",
-          "title": "User-installed Software; Least Functionality",
+          "controlId": "CM-6;CM-7;CM-07;CM-11;CM-11(02)",
+          "title": "Configuration Settings; Least Functionality; User-installed Software",
           "profiles": [
             "Low",
             "Moderate",
@@ -26996,12 +26681,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -27016,14 +26696,14 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -27220,12 +26900,7 @@
           "controlId": "ACL2.-3.1.18;CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "AC-19;CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-19;CM-07"
         },
         "iso-27001": {
           "controlId": "8.1;8.12;8.3;8.9"
@@ -27240,8 +26915,8 @@
           "controlId": "3.1.18;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-19;CM-7;CM-07",
-          "title": "Access Control for Mobile Devices; Least Functionality",
+          "controlId": "AC-19(5);SC-39;CM-6;CM-7;AC-19;CM-07",
+          "title": "Full Device or Container-based Encryption; Process Isolation; Configuration Settings; Least Functionality; Access Control for Mobile Devices",
           "profiles": [
             "Low",
             "Moderate",
@@ -27421,12 +27096,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -27441,13 +27111,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;CM-07",
+          "controlId": "CM-6;CM-7;CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
           ],
-          "title": "Least Functionality"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -27644,12 +27314,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;CML2.-3.4.6;IA.L1-B.1.V[b]"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;CM-07;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;CM-07;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18;8.12;8.3;8.9"
@@ -27664,8 +27329,8 @@
           "controlId": "3.1.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-3;CM-7;AC-02;AC-03;AC-05;AC-06;CM-07;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Least Functionality; Information Input Validation",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-02;AC-03;AC-05;AC-06;CM-07;SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -27847,12 +27512,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -27867,13 +27527,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;CM-07",
+          "controlId": "CM-7;CM-6;CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
           ],
-          "title": "Least Functionality"
+          "title": "Least Functionality; Configuration Settings"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -28053,12 +27713,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -28073,13 +27728,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;CM-07",
+          "controlId": "CM-7;CM-6;CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
           ],
-          "title": "Least Functionality"
+          "title": "Least Functionality; Configuration Settings"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -28255,12 +27910,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -28275,13 +27925,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;CM-07",
+          "controlId": "CM-6;CM-7;CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
           ],
-          "title": "Least Functionality"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -28461,12 +28111,7 @@
           "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "CM-07;IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18;8.12;8.3;8.9"
@@ -28481,14 +28126,14 @@
           "controlId": "3.4.6;3.5.8;3.5.9"
         },
         "nist-800-53": {
-          "controlId": "CM-7;IA-5;CM-07;IA-05;IA-05(01);IA-05(05)",
+          "controlId": "CM-7;IA-2(1);IA-2(2);CM-07;IA-05;IA-05(01);IA-05(05)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Authenticator Management"
+          "title": "Least Functionality; Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -28672,12 +28317,7 @@
           "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "CM-07;IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18;8.12;8.3;8.9"
@@ -28692,14 +28332,14 @@
           "controlId": "3.4.6;3.5.8;3.5.9"
         },
         "nist-800-53": {
-          "controlId": "CM-7;IA-5;CM-07;IA-05;IA-05(01);IA-05(05)",
+          "controlId": "IA-2(1);IA-2(2);CM-07;IA-05;IA-05(01);IA-05(05)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Authenticator Management"
+          "title": "Multi-factor Authentication to Privileged Accounts; Multi-factor Authentication to Non-privileged Accounts"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -28881,12 +28521,7 @@
           "controlId": "CML2.-3.4.6;CML2.-3.4.9"
         },
         "fedramp": {
-          "controlId": "CM-07;CM-11;CM-11(02)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;CM-11;CM-11(02)"
         },
         "iso-27001": {
           "controlId": "8.12;8.19;8.3;8.9"
@@ -28901,8 +28536,8 @@
           "controlId": "3.4.6;3.4.9"
         },
         "nist-800-53": {
-          "controlId": "CM-11;CM-7;CM-07;CM-11(02)",
-          "title": "User-installed Software; Least Functionality",
+          "controlId": "CM-10;CM-11;SC-18;CM-07;CM-11(02)",
+          "title": "Software Usage Restrictions; User-installed Software; Mobile Code",
           "profiles": [
             "Low",
             "Moderate",
@@ -29083,12 +28718,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -29103,13 +28733,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;CM-07",
+          "controlId": "AC-17(2);IA-5;IA-5(1);SC-8;SC-8(1);CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
           ],
-          "title": "Least Functionality"
+          "title": "Protection of Confidentiality and Integrity Using Encryption; Authenticator Management; Password-based Authentication; Transmission Confidentiality and Integrity; Cryptographic Protection"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -29292,12 +28922,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -29312,14 +28937,14 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -29495,12 +29120,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -29515,13 +29135,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;CM-07",
+          "controlId": "CM-7;AC-18;SC-23;CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
           ],
-          "title": "Least Functionality"
+          "title": "Least Functionality; Wireless Access; Session Authenticity"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -29719,12 +29339,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07;IA-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;IA-08"
         },
         "iso-27001": {
           "controlId": "5.16;8.12;8.3;8.9"
@@ -29739,13 +29354,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;IA-8;CM-07;IA-08",
+          "controlId": "AC-17(2);IA-5;IA-5(1);SC-8;SC-8(1);CM-07;IA-08",
           "profiles": [
             "Low",
             "Moderate",
             "High"
           ],
-          "title": "Least Functionality; Identification and Authentication (Non-organizational Users)"
+          "title": "Protection of Confidentiality and Integrity Using Encryption; Authenticator Management; Password-based Authentication; Transmission Confidentiality and Integrity; Cryptographic Protection"
         },
         "nist-csf": {
           "controlId": "PR.AA-01;PR.AA-03;PR.AA-05;PR.PS-05",
@@ -29942,12 +29557,7 @@
           "controlId": "ACL2.-3.1.18;CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "AC-19;CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-19;CM-07"
         },
         "iso-27001": {
           "controlId": "8.1;8.12;8.3;8.9"
@@ -29962,8 +29572,8 @@
           "controlId": "3.1.18;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-19;CM-7;CM-07",
-          "title": "Access Control for Mobile Devices; Least Functionality",
+          "controlId": "AC-19;CM-07",
+          "title": "Access Control for Mobile Devices",
           "profiles": [
             "Low",
             "Moderate",
@@ -30547,12 +30157,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -30567,14 +30172,14 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -30758,12 +30363,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -30778,14 +30378,13 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
-          ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          ]
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -30965,12 +30564,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SI-08"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -30985,13 +30579,12 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SI-8;CM-07;SI-08",
+          "controlId": "CM-07;SI-08",
           "profiles": [
             "Low",
             "Moderate",
             "High"
-          ],
-          "title": "Least Functionality; Spam Protection"
+          ]
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -31166,12 +30759,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -31186,13 +30774,12 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;CM-07",
+          "controlId": "CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
-          ],
-          "title": "Least Functionality"
+          ]
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -31375,12 +30962,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -31395,14 +30977,14 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "PL-8;SA-8;CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          "title": "Security and Privacy Architectures; Security and Privacy Engineering Principles"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -31578,12 +31160,7 @@
           "controlId": "CML2.-3.4.6"
         },
         "fedramp": {
-          "controlId": "CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.9"
@@ -31598,13 +31175,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;CM-07",
+          "controlId": "PL-8;SA-8;CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
           ],
-          "title": "Least Functionality"
+          "title": "Security and Privacy Architectures; Security and Privacy Engineering Principles"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -31787,12 +31364,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06;CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06;CM-07"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -31810,14 +31382,14 @@
           "controlId": "3.1.1;3.1.5;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-6;CM-7;AC-03;AC-06;CM-07;SA-08(14)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-2;AC-6(1);AC-6(7);AU-9(4);AC-03;AC-06;CM-07;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege; Least Functionality"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Account Management; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
@@ -31996,12 +31568,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06;CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06;CM-07"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -32019,14 +31586,14 @@
           "controlId": "3.1.1;3.1.5;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-6;CM-7;AC-03;AC-06;CM-07;SA-08(14)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-2;AC-6(1);AC-6(7);AU-9(4);AC-03;AC-06;CM-07;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege; Least Functionality"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Account Management; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
@@ -32209,12 +31776,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06;CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06;CM-07"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -32232,14 +31794,14 @@
           "controlId": "3.1.1;3.1.5;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-6;CM-7;AC-03;AC-06;CM-07;SA-08(14)",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-03;AC-06;CM-07;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege; Least Functionality"
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
@@ -32418,12 +31980,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06;CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06;CM-07"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -32441,14 +31998,14 @@
           "controlId": "3.1.1;3.1.5;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-6;CM-7;AC-03;AC-06;CM-07;SA-08(14)",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-03;AC-06;CM-07;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege; Least Functionality"
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
@@ -32631,12 +32188,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06;CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06;CM-07"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -32654,14 +32206,14 @@
           "controlId": "3.1.1;3.1.5;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-6;CM-7;AC-03;AC-06;CM-07;SA-08(14)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-03;AC-06;CM-07;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege; Least Functionality"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
@@ -32844,12 +32396,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-03;AC-06;CM-07",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-03;AC-06;CM-07"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -32867,14 +32414,14 @@
           "controlId": "3.1.1;3.1.5;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "AC-6;CM-7;AC-03;AC-06;CM-07;SA-08(14)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-03;AC-06;CM-07;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Privilege; Least Functionality"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access"
         },
         "nist-csf": {
           "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
@@ -33053,12 +32600,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -33073,14 +32615,14 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "PL-8;SA-8;CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          "title": "Security and Privacy Architectures; Security and Privacy Engineering Principles"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -33259,12 +32801,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -33279,14 +32816,14 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "PL-8;SA-8;CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          "title": "Security and Privacy Architectures; Security and Privacy Engineering Principles"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -33498,12 +33035,7 @@
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
         },
         "fedramp": {
-          "controlId": "CM-07;SI-02;SI-02(04);SI-03",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SI-02;SI-02(04);SI-03"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.7;8.8;8.9"
@@ -33521,14 +33053,14 @@
           "controlId": "3.11.3;3.14.1;3.14.2;3.14.4;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SI-3;CM-07;SI-02;SI-02(04);SI-03",
+          "controlId": "CM-6;CM-7;CM-07;SI-02;SI-02(04);SI-03",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Malicious Code Protection"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "DE.CM-09;ID.RA-01;ID.RA-08;PR.PS-02;PR.PS-05",
@@ -33740,12 +33272,7 @@
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
         },
         "fedramp": {
-          "controlId": "CM-07;SI-02;SI-02(04);SI-03",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SI-02;SI-02(04);SI-03"
         },
         "iso-27001": {
           "controlId": "8.12;8.3;8.7;8.8;8.9"
@@ -33763,14 +33290,14 @@
           "controlId": "3.11.3;3.14.1;3.14.2;3.14.4;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SI-3;CM-07;SI-02;SI-02(04);SI-03",
+          "controlId": "CM-6;CM-7;CM-07;SI-02;SI-02(04);SI-03",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Malicious Code Protection"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "DE.CM-09;ID.RA-01;ID.RA-08;PR.PS-02;PR.PS-05",
@@ -33949,12 +33476,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -33969,14 +33491,14 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-2;AC-6(1);AC-6(7);AU-9(4);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Account Management; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -34155,12 +33677,7 @@
           "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21;8.3;8.9"
@@ -34175,14 +33692,14 @@
           "controlId": "3.13.1;3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-7;SC-7(10);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-2;AC-6(1);AC-6(7);AU-9(4);CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Prevent Exfiltration"
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Account Management; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -34362,12 +33879,7 @@
           "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "CM-07;IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18;8.12;8.3;8.9"
@@ -34382,14 +33894,14 @@
           "controlId": "3.4.6;3.5.8;3.5.9"
         },
         "nist-800-53": {
-          "controlId": "CM-7;IA-5;CM-07;IA-05;IA-05(01);IA-05(05)",
+          "controlId": "CM-6;CM-7;CM-07;IA-05;IA-05(01);IA-05(05)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Authenticator Management"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -34569,12 +34081,7 @@
           "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9"
         },
         "fedramp": {
-          "controlId": "CM-07;IA-05;IA-05(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-07;IA-05;IA-05(01)"
         },
         "iso-27001": {
           "controlId": "5.17;5.18;8.12;8.3;8.9"
@@ -34589,14 +34096,14 @@
           "controlId": "3.4.6;3.5.8;3.5.9"
         },
         "nist-800-53": {
-          "controlId": "CM-7;IA-5;CM-07;IA-05;IA-05(01);IA-05(05)",
+          "controlId": "CM-6;CM-7;CM-07;IA-05;IA-05(01);IA-05(05)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Least Functionality; Authenticator Management"
+          "title": "Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -34782,12 +34289,13 @@
           "controlId": "3.4.6"
         },
         "nist-800-53": {
-          "controlId": "CM-07",
+          "controlId": "CM-4;CM-07",
           "profiles": [
             "Low",
             "Moderate",
             "High"
-          ]
+          ],
+          "title": "Impact Analyses"
         },
         "nist-csf": {
           "controlId": "PR.PS-05",
@@ -36228,12 +35736,7 @@
           "controlId": "CML2.-3.4.9"
         },
         "fedramp": {
-          "controlId": "CM-11;CM-11(02)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-11;CM-11(02)"
         },
         "iso-27001": {
           "controlId": "8.19"
@@ -36248,8 +35751,8 @@
           "controlId": "3.4.9"
         },
         "nist-800-53": {
-          "controlId": "CM-11;CM-11(02)",
-          "title": "User-installed Software",
+          "controlId": "CM-7(5);CM-10;CM-11;CM-11(02)",
+          "title": "Authorized Software — Allow-by-exception; Software Usage Restrictions; User-installed Software",
           "profiles": [
             "Low",
             "Moderate",
@@ -36801,12 +36304,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(10);CM-04",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(10);CM-04"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -36824,14 +36322,14 @@
           "controlId": "3.1.5;3.1.7;3.4.4"
         },
         "nist-800-53": {
-          "controlId": "AC-6(10);CM-4;AC-06;AC-06(10);CM-04;SA-08(14)",
+          "controlId": "AC-6(10);CM-5;CM-7(5);CM-10;AC-06;AC-06(10);CM-04;SA-08(14)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Impact Analyses"
+          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Access Restrictions for Change; Authorized Software — Allow-by-exception; Software Usage Restrictions"
         },
         "nist-csf": {
           "controlId": "ID.RA-07;PR.AA-05;PR.DS-10",
@@ -37439,12 +36937,7 @@
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
         },
         "fedramp": {
-          "controlId": "AU-01;SI-02;SI-02(04);SI-03;SI-04;SI-04(05)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AU-01;SI-02;SI-02(04);SI-03;SI-04;SI-04(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(1)(i);164.308(a)(1)(ii)(D);164.312(b)"
@@ -37465,8 +36958,8 @@
           "controlId": "3.11.3;3.14.1;3.14.2;3.14.4;3.14.6;3.3.3;NFO - AU-1;NFO - SI-4(5)"
         },
         "nist-800-53": {
-          "controlId": "SI-3;SI-4(5);AU-01;PM-31;SI-02;SI-02(04);SI-03;SI-04;SI-04(05)",
-          "title": "Malicious Code Protection; System-generated Alerts; Continuous Monitoring Strategy",
+          "controlId": "IR-1;IR-8;AU-01;PM-31;SI-02;SI-02(04);SI-03;SI-04;SI-04(05)",
+          "title": "Policy and Procedures; Incident Response Plan; Continuous Monitoring Strategy",
           "profiles": [
             "Low",
             "Moderate",
@@ -37620,11 +37113,7 @@
           "controlId": "AUL2.-3.3.3;SIL2.-3.14.6"
         },
         "fedramp": {
-          "controlId": "AU-01;SI-04;SI-04(05);SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AU-01;SI-04;SI-04(05);SI-08"
         },
         "hipaa": {
           "controlId": "164.308(a)(1)(i);164.308(a)(1)(ii)(D);164.312(b)"
@@ -37642,8 +37131,8 @@
           "controlId": "3.14.6;3.3.3;NFO - AU-1;NFO - SI-4(5)"
         },
         "nist-800-53": {
-          "controlId": "SI-4(5);SI-8;AU-01;PM-31;SI-04;SI-04(05);SI-08",
-          "title": "System-generated Alerts; Spam Protection; Continuous Monitoring Strategy",
+          "controlId": "AC-2;SC-7;AU-01;PM-31;SI-04;SI-04(05);SI-08",
+          "title": "Account Management; Boundary Protection; Continuous Monitoring Strategy",
           "profiles": [
             "Low",
             "Moderate",
@@ -37793,11 +37282,7 @@
           "controlId": "AUL2.-3.3.3;SIL2.-3.14.6"
         },
         "fedramp": {
-          "controlId": "AU-01;SI-04;SI-04(05)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AU-01;SI-04;SI-04(05)"
         },
         "hipaa": {
           "controlId": "164.308(a)(1)(i);164.308(a)(1)(ii)(D);164.312(b)"
@@ -37815,8 +37300,8 @@
           "controlId": "3.14.6;3.3.3;NFO - AU-1;NFO - SI-4(5)"
         },
         "nist-800-53": {
-          "controlId": "SI-4(5);AU-01;PM-31;SI-04;SI-04(05)",
-          "title": "System-generated Alerts; Continuous Monitoring Strategy",
+          "controlId": "SI-3;SI-16;AU-01;PM-31;SI-04;SI-04(05)",
+          "title": "Malicious Code Protection; Memory Protection; Continuous Monitoring Strategy",
           "profiles": [
             "Low",
             "Moderate",
@@ -37965,11 +37450,7 @@
           "controlId": "AUL2.-3.3.3;AUL2.-3.3.4;SIL2.-3.14.6"
         },
         "fedramp": {
-          "controlId": "AU-01;AU-05;AU-05(02);SI-04;SI-04(05);SI-04(12)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AU-01;AU-05;AU-05(02);SI-04;SI-04(05);SI-04(12)"
         },
         "hipaa": {
           "controlId": "164.308(a)(1)(i);164.308(a)(1)(ii)(D);164.312(b)"
@@ -37987,8 +37468,8 @@
           "controlId": "3.14.6;3.3.3;3.3.4;NFO - AU-1;NFO - SI-4(5)"
         },
         "nist-800-53": {
-          "controlId": "SI-4(12);SI-4(5);AU-01;AU-05;AU-05(02);PM-31;SI-04;SI-04(05);SI-04(12)",
-          "title": "Automated Organization-generated Alerts; System-generated Alerts; Continuous Monitoring Strategy",
+          "controlId": "AU-01;AU-05;AU-05(02);PM-31;SI-04;SI-04(05);SI-04(12)",
+          "title": "Continuous Monitoring Strategy",
           "profiles": [
             "Low",
             "Moderate",
@@ -39144,12 +38625,7 @@
           "controlId": "AUL2.-3.3.6"
         },
         "fedramp": {
-          "controlId": "AU-07;AU-07(01);AU-12",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AU-07;AU-07(01);AU-12"
         },
         "iso-27001": {
           "controlId": "6.8;8.15"
@@ -39161,8 +38637,8 @@
           "controlId": "3.3.6"
         },
         "nist-800-53": {
-          "controlId": "AU-12;AU-07;AU-07(01)",
-          "title": "Audit Record Generation",
+          "controlId": "AU-2;AU-7;AU-12;AU-07;AU-07(01)",
+          "title": "Event Logging; Audit Record Reduction and Report Generation; Audit Record Generation",
           "profiles": [
             "Low",
             "Moderate",
@@ -39325,12 +38801,7 @@
           "controlId": "AUL2.-3.3.6"
         },
         "fedramp": {
-          "controlId": "AU-07;AU-07(01);AU-12",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AU-07;AU-07(01);AU-12"
         },
         "iso-27001": {
           "controlId": "6.8;8.15"
@@ -39342,8 +38813,8 @@
           "controlId": "3.3.6"
         },
         "nist-800-53": {
-          "controlId": "AU-12;AU-07;AU-07(01)",
-          "title": "Audit Record Generation",
+          "controlId": "AU-2;AU-7;AU-12;AU-07;AU-07(01)",
+          "title": "Event Logging; Audit Record Reduction and Report Generation; Audit Record Generation",
           "profiles": [
             "Low",
             "Moderate",
@@ -39506,12 +38977,7 @@
           "controlId": "AUL2.-3.3.6"
         },
         "fedramp": {
-          "controlId": "AU-07;AU-07(01);AU-12",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AU-07;AU-07(01);AU-12"
         },
         "iso-27001": {
           "controlId": "6.8;8.15"
@@ -39523,8 +38989,8 @@
           "controlId": "3.3.6"
         },
         "nist-800-53": {
-          "controlId": "AU-12;AU-07;AU-07(01)",
-          "title": "Audit Record Generation",
+          "controlId": "AU-2;AU-7;AU-12;AU-07;AU-07(01)",
+          "title": "Event Logging; Audit Record Reduction and Report Generation; Audit Record Generation",
           "profiles": [
             "Low",
             "Moderate",
@@ -39687,12 +39153,7 @@
           "controlId": "AUL2.-3.3.6"
         },
         "fedramp": {
-          "controlId": "AU-07;AU-07(01);AU-12",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AU-07;AU-07(01);AU-12"
         },
         "iso-27001": {
           "controlId": "6.8;8.15"
@@ -39704,8 +39165,8 @@
           "controlId": "3.3.6"
         },
         "nist-800-53": {
-          "controlId": "AU-12;AU-07;AU-07(01)",
-          "title": "Audit Record Generation",
+          "controlId": "AU-3;AU-3(1);AU-7;AU-12;AU-07;AU-07(01)",
+          "title": "Content of Audit Records; Additional Audit Information; Audit Record Reduction and Report Generation; Audit Record Generation",
           "profiles": [
             "Low",
             "Moderate",
@@ -41542,12 +41003,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18;8.12;8.2;8.21"
@@ -41562,8 +41018,8 @@
           "controlId": "3.1.1;3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AC-3;SC-7(10);AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Prevent Exfiltration; Information Input Validation",
+          "controlId": "CM-6;CM-7;AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
+          "title": "Configuration Settings; Least Functionality; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -41724,12 +41180,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18;8.12;8.2;8.21"
@@ -41744,8 +41195,8 @@
           "controlId": "3.1.1;3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AC-3;SC-7(10);AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Prevent Exfiltration; Information Input Validation",
+          "controlId": "CM-6;CM-7;AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
+          "title": "Configuration Settings; Least Functionality; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -41867,10 +41318,7 @@
           "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "High"
-          ]
+          "controlId": "SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21"
@@ -41885,14 +41333,14 @@
           "controlId": "3.13.1"
         },
         "nist-800-53": {
-          "controlId": "SC-7(10);SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "AU-11;CM-12;SI-12;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Prevent Exfiltration"
+          "title": "Audit Record Retention; Information Location; Information Management and Retention"
         },
         "pci-dss": {
           "controlId": "1.3.2;1.3.3;1.4;1.4.1;1.4.2;11.5.1;A3.2.6"
@@ -42012,10 +41460,7 @@
           "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "High"
-          ]
+          "controlId": "SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "iso-27001": {
           "controlId": "8.12;8.2;8.21"
@@ -42030,14 +41475,14 @@
           "controlId": "3.13.1"
         },
         "nist-800-53": {
-          "controlId": "SC-7(10);SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "AU-11;CM-12;SI-12;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Prevent Exfiltration"
+          "title": "Audit Record Retention; Information Location; Information Management and Retention"
         },
         "pci-dss": {
           "controlId": "1.3.2;1.3.3;1.4;1.4.1;1.4.2;11.5.1;A3.2.6"
@@ -42191,12 +41636,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18;8.12;8.2;8.21"
@@ -42211,8 +41651,8 @@
           "controlId": "3.1.1;3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AC-3;SC-7(10);AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Prevent Exfiltration; Information Input Validation",
+          "controlId": "RA-2;AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
+          "title": "Security Categorization; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -42360,11 +41800,7 @@
           "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-04;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18);SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-04;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18);SI-08"
         },
         "iso-27001": {
           "controlId": "5.14;8.12;8.2;8.21;8.3"
@@ -42379,14 +41815,13 @@
           "controlId": "3.1.3;3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AC-4;SC-7(10);SI-8;AC-04;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18);SI-08",
+          "controlId": "AC-04;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18);SI-08",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
-          ],
-          "title": "Information Flow Enforcement; Prevent Exfiltration; Spam Protection"
+          ]
         },
         "pci-dss": {
           "controlId": "1.1;1.3;1.3.1;1.3.2;1.3.3;1.4;1.4.1;1.4.2;1.4.3;11.5.1;5.4;5.4.1;A3.2.6"
@@ -42541,12 +41976,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18;8.12;8.2;8.21"
@@ -42561,8 +41991,8 @@
           "controlId": "3.1.1;3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AC-3;SC-7(10);AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Prevent Exfiltration; Information Input Validation",
+          "controlId": "CM-12;PM-5(1);RA-2;AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
+          "title": "Information Location; Inventory of Personally Identifiable Information; Security Categorization; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -42718,12 +42148,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18;8.12;8.2;8.21"
@@ -42738,8 +42163,8 @@
           "controlId": "3.1.1;3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AC-3;SC-7(10);AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Prevent Exfiltration; Information Input Validation",
+          "controlId": "CM-12;PM-5(1);RA-2;AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10",
+          "title": "Information Location; Inventory of Personally Identifiable Information; Security Categorization; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -42895,11 +42320,7 @@
           "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-21;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-21;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "hipaa": {
           "controlId": "164.506(c)(1);164.506(c)(2);164.506(c)(3);164.506(c)(4);164.508(a)(1);164.508(a)(4)(i)"
@@ -42917,8 +42338,8 @@
           "controlId": "3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AC-21;SC-7(10);SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "title": "Information Sharing; Prevent Exfiltration",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-21;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Information Sharing",
           "profiles": [
             "Low",
             "Moderate",
@@ -43070,11 +42491,7 @@
           "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-21;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-21;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
         },
         "hipaa": {
           "controlId": "164.506(c)(1);164.506(c)(2);164.506(c)(3);164.506(c)(4);164.508(a)(1);164.508(a)(4)(i)"
@@ -43092,8 +42509,8 @@
           "controlId": "3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AC-21;SC-7(10);SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
-          "title": "Information Sharing; Prevent Exfiltration",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-21;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; Information Sharing",
           "profiles": [
             "Low",
             "Moderate",
@@ -43409,11 +42826,7 @@
           "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
         },
         "fedramp": {
-          "controlId": "AC-04;SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-04;SI-08"
         },
         "iso-27001": {
           "controlId": "5.14;8.2;8.3"
@@ -43428,12 +42841,12 @@
           "controlId": "3.1.3"
         },
         "nist-800-53": {
-          "controlId": "AC-4;SI-8;AC-04;SI-08",
+          "controlId": "SI-3;SI-8;AC-04;SI-08",
           "profiles": [
             "Moderate",
             "High"
           ],
-          "title": "Information Flow Enforcement; Spam Protection"
+          "title": "Malicious Code Protection; Spam Protection"
         },
         "pci-dss": {
           "controlId": "1.1;1.3;1.3.1;1.3.2;1.4.2;1.4.3;5.4;5.4.1"
@@ -43605,11 +43018,7 @@
           "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
         },
         "fedramp": {
-          "controlId": "AC-04;SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-04;SI-08"
         },
         "iso-27001": {
           "controlId": "5.14;8.2;8.3"
@@ -43624,12 +43033,12 @@
           "controlId": "3.1.3"
         },
         "nist-800-53": {
-          "controlId": "AC-4;SI-8;AC-04;SI-08",
+          "controlId": "SI-3;SI-8;AC-04;SI-08",
           "profiles": [
             "Moderate",
             "High"
           ],
-          "title": "Information Flow Enforcement; Spam Protection"
+          "title": "Malicious Code Protection; Spam Protection"
         },
         "pci-dss": {
           "controlId": "1.1;1.3;1.3.1;1.3.2;1.4.2;1.4.3;5.4;5.4.1"
@@ -43997,11 +43406,7 @@
           "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
         },
         "fedramp": {
-          "controlId": "AC-04",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-04"
         },
         "iso-27001": {
           "controlId": "5.14;8.2;8.3"
@@ -45060,12 +44465,7 @@
           "controlId": "ACL2.-3.1.12;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
         },
         "fedramp": {
-          "controlId": "AC-17;SC-07;SC-07(09);SC-07(11)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-17;SC-07;SC-07(09);SC-07(11)"
         },
         "iso-27001": {
           "controlId": "6.7;8.2;8.21"
@@ -45253,12 +44653,7 @@
           "controlId": "ACL2.-3.1.12"
         },
         "fedramp": {
-          "controlId": "AC-17",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-17"
         },
         "iso-27001": {
           "controlId": "6.7"
@@ -46155,12 +45550,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -46178,8 +45568,8 @@
           "controlId": "3.1.5;3.1.7;3.4.5;3.4.9"
         },
         "nist-800-53": {
-          "controlId": "AC-6(10);CM-5;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
-          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Access Restrictions for Change; User-installed Software",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; User-installed Software",
           "profiles": [
             "Low",
             "Moderate",
@@ -46338,12 +45728,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -46361,8 +45746,8 @@
           "controlId": "3.1.5;3.1.7;3.4.5;3.4.9"
         },
         "nist-800-53": {
-          "controlId": "AC-6(10);CM-5;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
-          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Access Restrictions for Change; User-installed Software",
+          "controlId": "CM-7(5);CM-10;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
+          "title": "Authorized Software — Allow-by-exception; Software Usage Restrictions; User-installed Software",
           "profiles": [
             "Low",
             "Moderate",
@@ -46524,12 +45909,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -46547,8 +45927,8 @@
           "controlId": "3.1.5;3.1.7;3.4.5;3.4.9"
         },
         "nist-800-53": {
-          "controlId": "AC-6(10);CM-5;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
-          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Access Restrictions for Change; User-installed Software",
+          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
+          "title": "User-installed Software",
           "profiles": [
             "Low",
             "Moderate",
@@ -46707,12 +46087,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -46730,8 +46105,8 @@
           "controlId": "3.1.5;3.1.7;3.4.5;3.4.9"
         },
         "nist-800-53": {
-          "controlId": "AC-6(10);CM-5;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
-          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Access Restrictions for Change; User-installed Software",
+          "controlId": "AC-3;AC-5;AC-6;MP-2;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
+          "title": "Access Enforcement; Separation of Duties; Least Privilege; Media Access; User-installed Software",
           "profiles": [
             "Low",
             "Moderate",
@@ -46890,12 +46265,7 @@
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
         },
         "fedramp": {
-          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-06;AC-06(10);CM-05;CM-11;CM-11(02)"
         },
         "hipaa": {
           "controlId": "164.308(a)(3)(i);164.312(a)(1)"
@@ -46913,8 +46283,8 @@
           "controlId": "3.1.5;3.1.7;3.4.5;3.4.9"
         },
         "nist-800-53": {
-          "controlId": "AC-6(10);CM-5;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
-          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Access Restrictions for Change; User-installed Software",
+          "controlId": "AC-6(10);CM-5;AC-3;AC-5;AC-6;MP-2;AC-06;AC-06(10);CM-05;CM-11;CM-11(02);SA-08(14)",
+          "title": "Prohibit Non-privileged Users from Executing Privileged Functions; Access Restrictions for Change; Access Enforcement; Separation of Duties; Least Privilege; Media Access; User-installed Software",
           "profiles": [
             "Low",
             "Moderate",
@@ -47152,12 +46522,7 @@
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -47178,8 +46543,8 @@
           "controlId": "3.14.1;3.14.2;3.14.4;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "CM-6;SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "title": "Configuration Settings; Malicious Code Protection; Spam Protection; Baseline Selection",
+          "controlId": "SI-3;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
+          "title": "Malicious Code Protection; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -47416,12 +46781,7 @@
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -47442,8 +46802,8 @@
           "controlId": "3.14.1;3.14.2;3.14.4;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "CM-6;SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "title": "Configuration Settings; Malicious Code Protection; Spam Protection; Baseline Selection",
+          "controlId": "SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
+          "title": "Malicious Code Protection; Spam Protection; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -47681,12 +47041,7 @@
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -47707,8 +47062,8 @@
           "controlId": "3.14.1;3.14.2;3.14.4;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "CM-6;SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "title": "Configuration Settings; Malicious Code Protection; Spam Protection; Baseline Selection",
+          "controlId": "SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
+          "title": "Malicious Code Protection; Spam Protection; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -47945,12 +47300,7 @@
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;SI-02;SI-02(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;SI-02;SI-02(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "8.7;8.8"
@@ -47968,8 +47318,8 @@
           "controlId": "3.11.3;3.14.1;3.14.2;3.14.4"
         },
         "nist-800-53": {
-          "controlId": "SI-3;AC-02;AC-03;AC-05;SI-02;SI-02(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Malicious Code Protection; Information Input Validation",
+          "controlId": "SI-3;SI-8;AC-02;AC-03;AC-05;SI-02;SI-02(04);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Malicious Code Protection; Spam Protection; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -48203,12 +47553,7 @@
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -48229,8 +47574,8 @@
           "controlId": "3.14.1;3.14.2;3.14.4;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "CM-6;SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "title": "Configuration Settings; Malicious Code Protection; Spam Protection; Baseline Selection",
+          "controlId": "IR-1;IR-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
+          "title": "Policy and Procedures; Incident Response Plan; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -48465,12 +47810,7 @@
           "controlId": "ML1-P1;ML1-P2;ML1-P6;ML1-P7;ML2-P1;ML2-P2;ML2-P5;ML2-P6;ML2-P7;ML3-P1;ML3-P2;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-02(04);SI-03",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-02(04);SI-03"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -48491,8 +47831,8 @@
           "controlId": "3.11.3;3.14.1;3.14.2;3.14.4;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "CM-6;SI-3;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-02(04);SI-03",
-          "title": "Configuration Settings; Malicious Code Protection; Baseline Selection",
+          "controlId": "SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-02(04);SI-03",
+          "title": "Malicious Code Protection; Spam Protection; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -48726,12 +48066,7 @@
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -48752,8 +48087,8 @@
           "controlId": "3.14.1;3.14.2;3.14.4;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "CM-6;SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "title": "Configuration Settings; Malicious Code Protection; Spam Protection; Baseline Selection",
+          "controlId": "SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
+          "title": "Malicious Code Protection; Spam Protection; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -48987,12 +48322,7 @@
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
         },
         "fedramp": {
-          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08"
         },
         "hipaa": {
           "controlId": "164.312(a)(2)(iii);164.312(e)(1);164.312(e)(2)(i);164.312(e)(2)(ii)"
@@ -49013,8 +48343,8 @@
           "controlId": "3.14.1;3.14.2;3.14.4;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "CM-6;SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "title": "Configuration Settings; Malicious Code Protection; Spam Protection; Baseline Selection",
+          "controlId": "SI-3;SI-8;SI-4;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
+          "title": "Malicious Code Protection; Spam Protection; System Monitoring; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -49248,12 +48578,7 @@
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
         },
         "fedramp": {
-          "controlId": "SI-02;SI-02(04);SI-03;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SI-02;SI-02(04);SI-03;SI-08"
         },
         "iso-27001": {
           "controlId": "8.7;8.8"
@@ -49271,14 +48596,14 @@
           "controlId": "3.11.3;3.14.1;3.14.2;3.14.4"
         },
         "nist-800-53": {
-          "controlId": "SI-3;SI-8;SI-02;SI-02(04);SI-03;SI-08",
+          "controlId": "SI-3;SI-02;SI-02(04);SI-03;SI-08",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Malicious Code Protection; Spam Protection"
+          "title": "Malicious Code Protection"
         },
         "nist-csf": {
           "controlId": "DE.CM-09;ID.RA-01;ID.RA-08;PR.PS-02",
@@ -49753,12 +49078,7 @@
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
         },
         "fedramp": {
-          "controlId": "SI-02;SI-02(04);SI-03;SI-08",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SI-02;SI-02(04);SI-03;SI-08"
         },
         "iso-27001": {
           "controlId": "8.7;8.8"
@@ -49776,14 +49096,14 @@
           "controlId": "3.11.3;3.14.1;3.14.2;3.14.4"
         },
         "nist-800-53": {
-          "controlId": "AC-19;CM-7;SI-02;SI-02(04);SI-03;SI-08",
+          "controlId": "AC-19(5);SC-39;CM-6;CM-7;SI-02;SI-02(04);SI-03;SI-08",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Access Control for Mobile Devices; Least Functionality"
+          "title": "Full Device or Container-based Encryption; Process Isolation; Configuration Settings; Least Functionality"
         },
         "nist-csf": {
           "controlId": "DE.CM-09;ID.RA-01;ID.RA-08;PR.PS-02",
@@ -50505,12 +49825,7 @@
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;SI-02;SI-02(04);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;SI-02;SI-02(04);SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "8.7;8.8"
@@ -51263,22 +50578,18 @@
           "controlId": "9.0;9.6;9.7"
         },
         "fedramp": {
-          "controlId": "SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SI-08"
         },
         "mitre-attack": {
           "controlId": "T1137;T1137.001;T1137.002;T1137.003;T1137.004;T1137.005;T1137.006;T1204;T1204.001;T1204.002;T1204.003;T1221;T1566;T1566.001;T1566.002;T1566.003;T1598;T1598.001;T1598.002;T1598.003"
         },
         "nist-800-53": {
-          "controlId": "SI-8;SI-08",
+          "controlId": "SI-3;AT-2(3);SI-08",
           "profiles": [
             "Moderate",
             "High"
           ],
-          "title": "Spam Protection"
+          "title": "Malicious Code Protection; Social Engineering and Mining"
         },
         "pci-dss": {
           "controlId": "5.4;5.4.1"
@@ -51412,22 +50723,18 @@
           "controlId": "9.0;9.6;9.7"
         },
         "fedramp": {
-          "controlId": "SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SI-08"
         },
         "mitre-attack": {
           "controlId": "T1137;T1137.001;T1137.002;T1137.003;T1137.004;T1137.005;T1137.006;T1204;T1204.001;T1204.002;T1204.003;T1221;T1566;T1566.001;T1566.002;T1566.003;T1598;T1598.001;T1598.002;T1598.003"
         },
         "nist-800-53": {
-          "controlId": "SI-8;SI-08",
+          "controlId": "SI-3;SI-8;SI-08",
           "profiles": [
             "Moderate",
             "High"
           ],
-          "title": "Spam Protection"
+          "title": "Malicious Code Protection; Spam Protection"
         },
         "pci-dss": {
           "controlId": "5.4;5.4.1"
@@ -51563,22 +50870,18 @@
           "controlId": "9.0;9.6;9.7"
         },
         "fedramp": {
-          "controlId": "SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SI-08"
         },
         "mitre-attack": {
           "controlId": "T1137;T1137.001;T1137.002;T1137.003;T1137.004;T1137.005;T1137.006;T1204;T1204.001;T1204.002;T1204.003;T1221;T1566;T1566.001;T1566.002;T1566.003;T1598;T1598.001;T1598.002;T1598.003"
         },
         "nist-800-53": {
-          "controlId": "SI-8;SI-08",
+          "controlId": "SI-3;SI-8;SI-08",
           "profiles": [
             "Moderate",
             "High"
           ],
-          "title": "Spam Protection"
+          "title": "Malicious Code Protection; Spam Protection"
         },
         "pci-dss": {
           "controlId": "5.4;5.4.1"
@@ -51845,22 +51148,18 @@
           "controlId": "9.0;9.6;9.7"
         },
         "fedramp": {
-          "controlId": "SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SI-08"
         },
         "mitre-attack": {
           "controlId": "T1137;T1137.001;T1137.002;T1137.003;T1137.004;T1137.005;T1137.006;T1204;T1204.001;T1204.002;T1204.003;T1221;T1566;T1566.001;T1566.002;T1566.003;T1598;T1598.001;T1598.002;T1598.003"
         },
         "nist-800-53": {
-          "controlId": "SI-8;SI-08",
+          "controlId": "SI-3;SI-8;SI-08",
           "profiles": [
             "Moderate",
             "High"
           ],
-          "title": "Spam Protection"
+          "title": "Malicious Code Protection; Spam Protection"
         },
         "pci-dss": {
           "controlId": "5.4;5.4.1"
@@ -51994,11 +51293,7 @@
           "controlId": "9.0;9.6;9.7"
         },
         "fedramp": {
-          "controlId": "SI-08",
-          "profiles": [
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SI-08"
         },
         "mitre-attack": {
           "controlId": "T1137;T1137.001;T1137.002;T1137.003;T1137.004;T1137.005;T1137.006;T1204;T1204.001;T1204.002;T1204.003;T1221;T1566;T1566.001;T1566.002;T1566.003;T1598;T1598.001;T1598.002;T1598.003"
@@ -52388,12 +51683,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SCL2.-3.13.12"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-15;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-15;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18"
@@ -52408,8 +51698,8 @@
           "controlId": "3.1.1;3.13.12"
         },
         "nist-800-53": {
-          "controlId": "AC-3;SC-15;AC-02;AC-03;AC-05;AC-06;SC-15(01);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Collaborative Computing Devices and Applications; Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-15;SC-15(01);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Collaborative Computing Devices and Applications; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -52569,12 +51859,7 @@
           "controlId": "SCL2.-3.13.12"
         },
         "fedramp": {
-          "controlId": "SC-15",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SC-15"
         },
         "nist-800-171": {
           "controlId": "3.13.12"
@@ -52737,12 +52022,7 @@
           "controlId": "SCL2.-3.13.12"
         },
         "fedramp": {
-          "controlId": "SC-15",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SC-15"
         },
         "nist-800-171": {
           "controlId": "3.13.12"
@@ -52926,12 +52206,7 @@
           "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SCL2.-3.13.12"
         },
         "fedramp": {
-          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-15;SI-03;SI-04;SI-05;SI-07;SI-10",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-15;SI-03;SI-04;SI-05;SI-07;SI-10"
         },
         "iso-27001": {
           "controlId": "5.18"
@@ -52946,8 +52221,8 @@
           "controlId": "3.1.1;3.13.12"
         },
         "nist-800-53": {
-          "controlId": "AC-3;SC-15;AC-02;AC-03;AC-05;AC-06;SC-15(01);SI-03;SI-04;SI-05;SI-07;SI-10",
-          "title": "Access Enforcement; Collaborative Computing Devices and Applications; Information Input Validation",
+          "controlId": "AC-02;AC-03;AC-05;AC-06;SC-15;SC-15(01);SI-03;SI-04;SI-05;SI-07;SI-10",
+          "title": "Collaborative Computing Devices and Applications; Information Input Validation",
           "profiles": [
             "Low",
             "Moderate",
@@ -53121,12 +52396,7 @@
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
         },
         "fedramp": {
-          "controlId": "AC-19;CM-08;PM-05",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "AC-19;CM-08;PM-05"
         },
         "hipaa": {
           "controlId": "164.310(d)(2)(iii)"
@@ -53147,8 +52417,8 @@
           "controlId": "3.1.18;3.4.1;NFO - CM-8(5)"
         },
         "nist-800-53": {
-          "controlId": "AC-19;CM-8;CM-08;PM-05",
-          "title": "Access Control for Mobile Devices; System Component Inventory",
+          "controlId": "AC-2;AC-5;AC-6;AC-6(1);AC-6(7);AU-9(4);AC-19;CM-08;PM-05",
+          "title": "Account Management; Separation of Duties; Least Privilege; Authorize Access to Security Functions; Review of User Privileges; Access by Subset of Privileged Users; Access Control for Mobile Devices",
           "profiles": [
             "Low",
             "Moderate",
@@ -53824,12 +53094,7 @@
           "controlId": "SCL2.-3.13.8"
         },
         "fedramp": {
-          "controlId": "SC-08;SC-08(01);SC-16(01);SC-28(01)",
-          "profiles": [
-            "Low",
-            "Moderate",
-            "High"
-          ]
+          "controlId": "SC-08;SC-08(01);SC-16(01);SC-28(01)"
         },
         "hipaa": {
           "controlId": "164.312(e)(1);164.312(e)(2)(i)"
@@ -53847,13 +53112,13 @@
           "controlId": "3.13.8;NFO - SI-1"
         },
         "nist-800-53": {
-          "controlId": "SC-8;SC-08;SC-08(01);SC-16(01);SC-28(01)",
+          "controlId": "SI-8;SC-7;SC-08;SC-08(01);SC-16(01);SC-28(01)",
           "profiles": [
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Transmission Confidentiality and Integrity"
+          "title": "Spam Protection; Boundary Protection"
         },
         "nist-csf": {
           "controlId": "PR.DS-02",

--- a/data/scuba-nist-mapping.json
+++ b/data/scuba-nist-mapping.json
@@ -1,0 +1,357 @@
+{
+  "schemaVersion": "1.0.0",
+  "source": "scuba-to-nist-sp-800-53-r5-fedramp-high.csv",
+  "baseline": "FedRAMP High",
+  "derivation": "CISA ScubaGear authoritative SCuBA policy -> NIST 800-53 R5 mapping",
+  "controls": {
+    "MS.AAD.1.1": [
+      "CM-7"
+    ],
+    "MS.AAD.2.1": [
+      "AC-2(12)",
+      "AC-2(13)"
+    ],
+    "MS.AAD.2.2": [
+      "AC-2(12)"
+    ],
+    "MS.AAD.2.3": [
+      "AC-2(12)",
+      "AC-2(13)"
+    ],
+    "MS.AAD.3.1": [
+      "IA-2(1)",
+      "IA-2(2)",
+      "IA-5",
+      "IA-2(8)"
+    ],
+    "MS.AAD.3.2": [
+      "IA-2(1)",
+      "IA-2(2)"
+    ],
+    "MS.AAD.3.3": [
+      "IA-2(1)",
+      "IA-2(2)",
+      "IA-5",
+      "IA-2(8)",
+      "IA-2(13)"
+    ],
+    "MS.AAD.3.4": [
+      "CM-7"
+    ],
+    "MS.AAD.3.5": [
+      "CM-7",
+      "IA-5"
+    ],
+    "MS.AAD.3.6": [
+      "IA-2(1)",
+      "IA-5",
+      "IA-2(8)"
+    ],
+    "MS.AAD.3.7": [
+      "AC-20",
+      "IA-3"
+    ],
+    "MS.AAD.3.8": [
+      "AC-20",
+      "IA-3"
+    ],
+    "MS.AAD.3.9": [
+      "CM-7"
+    ],
+    "MS.AAD.4.1": [
+      "AU-4"
+    ],
+    "MS.AAD.5.1": [
+      "AC-6(10)",
+      "CM-5"
+    ],
+    "MS.AAD.5.2": [
+      "AC-6(10)",
+      "CM-5"
+    ],
+    "MS.AAD.5.3": [
+      "CM-4"
+    ],
+    "MS.AAD.6.1": [
+      "IA-5(1)"
+    ],
+    "MS.AAD.7.1": [
+      "AC-6(5)"
+    ],
+    "MS.AAD.7.2": [
+      "AC-5"
+    ],
+    "MS.AAD.7.3": [
+      "AC-6(5)"
+    ],
+    "MS.AAD.7.4": [
+      "AC-2"
+    ],
+    "MS.AAD.7.5": [
+      "AC-2"
+    ],
+    "MS.AAD.7.6": [
+      "AC-6(1)"
+    ],
+    "MS.AAD.7.7": [
+      "AC-2(1)"
+    ],
+    "MS.AAD.7.8": [
+      "AC-6(9)"
+    ],
+    "MS.AAD.7.9": [
+      "AC-6(9)"
+    ],
+    "MS.AAD.8.1": [
+      "AC-6"
+    ],
+    "MS.AAD.8.2": [
+      "AC-6(10)"
+    ],
+    "MS.AAD.8.3": [
+      "AC-3"
+    ],
+    "MS.TEAMS.1.1": [
+      "AC-17"
+    ],
+    "MS.TEAMS.1.2": [
+      "SC-15"
+    ],
+    "MS.TEAMS.1.3": [
+      "SC-15"
+    ],
+    "MS.TEAMS.1.4": [
+      "AC-3"
+    ],
+    "MS.TEAMS.1.5": [
+      "SC-15"
+    ],
+    "MS.TEAMS.1.6": [
+      "CM-7"
+    ],
+    "MS.TEAMS.1.7": [
+      "AC-21"
+    ],
+    "MS.TEAMS.2.1": [
+      "AC-3"
+    ],
+    "MS.TEAMS.2.2": [
+      "CM-7",
+      "SI-8"
+    ],
+    "MS.TEAMS.2.3": [
+      "CM-7",
+      "SC-7(10)"
+    ],
+    "MS.TEAMS.4.1": [
+      "SI-8",
+      "SC-7(10)",
+      "AC-4"
+    ],
+    "MS.TEAMS.5.1": [
+      "CM-11"
+    ],
+    "MS.TEAMS.5.2": [
+      "CM-11"
+    ],
+    "MS.TEAMS.5.3": [
+      "CM-11"
+    ],
+    "MS.SHAREPOINT.1.1": [
+      "AC-2",
+      "AC-3",
+      "IA-8"
+    ],
+    "MS.SHAREPOINT.1.2": [
+      "AC-2",
+      "AC-3",
+      "IA-8"
+    ],
+    "MS.SHAREPOINT.1.3": [
+      "AC-3",
+      "AC-6(10)"
+    ],
+    "MS.SHAREPOINT.2.1": [
+      "AC-6"
+    ],
+    "MS.SHAREPOINT.2.2": [
+      "AC-6"
+    ],
+    "MS.SHAREPOINT.3.1": [
+      "AC-3",
+      "AC-21"
+    ],
+    "MS.SHAREPOINT.3.2": [
+      "AC-6"
+    ],
+    "MS.SHAREPOINT.3.3": [
+      "IA-11"
+    ],
+    "MS.POWERPLATFORM.1.1": [
+      "AC-6(10)"
+    ],
+    "MS.POWERPLATFORM.1.2": [
+      "AC-6(10)"
+    ],
+    "MS.POWERPLATFORM.2.1": [
+      "SC-7(10)"
+    ],
+    "MS.POWERPLATFORM.2.2": [
+      "SC-7(10)"
+    ],
+    "MS.POWERPLATFORM.3.1": [
+      "AC-3",
+      "SC-7(5)"
+    ],
+    "MS.POWERPLATFORM.3.2": [
+      "AC-3",
+      "SC-7(5)"
+    ],
+    "MS.POWERPLATFORM.4.1": [
+      "SI-10"
+    ],
+    "MS.POWERPLATFORM.5.1": [
+      "AC-6(10)"
+    ],
+    "MS.POWERBI.1.1": [
+      "CM-7",
+      "SC-7(10)"
+    ],
+    "MS.POWERBI.2.1": [
+      "CM-7",
+      "AC-6"
+    ],
+    "MS.POWERBI.3.1": [
+      "CM-7",
+      "AC-6"
+    ],
+    "MS.POWERBI.4.1": [
+      "AC-4",
+      "AC-6(5)"
+    ],
+    "MS.POWERBI.4.2": [
+      "AC-4",
+      "AC-6(5)"
+    ],
+    "MS.POWERBI.5.1": [
+      "CM-7",
+      "IA-5"
+    ],
+    "MS.POWERBI.6.1": [
+      "CM-7",
+      "SI-3"
+    ],
+    "MS.POWERBI.7.1": [
+      "AC-21",
+      "SC-7(10)"
+    ],
+    "MS.EXO.1.1": [
+      "AC-4"
+    ],
+    "MS.EXO.2.2": [
+      "AC-2"
+    ],
+    "MS.EXO.3.1": [
+      "SC-8"
+    ],
+    "MS.EXO.4.1": [
+      "SI-8"
+    ],
+    "MS.EXO.4.2": [
+      "SI-8"
+    ],
+    "MS.EXO.4.3": [
+      "SI-4(5)"
+    ],
+    "MS.EXO.4.4": [
+      "SI-4(5)"
+    ],
+    "MS.EXO.5.1": [
+      "CM-7"
+    ],
+    "MS.EXO.6.1": [
+      "AC-3",
+      "SC-7(10)"
+    ],
+    "MS.EXO.6.2": [
+      "AC-3",
+      "SC-7(10)"
+    ],
+    "MS.EXO.7.1": [
+      "SI-8"
+    ],
+    "MS.EXO.13.1": [
+      "AU-12"
+    ],
+    "MS.SECURITYSUITE.1.1": [
+      "SI-3"
+    ],
+    "MS.SECURITYSUITE.1.2": [
+      "SI-3"
+    ],
+    "MS.SECURITYSUITE.1.3": [
+      "SI-3"
+    ],
+    "MS.SECURITYSUITE.1.4": [
+      "SI-3"
+    ],
+    "MS.SECURITYSUITE.2.1": [
+      "SI-8"
+    ],
+    "MS.SECURITYSUITE.2.2": [
+      "SI-8"
+    ],
+    "MS.SECURITYSUITE.2.3": [
+      "SI-8"
+    ],
+    "MS.SECURITYSUITE.3.1": [
+      "SC-7(10)"
+    ],
+    "MS.SECURITYSUITE.3.2": [
+      "SC-7(10)"
+    ],
+    "MS.SECURITYSUITE.3.3": [
+      "SC-7(10)"
+    ],
+    "MS.SECURITYSUITE.3.4": [
+      "AT-2"
+    ],
+    "MS.SECURITYSUITE.3.5": [
+      "AC-19"
+    ],
+    "MS.SECURITYSUITE.4.1": [
+      "SI-4(5)"
+    ],
+    "MS.SECURITYSUITE.4.2": [
+      "SI-4(5)"
+    ],
+    "MS.SECURITYSUITE.5.1": [
+      "AU-12"
+    ],
+    "MS.SECURITYSUITE.5.2": [
+      "AU-11"
+    ],
+    "MS.SECURITYSUITE.6.1": [
+      "SI-8"
+    ],
+    "MS.SECURITYSUITE.6.2": [
+      "SI-8"
+    ],
+    "MS.SECURITYSUITE.7.1": [
+      "SI-3"
+    ],
+    "MS.SECURITYSUITE.7.2": [
+      "SI-3"
+    ],
+    "MS.SECURITYSUITE.7.3": [
+      "SI-3",
+      "AU-12"
+    ],
+    "MS.SECURITYSUITE.8.1": [
+      "AC-4"
+    ],
+    "MS.SECURITYSUITE.8.2": [
+      "AC-4"
+    ]
+  }
+}

--- a/scripts/Build-CisM365Crosswalk.py
+++ b/scripts/Build-CisM365Crosswalk.py
@@ -1,13 +1,18 @@
-"""Build CIS M365 crosswalk data files for CheckID.
+"""Build CIS M365 crosswalk and SCuBA NIST mapping files for CheckID.
 
-Reads CIS_M365_to_NIST_to_FedRAMP_Crosswalk.csv from the SecFrame/CIS directory
-and produces:
-  - data/cis-m365-crosswalk.json   authoritative CIS M365 -> NIST / FedRAMP mapping
-  - data/framework-titles.json     updated with cis-m365-v6 section
+Reads from SecFrame/CIS/:
+  - CIS_Microsoft_365_Foundations_Benchmark_v6.0.1.xlsx  (CIS M365 -> safeguards)
+  - CIS_Controls_v8.1_Mapping_to_NIST_SP_800-53_Rev5.csv (safeguards -> NIST)
+  - scuba-to-nist-sp-800-53-r5-fedramp-high.csv          (SCuBA policy -> NIST)
+
+Produces:
+  - data/cis-m365-crosswalk.json    CIS M365 v6 -> NIST via CIS safeguard path
+  - data/scuba-nist-mapping.json    SCuBA policy -> NIST (CISA-authoritative)
+  - data/framework-titles.json      updated with cis-m365-v6 section
 
 Usage:
     python scripts/Build-CisM365Crosswalk.py
-    python scripts/Build-CisM365Crosswalk.py --csv path/to/crosswalk.csv
+    python scripts/Build-CisM365Crosswalk.py --cis-dir path/to/SecFrame/CIS
 """
 
 import argparse
@@ -17,135 +22,276 @@ import re
 from collections import OrderedDict
 from pathlib import Path
 
+try:
+    import openpyxl
+except ImportError:
+    raise SystemExit("ERROR: openpyxl is required. Run: pip install openpyxl")
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
-DEFAULT_CSV = REPO_ROOT.parent / "SecFrame" / "CIS" / "CIS_M365_to_NIST_to_FedRAMP_Crosswalk.csv"
-CROSSWALK_OUT = REPO_ROOT / "data" / "cis-m365-crosswalk.json"
-TITLES_PATH = REPO_ROOT / "data" / "framework-titles.json"
-SCHEMA_VERSION = "1.0.0"
+DEFAULT_CIS_DIR = REPO_ROOT.parent / "SecFrame" / "CIS"
+
+XLSX_NAME   = "CIS_Microsoft_365_Foundations_Benchmark_v6.0.1.xlsx"
+SG_CSV_NAME = "CIS_Controls_v8.1_Mapping_to_NIST_SP_800-53_Rev5.csv"
+SCUBA_CSV_NAME = "scuba-to-nist-sp-800-53-r5-fedramp-high.csv"
+
+CROSSWALK_OUT     = REPO_ROOT / "data" / "cis-m365-crosswalk.json"
+SCUBA_MAPPING_OUT = REPO_ROOT / "data" / "scuba-nist-mapping.json"
+TITLES_PATH       = REPO_ROOT / "data" / "framework-titles.json"
+
+SCHEMA_VERSION = "1.1.0"
 
 
-def parse_nist_ids(raw: str) -> list[str]:
-    """Split semicolon-separated NIST IDs, normalise whitespace and parens.
+# ---------------------------------------------------------------------------
+# NIST ID normalisation
+# ---------------------------------------------------------------------------
 
-    Input:  "AC-2; AC-6(5); IA-5c; CM-7b"
-    Output: ["AC-2", "AC-6(5)", "IA-5", "CM-7"]
+def parse_nist_ids(raw: str, sep: str = ";") -> list[str]:
+    """Split and normalise NIST control IDs from a delimited string.
 
-    CIS sometimes references NIST sub-items using letter suffixes (IA-5c, CM-7b)
-    which are not standard NIST control IDs. These are normalised to the parent
-    control (letter stripped) and deduplicated.
+    Handles both semicolon (CIS Controls CSV) and comma (SCuBA CSV) separators.
+    Normalises:
+      - whitespace before parens: "AC-6 (5)" -> "AC-6(5)"
+      - letter suffix on base control: "IA-5c", "IA-5g" -> "IA-5"
+      - letter-paren suffix on enhancement: "SC-7(10)(a)" -> "SC-7(10)"
+    Deduplicates while preserving first-seen order.
     """
     ids: list[str] = []
     seen: set[str] = set()
-    for part in raw.split(";"):
+    for part in re.split(r"[;,]", raw):
         part = part.strip()
         if not part:
             continue
-        # Normalise parenthetical suffix spacing: "AC-6 (5)" -> "AC-6(5)"
         part = re.sub(r'\s+\(', '(', part)
-        # Normalise letter sub-item suffix: "IA-5c" -> "IA-5", "CM-7b" -> "CM-7"
-        # Only strip when it's a bare letter (no parenthesis follows)
-        part = re.sub(r'^([A-Z]+-\d+)[a-z]$', r'\1', part)
+        part = re.sub(r'\([a-z]\)$', '', part)          # SC-7(10)(a) -> SC-7(10)
+        part = re.sub(r'^([A-Z]+-\d+)[a-z]+$', r'\1', part)  # IA-5c, IA-5g -> IA-5
         if part not in seen:
             seen.add(part)
             ids.append(part)
     return ids
 
 
-def strip_level_prefix(title: str) -> str:
-    """Remove leading level tag from CIS titles.
+# ---------------------------------------------------------------------------
+# CIS safeguard -> NIST lookup
+# ---------------------------------------------------------------------------
 
-    "(L1) Ensure Administrative accounts are cloud-only"
-    -> "Ensure Administrative accounts are cloud-only"
-    """
-    return re.sub(r'^\(L\d\)\s*', '', title).strip()
+def load_safeguard_nist(csv_path: Path) -> dict[str, list[str]]:
+    """{safeguard_id: [nist_control_ids]} from CIS Controls v8.1 -> NIST CSV."""
+    mapping: dict[str, list[str]] = {}
+    with open(csv_path, encoding="latin-1", newline="") as fh:
+        for row in csv.DictReader(fh):
+            sg = row.get("CIS Sub-Control", "").strip()
+            nist = row.get("Control Identifier", "").strip()
+            if sg and nist:
+                mapping.setdefault(sg, [])
+                if nist not in mapping[sg]:
+                    mapping[sg].append(nist)
+    return mapping
 
 
-def build_crosswalk(csv_path: Path) -> tuple[dict, dict]:
-    """Parse the CSV and return (controls_dict, titles_dict).
+# ---------------------------------------------------------------------------
+# CIS M365 crosswalk (CIS XLSX + safeguard NIST CSV)
+# ---------------------------------------------------------------------------
 
-    controls_dict: {cisId: {title, section, level, license, nist800_53, fedramp}}
+def build_crosswalk(xlsx_path: Path, sg_nist: dict[str, list[str]]) -> tuple[dict, dict]:
+    """Parse CIS M365 XLSX and return (controls_dict, titles_dict).
+
+    controls_dict: {cisId: {title, section, level, license, safeguards, nist800_53}}
     titles_dict:   {cisId: title_string}
+
+    NIST IDs are derived via the CIS safeguard path:
+      CIS M365 recommendation -> CIS Controls v8 safeguard(s) -> NIST 800-53
     """
+    wb = openpyxl.load_workbook(xlsx_path, read_only=True, data_only=True)
+    ws = wb["Combined Profiles"]
+    rows = list(ws.iter_rows(values_only=True))
+    headers = rows[0]
+
+    def col(name: str) -> int:
+        return next(i for i, h in enumerate(headers) if h == name)
+
+    rec_col   = col("Recommendation #")
+    title_col = col("Title")
+    sg_cols   = [i for i, h in enumerate(headers) if h and "Safeguard" in str(h) and "v8" in str(h)]
+
+    # Section headers in the XLSX have a title row above each group of recs.
+    # Track current section name (non-numeric Title rows with no Recommendation #).
+    current_section = ""
+    level_map: dict[str, str] = {}   # rec_id -> level
+    section_map: dict[str, str] = {} # rec_id -> section
+
+    # First pass: read level sheets to get L1/L2 and license per rec
+    license_map: dict[str, str] = {}
+    for sheet_name in wb.sheetnames:
+        m = re.match(r'^(E\d+) Level (\d+)$', sheet_name)
+        if not m:
+            continue
+        lic, lvl = m.group(1), m.group(2)
+        ws2 = wb[sheet_name]
+        sh_headers = [c.value for c in next(ws2.iter_rows(min_row=1, max_row=1))]
+        try:
+            r_col = sh_headers.index("Recommendation #")
+        except ValueError:
+            continue
+        for row2 in ws2.iter_rows(min_row=2, values_only=True):
+            r = str(row2[r_col]).strip() if row2[r_col] else ""
+            if re.match(r'^\d+\.\d+', r):
+                if r not in level_map:
+                    level_map[r] = f"L{lvl}"
+                    license_map[r] = lic
+
     controls: dict = {}
     titles: dict = {}
 
-    with open(csv_path, encoding="utf-8-sig", newline="") as fh:
-        reader = csv.DictReader(fh)
-        for row in reader:
-            cis_id = row["RecommendationId"].strip()
-            if not cis_id:
-                continue
+    for row in rows[1:]:
+        rec = str(row[rec_col]).strip() if row[rec_col] else ""
+        raw_title = str(row[title_col]).strip() if row[title_col] else ""
 
-            raw_title = row.get("Title", "").strip()
-            title = strip_level_prefix(raw_title)
-            section = row.get("Section", "").strip()
-            level = row.get("Level", "").strip()
-            license_ = row.get("License", "").strip()
-            nist_raw = row.get("NIST80053", "").strip()
-            nist_ids = parse_nist_ids(nist_raw) if nist_raw else []
-            fedramp = {
-                "high":     row.get("FedRAMP_High", "").strip().lower() == "yes",
-                "moderate": row.get("FedRAMP_Moderate", "").strip().lower() == "yes",
-                "low":      row.get("FedRAMP_Low", "").strip().lower() == "yes",
+        # Section header row (no rec number)
+        if not re.match(r'^\d+\.\d+', rec):
+            if raw_title and rec == "":
+                current_section = raw_title
+            continue
+
+        title = re.sub(r'^\(L\d\)\s*', '', raw_title).strip()
+        safeguards = [
+            str(row[i]).strip()
+            for i in sg_cols
+            if row[i] and str(row[i]).strip() not in ("", "None")
+        ]
+
+        # Union NIST IDs across all mapped safeguards
+        nist_seen: set[str] = set()
+        nist_ids: list[str] = []
+        for sg in safeguards:
+            for nist_id in sg_nist.get(sg, []):
+                if nist_id not in nist_seen:
+                    nist_seen.add(nist_id)
+                    nist_ids.append(nist_id)
+
+        if rec not in controls:
+            controls[rec] = {
+                "title":      title,
+                "section":    current_section,
+                "level":      level_map.get(rec, ""),
+                "license":    license_map.get(rec, ""),
+                "safeguards": safeguards,
+                "nist800_53": nist_ids,
             }
-
-            # Keep first occurrence if the same ID appears more than once
-            if cis_id not in controls:
-                controls[cis_id] = {
-                    "title":     title,
-                    "section":   section,
-                    "level":     level,
-                    "license":   license_,
-                    "nist800_53": nist_ids,
-                    "fedramp":   fedramp,
-                }
-                titles[cis_id] = title
+            titles[rec] = title
 
     return controls, titles
 
 
+# ---------------------------------------------------------------------------
+# SCuBA NIST mapping
+# ---------------------------------------------------------------------------
+
+def build_scuba_mapping(csv_path: Path) -> dict[str, list[str]]:
+    """{base_policy_id: [nist_ids]} from CISA ScubaGear NIST mapping CSV.
+
+    Keys strip the version suffix (e.g. 'MS.AAD.3.2') so lookup works
+    regardless of whether the registry stores v1 or v2.
+    """
+    mapping: dict[str, list[str]] = {}
+    with open(csv_path, encoding="utf-8-sig", newline="") as fh:
+        for row in csv.DictReader(fh):
+            policy_id = row.get("scuba-control-id", "").strip()
+            nist_raw  = row.get("nist-800-53-control-id", "").strip()
+            if not policy_id or not nist_raw:
+                continue
+            base_id = re.sub(r'v\d+$', '', policy_id)
+            nist_ids = parse_nist_ids(nist_raw, sep=",")
+            if base_id not in mapping:
+                mapping[base_id] = nist_ids
+            else:
+                # Merge if same base ID appears under multiple versions
+                existing = set(mapping[base_id])
+                mapping[base_id].extend(n for n in nist_ids if n not in existing)
+    return mapping
+
+
+# ---------------------------------------------------------------------------
+# Writers
+# ---------------------------------------------------------------------------
+
 def write_crosswalk(controls: dict, out_path: Path) -> None:
     payload = OrderedDict([
         ("schemaVersion", SCHEMA_VERSION),
-        ("source", "CIS_M365_to_NIST_to_FedRAMP_Crosswalk.csv"),
-        ("controls", controls),
+        ("source",        f"{XLSX_NAME} + {SG_CSV_NAME}"),
+        ("derivation",    "CIS M365 recommendation -> CIS Controls v8 safeguard -> NIST 800-53 R5"),
+        ("controls",      controls),
     ])
     out_path.write_text(
         json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
-    print(f"  Written: {out_path.relative_to(REPO_ROOT)} ({len(controls)} controls)")
+    covered = sum(1 for c in controls.values() if c["nist800_53"])
+    print(f"  Written: {out_path.relative_to(REPO_ROOT)} "
+          f"({len(controls)} controls, {covered} with NIST mappings)")
+
+
+def write_scuba_mapping(mapping: dict, out_path: Path) -> None:
+    payload = OrderedDict([
+        ("schemaVersion", "1.0.0"),
+        ("source",        SCUBA_CSV_NAME),
+        ("baseline",      "FedRAMP High"),
+        ("derivation",    "CISA ScubaGear authoritative SCuBA policy -> NIST 800-53 R5 mapping"),
+        ("controls",      mapping),
+    ])
+    out_path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    print(f"  Written: {out_path.relative_to(REPO_ROOT)} ({len(mapping)} SCuBA policies)")
 
 
 def update_framework_titles(titles: dict, titles_path: Path) -> None:
     existing = json.loads(titles_path.read_text(encoding="utf-8"))
     existing["cis-m365-v6"] = titles
-    # Sort top-level keys for stable output
     ordered = OrderedDict(sorted(existing.items()))
     titles_path.write_text(
         json.dumps(ordered, indent=2, ensure_ascii=False) + "\n",
         encoding="utf-8",
     )
-    print(f"  Updated: {titles_path.relative_to(REPO_ROOT)} (added cis-m365-v6: {len(titles)} titles)")
+    print(f"  Updated: {titles_path.relative_to(REPO_ROOT)} "
+          f"(cis-m365-v6: {len(titles)} titles)")
 
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--csv", type=Path, default=DEFAULT_CSV,
-        help="Path to CIS_M365_to_NIST_to_FedRAMP_Crosswalk.csv (default: %(default)s)",
+        "--cis-dir", type=Path, default=DEFAULT_CIS_DIR,
+        help="Directory containing CIS source files (default: %(default)s)",
     )
     args = parser.parse_args()
 
-    if not args.csv.exists():
-        print(f"ERROR: CSV not found: {args.csv}")
-        raise SystemExit(1)
+    xlsx_path  = args.cis_dir / XLSX_NAME
+    sg_csv     = args.cis_dir / SG_CSV_NAME
+    scuba_csv  = args.cis_dir / SCUBA_CSV_NAME
 
-    print(f"Reading: {args.csv.name}")
-    controls, titles = build_crosswalk(args.csv)
-    print(f"  Parsed {len(controls)} CIS M365 control entries")
+    for p in (xlsx_path, sg_csv, scuba_csv):
+        if not p.exists():
+            print(f"ERROR: file not found: {p}")
+            raise SystemExit(1)
+
+    print(f"Reading safeguard -> NIST mapping: {sg_csv.name}")
+    sg_nist = load_safeguard_nist(sg_csv)
+    print(f"  {len(sg_nist)} safeguards with NIST mappings")
+
+    print(f"Reading CIS M365 benchmark: {xlsx_path.name}")
+    controls, titles = build_crosswalk(xlsx_path, sg_nist)
+    print(f"  {len(controls)} recommendations parsed")
+
+    print(f"Reading SCuBA NIST mapping: {scuba_csv.name}")
+    scuba_mapping = build_scuba_mapping(scuba_csv)
+    print(f"  {len(scuba_mapping)} SCuBA policies parsed")
 
     write_crosswalk(controls, CROSSWALK_OUT)
+    write_scuba_mapping(scuba_mapping, SCUBA_MAPPING_OUT)
     update_framework_titles(titles, TITLES_PATH)
 
     print("\nDone.")

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -135,12 +135,25 @@ def load_framework_mappings(
 
 
 # ---------------------------------------------------------------------------
-# CIS M365 crosswalk loader
+# CIS M365 crosswalk and SCuBA NIST loaders
 # ---------------------------------------------------------------------------
 
 def load_cis_m365_crosswalk(repo_root: Path) -> dict:
-    """{cisId: {title, nist800_53: [...], fedramp: {high, moderate, low}}} or {} if absent."""
+    """{cisId: {title, nist800_53: [...], ...}} or {} if absent."""
     path = repo_root / "data" / "cis-m365-crosswalk.json"
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return data.get("controls", {})
+
+
+def load_scuba_nist_mapping(repo_root: Path) -> dict:
+    """{base_scuba_id: [nist_ids]} or {} if absent.
+
+    Keys are version-stripped (e.g. 'MS.AAD.3.2') so they match regardless
+    of which policy version the registry stores.
+    """
+    path = repo_root / "data" / "scuba-nist-mapping.json"
     if not path.exists():
         return {}
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -536,10 +549,13 @@ def main():
         fw_overrides = overrides_data.get("overrides", {})
         print(f"Loaded {len(fw_overrides)} framework overrides")
 
-    # Load CIS M365 crosswalk (authoritative NIST + FedRAMP source for CIS-mapped checks)
+    # Load CIS M365 and SCuBA NIST sources
     cis_crosswalk = load_cis_m365_crosswalk(REPO_ROOT)
     if cis_crosswalk:
         print(f"Loaded CIS M365 crosswalk ({len(cis_crosswalk)} controls)")
+    scuba_nist = load_scuba_nist_mapping(REPO_ROOT)
+    if scuba_nist:
+        print(f"Loaded SCuBA NIST mapping ({len(scuba_nist)} policies)")
 
     # Connect to SCF database
     print(f"Connecting to SCF database at {args.scf_db}")
@@ -608,26 +624,30 @@ def main():
                 cis_entry["profiles"] = cis_profiles
             frameworks["cis-m365-v6"] = cis_entry
 
-        # Enrich NIST 800-53 and FedRAMP from CIS M365 authoritative crosswalk.
-        # CIS IDs are placed first (benchmark-specific); SCF-derived IDs are appended
-        # if not already present (union strategy).
-        cis_data = cis_crosswalk.get(cis_id, {}) if cis_id else {}
-        if cis_data:
-            cis_nist = cis_data.get("nist800_53", [])
-            if cis_nist and "nist-800-53" in frameworks:
-                frameworks["nist-800-53"]["controlId"] = merge_control_ids(
-                    cis_nist, frameworks["nist-800-53"].get("controlId", "")
-                )
-                new_title = resolve_title(frameworks["nist-800-53"]["controlId"], "nist-800-53", titles)
-                if new_title:
-                    frameworks["nist-800-53"]["title"] = new_title
+        # Enrich NIST 800-53 from M365-specific authoritative sources.
+        # Priority: SCuBA (CISA, FedRAMP High) > CIS transitive path > SCF.
+        # Each source adds IDs not already present; SCF-derived IDs stay as supplement.
+        scuba_id_raw = cm.get("cisaScubaControlId", "")
+        scuba_nist_ids: list[str] = []
+        if scuba_id_raw:
+            seen: set[str] = set()
+            for sid in (s.strip() for s in scuba_id_raw.split(";") if s.strip()):
+                base = re.sub(r'v\d+$', '', sid)
+                for nid in scuba_nist.get(base, []):
+                    if nid not in seen:
+                        seen.add(nid)
+                        scuba_nist_ids.append(nid)
 
-            fedramp_cis = cis_data.get("fedramp", {})
-            if fedramp_cis and "fedramp" in frameworks:
-                order = ["Low", "Moderate", "High"]
-                profiles = [lvl for lvl in order if fedramp_cis.get(lvl.lower())]
-                if profiles:
-                    frameworks["fedramp"]["profiles"] = profiles
+        cis_nist_ids = cis_crosswalk.get(cis_id, {}).get("nist800_53", []) if cis_id else []
+
+        combined = scuba_nist_ids + [x for x in cis_nist_ids if x not in scuba_nist_ids]
+        if combined and "nist-800-53" in frameworks:
+            frameworks["nist-800-53"]["controlId"] = merge_control_ids(
+                combined, frameworks["nist-800-53"].get("controlId", "")
+            )
+            new_title = resolve_title(frameworks["nist-800-53"]["controlId"], "nist-800-53", titles)
+            if new_title:
+                frameworks["nist-800-53"]["title"] = new_title
 
         scuba_id = cm.get("cisaScubaControlId", "")
         if scuba_id:


### PR DESCRIPTION
## Summary

Follows #189. Replaces the unverifiable M365-Assess-authored NIST column in the CIS M365 crosswalk with two authoritative, reproducible sources:

- **CIS transitive path**: CIS M365 Foundations Benchmark XLSX → CIS Controls v8.1 safeguard → `CIS_Controls_v8.1_Mapping_to_NIST_SP_800-53_Rev5.csv` → NIST 800-53 R5. Both steps are CIS-published files; the chain is fully auditable.
- **CISA ScubaGear**: `scuba-to-nist-sp-800-53-r5-fedramp-high.csv` maps 103 SCuBA policies to NIST 800-53 R5 (FedRAMP High baseline), committed to SecFrame/CIS.

**NIST enrichment priority in `Build-Registry.py`:**
```
SCuBA (CISA, FedRAMP High)  ← most authoritative where available (~44 checks)
    ↓ union
CIS transitive path          ← citable to two CIS publications (114/140 recs)
    ↓ union
SCF                          ← fills remaining gaps
```

Also removes the FedRAMP crosswalk enrichment (SCF now handles FedRAMP correctly via the 2026.1 IDs fixed in #189).

## New files
- `data/scuba-nist-mapping.json` — 103 SCuBA policy → NIST mappings (generated from CISA CSV)
- `Build-CisM365Crosswalk.py` rewritten — now reads XLSX + two CSVs, no M365-Assess dependency

## Test plan
- [x] `Build-CisM365Crosswalk.py` runs clean (140 CIS recs, 103 SCuBA policies)
- [x] `Build-Registry.py` runs clean (306 checks, same framework coverage)
- [x] Pester `Invoke-Pester tests/` — 281/281 pass
- [x] Spot-checked SCuBA-first ordering on `CA-MFA-ADMIN-001`, `ENTRA-ADMIN-001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)