### PR TITLE
research(effort): Sprint 4 — false-positive isPhased cleanup + Low/Info QA

### DIFF
--- a/data/effort-overrides.json
+++ b/data/effort-overrides.json
@@ -434,6 +434,39 @@
       "disruptionRisk": true,
       "disruptionScope": "user-facing",
       "_rationale": "Requiring a managed device to register security information prevents users on personal/unmanaged devices from registering new MFA methods. Directly affects users trying to register authenticators from non-managed devices — a deliberate security restriction with user-facing impact."
+    },
+
+    "CA-LEGACYAUTH-001": {
+      "complexity": 3,
+      "isPhased": true,
+      "phaseCount": 2,
+      "disruptionRisk": true,
+      "disruptionScope": "user-facing",
+      "_rationale": "Enabling a CA policy to block legacy authentication protocols (IMAP, POP3, basic auth SMTP) breaks mail clients and apps that have not migrated to modern auth. Two phases: report-only CA policy (identify legacy auth traffic via sign-in logs) → enforce blocking after legacy client remediation. Sprint 4: explicit override added after 'block' keyword removed from _PHASED_NAME_KEYWORDS — this is one of the few legitimate block-keyword phased cases."
+    },
+    "EXO-LOCKBOX-001": {
+      "complexity": 2,
+      "isPhased": false,
+      "phaseCount": 1,
+      "disruptionRisk": false,
+      "_rationale": "Customer Lockbox is a single toggle in the M365 admin center (Settings > Org Settings > Customer Lockbox). Enabling it does not change any data access or security posture immediately — it only requires admin approval before Microsoft support can access tenant data during support cases. No user impact, no disruption. Derivation overcounted via E5 + manual check adjustments."
+    },
+    "SPO-SITE-003": {
+      "complexity": 1,
+      "isPhased": false,
+      "phaseCount": 1,
+      "disruptionRisk": false,
+      "_rationale": "Site collection administrator visibility is an Informational (observe-only) check. The remediation is to review the list of site collection admins — no configuration change is made. Complexity 1 (read-only admin review). Derivation overcounted because impactRating.severity=Informational defaults to base=1 but E5 and weighting bumped it to 3."
+    },
+    "ENTRA-PIM-006": {
+      "isPhased": false,
+      "phaseCount": 1,
+      "_rationale": "Tier-0 role activation duration setting (e.g., max 4 hours) is a single slider in PIM settings. Changing the maximum duration does not require a phased rollout — the new limit applies to future activations only; existing activations are not affected. Complexity=4 is retained (E5 + weighting, appropriate for Tier-0 governance), but isPhased is not warranted for a single-field config change."
+    },
+    "ENTRA-PIM-009": {
+      "isPhased": false,
+      "phaseCount": 1,
+      "_rationale": "Remediating permanent eligible Tier-0 role assignments requires converting each assignment to time-bound in PIM settings. While this requires coordination with each role holder, it is not a sequential phased technical deployment — it is a bulk admin task that can be completed in one change window. Complexity=4 is appropriate; isPhased is not warranted since there is no staged rollout with dwell time between phases."
     }
   }
 }

--- a/data/registry.json
+++ b/data/registry.json
@@ -11702,7 +11702,7 @@
         "scfWeighting": 10
       },
       "effort": {
-        "complexity": 3,
+        "complexity": 1,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
@@ -12631,8 +12631,8 @@
       },
       "effort": {
         "complexity": 4,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       }
@@ -12788,8 +12788,8 @@
       },
       "effort": {
         "complexity": 4,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       }
@@ -15860,7 +15860,7 @@
         "scfWeighting": 10
       },
       "effort": {
-        "complexity": 3,
+        "complexity": 2,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
@@ -26253,8 +26253,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -46185,8 +46185,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -46507,8 +46507,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -47311,8 +47311,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -55172,8 +55172,8 @@
       },
       "effort": {
         "complexity": 3,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
@@ -56014,7 +56014,7 @@
       "effort": {
         "complexity": 3,
         "isPhased": true,
-        "phaseCount": 3,
+        "phaseCount": 2,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
@@ -62389,8 +62389,8 @@
       },
       "effort": {
         "complexity": 3,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       }
@@ -62593,8 +62593,8 @@
       },
       "effort": {
         "complexity": 3,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
@@ -72627,8 +72627,8 @@
       },
       "effort": {
         "complexity": 1,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": false
       }
     },
@@ -82548,8 +82548,8 @@
       },
       "effort": {
         "complexity": 3,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -83010,8 +83010,8 @@
       },
       "effort": {
         "complexity": 3,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -83472,8 +83472,8 @@
       },
       "effort": {
         "complexity": 3,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -93146,8 +93146,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -93288,8 +93288,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -93430,8 +93430,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -93927,8 +93927,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -102380,8 +102380,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -102524,8 +102524,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }
@@ -107401,8 +107401,8 @@
       },
       "effort": {
         "complexity": 2,
-        "isPhased": true,
-        "phaseCount": 3,
+        "isPhased": false,
+        "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
       }

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -357,7 +357,7 @@ def load_az_assess_source_checks(repo_root: Path) -> list[dict]:
 
 _SEVERITY_BASE = {"Critical": 4, "High": 3, "Medium": 2, "Low": 1, "Informational": 1}
 _PHASED_COLLECTORS = {"DNS"}
-_PHASED_NAME_KEYWORDS = {"enforcement", "quarantine", "reject", "block"}
+_PHASED_NAME_KEYWORDS = {"enforcement", "quarantine", "reject"}
 _USER_FACING_COLLECTORS = {"Entra", "CAEvaluator", "SharePoint", "Teams", "Forms", "PowerBI", "Intune"}
 _EMAIL_COLLECTORS = {"ExchangeOnline", "DNS"}
 _AZURE_COLLECTORS = {"AzAssess"}


### PR DESCRIPTION
## Summary

- **Systemic fix**: Removed `block` from `_PHASED_NAME_KEYWORDS` — it was triggering `isPhased=True` on ~20 Windows GPO checks where "Block" is a setting value (e.g., "Enabled: Block All"), not a deployment phase. Phased count: 100 → 80
- **CA-LEGACYAUTH-001**: Explicit override restores `isPhased=True` — legitimate case (report-only CA policy → enforce legacy auth blocking after client audit)
- **4 targeted overrides**: EXO-LOCKBOX-001 (complexity 3→2), SPO-SITE-003 (complexity 3→1, informational check), ENTRA-PIM-006 and ENTRA-PIM-009 (isPhased=False, single config changes not staged rollouts)
- **AzAssess validation**: Random 10-check spot-check of 586 High/Critical AzAssess checks — all complexity and scope values confirmed correct

## Test plan

- [x] `Build-Registry.py` runs cleanly — 1,092 checks, 776 disruption risk, 80 phased
- [x] 10 spot-checks verified (CA-LEGACYAUTH-001 phased=True, EXO-LOCKBOX complexity=2, SPO-SITE-003 complexity=1, PIM checks phased=False, WIN-CONFIG false positives cleared)
- [ ] CI validation on push

## Sprint gate — v2.1.0 research complete

All 4 sprints complete:
- Sprint 1: Schema, derivation foundation, 8 seed overrides
- Sprint 2: Critical/High M365 validation (85 checks, 25 overrides)
- Sprint 3: Medium severity disruption coverage + deep dives (17 overrides, systemic rule fix)
- Sprint 4: Low/Info QA, AzAssess spot-check, false-positive isPhased cleanup

Total overrides: 48 entries across 4 sprints. Override rate trending down sprint-over-sprint ✓

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)