### PR TITLE
feat: add description and homepageUrl to all framework JSON files

### DIFF
--- a/data/frameworks/cis-controls-v8.json
+++ b/data/frameworks/cis-controls-v8.json
@@ -2,6 +2,8 @@
   "frameworkId": "cis-controls-v8",
   "label": "CIS Controls v8.1",
   "version": "8.1",
+  "description": "A prioritized set of 18 safeguards defending against the most prevalent cyber attacks, organized into Implementation Groups (IG1–IG3) based on organizational risk profile.",
+  "homepageUrl": "https://www.cisecurity.org/controls",
   "css": "fw-cis-ctrl",
   "totalControls": 153,
   "registryKey": "cis-controls-v8",

--- a/data/frameworks/cis-m365-v6.json
+++ b/data/frameworks/cis-m365-v6.json
@@ -2,6 +2,8 @@
   "frameworkId": "cis-m365-v6",
   "label": "CIS Microsoft 365 v6.0.1",
   "version": "6.0.1",
+  "description": "Prescriptive configuration recommendations for Microsoft 365 services, organized into L1/L2 profiles and E3/E5 licensing tiers. Maintained by the Center for Internet Security.",
+  "homepageUrl": "https://www.cisecurity.org/benchmark/microsoft_365",
   "css": "fw-cis",
   "totalControls": 139,
   "registryKey": "cis-m365-v6",
@@ -10,15 +12,57 @@
   "scoring": {
     "method": "profile-compliance",
     "profiles": {
-      "E3-L1": { "label": "CIS E3 Level 1", "css": "fw-cis", "profileKey": "E3-L1" },
-      "E3-L2": { "label": "CIS E3 Level 2", "css": "fw-cis-l2", "profileKey": "E3-L2", "colors": { "light": { "background": "#dbeafe", "color": "#1e40af" }, "dark": { "background": "#1E3A5F", "color": "#60A5FA" } } },
-      "E5-L1": { "label": "CIS E5 Level 1", "css": "fw-cis", "profileKey": "E5-L1" },
-      "E5-L2": { "label": "CIS E5 Level 2", "css": "fw-cis-l2", "profileKey": "E5-L2", "colors": { "light": { "background": "#dbeafe", "color": "#1e40af" }, "dark": { "background": "#1E3A5F", "color": "#60A5FA" } } }
+      "E3-L1": {
+        "label": "CIS E3 Level 1",
+        "css": "fw-cis",
+        "profileKey": "E3-L1"
+      },
+      "E3-L2": {
+        "label": "CIS E3 Level 2",
+        "css": "fw-cis-l2",
+        "profileKey": "E3-L2",
+        "colors": {
+          "light": {
+            "background": "#dbeafe",
+            "color": "#1e40af"
+          },
+          "dark": {
+            "background": "#1E3A5F",
+            "color": "#60A5FA"
+          }
+        }
+      },
+      "E5-L1": {
+        "label": "CIS E5 Level 1",
+        "css": "fw-cis",
+        "profileKey": "E5-L1"
+      },
+      "E5-L2": {
+        "label": "CIS E5 Level 2",
+        "css": "fw-cis-l2",
+        "profileKey": "E5-L2",
+        "colors": {
+          "light": {
+            "background": "#dbeafe",
+            "color": "#1e40af"
+          },
+          "dark": {
+            "background": "#1E3A5F",
+            "color": "#60A5FA"
+          }
+        }
+      }
     }
   },
   "colors": {
-    "light": { "background": "#e8f0fe", "color": "#1a56db" },
-    "dark": { "background": "#1E3A5F", "color": "#93C5FD" }
+    "light": {
+      "background": "#e8f0fe",
+      "color": "#1a56db"
+    },
+    "dark": {
+      "background": "#1E3A5F",
+      "color": "#93C5FD"
+    }
   },
   "groupBy": "section-prefix",
   "sections": {

--- a/data/frameworks/cisa-scuba.json
+++ b/data/frameworks/cisa-scuba.json
@@ -2,6 +2,8 @@
   "frameworkId": "cisa-scuba",
   "label": "CISA SCuBA",
   "version": "Baselines",
+  "description": "CISA Secure Cloud Business Applications (SCuBA) project — configuration baselines and assessment tooling for cloud services used by US federal civilian agencies, including Microsoft 365.",
+  "homepageUrl": "https://www.cisa.gov/resources-tools/services/secure-cloud-business-applications-scuba-project",
   "css": "fw-scuba",
   "totalControls": 134,
   "registryKey": "cisa-scuba",

--- a/data/frameworks/cmmc.json
+++ b/data/frameworks/cmmc.json
@@ -2,6 +2,8 @@
   "frameworkId": "cmmc",
   "label": "CMMC 2.0",
   "version": "2.0",
+  "description": "Cybersecurity Maturity Model Certification — DoD framework protecting Controlled Unclassified Information (CUI) across the Defense Industrial Base supply chain. Three maturity levels: L1, L2, L3.",
+  "homepageUrl": "https://dodcio.defense.gov/CMMC/",
   "css": "fw-cmmc",
   "totalControls": 110,
   "registryKey": "cmmc",

--- a/data/frameworks/essential-eight.json
+++ b/data/frameworks/essential-eight.json
@@ -2,8 +2,8 @@
   "frameworkId": "essential-eight",
   "label": "ASD Essential Eight",
   "version": "2023",
-  "publisher": "Australian Signals Directorate (ASD)",
-  "url": "https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/essential-eight",
+  "description": "Eight prioritized mitigation strategies from the Australian Signals Directorate to protect against the most common cyber threats. Organized into three maturity levels (ML1–ML3).",
+  "homepageUrl": "https://www.cyber.gov.au/resources-business-and-government/essential-cyber-security/essential-eight",
   "css": "fw-e8",
   "totalControls": 24,
   "registryKey": "essential-eight",
@@ -63,11 +63,27 @@
   "controlIdFormat": "ML{level}-P{strategy}",
   "m365Coverage": {
     "note": "Essential Eight coverage through M365 configuration assessment focuses on strategies assessable via cloud settings. P8 (Regular Backups) is not mapped because backup validation requires infrastructure-level assessment beyond M365 configuration export.",
-    "mappedStrategies": ["P1", "P2", "P3", "P4", "P5", "P6", "P7"],
-    "unmappedStrategies": ["P8"]
+    "mappedStrategies": [
+      "P1",
+      "P2",
+      "P3",
+      "P4",
+      "P5",
+      "P6",
+      "P7"
+    ],
+    "unmappedStrategies": [
+      "P8"
+    ]
   },
   "colors": {
-    "light": { "background": "#fefce8", "color": "#854d0e" },
-    "dark": { "background": "#713F12", "color": "#FDE047" }
+    "light": {
+      "background": "#fefce8",
+      "color": "#854d0e"
+    },
+    "dark": {
+      "background": "#713F12",
+      "color": "#FDE047"
+    }
   }
 }

--- a/data/frameworks/fedramp.json
+++ b/data/frameworks/fedramp.json
@@ -2,6 +2,8 @@
   "frameworkId": "fedramp",
   "label": "FedRAMP Rev 5",
   "version": "Rev 5",
+  "description": "Federal Risk and Authorization Management Program — US government-wide program standardizing cloud service security assessment and authorization. Based on NIST SP 800-53.",
+  "homepageUrl": "https://www.fedramp.gov/",
   "css": "fw-fedramp",
   "totalControls": 325,
   "registryKey": "fedramp",

--- a/data/frameworks/gdpr.json
+++ b/data/frameworks/gdpr.json
@@ -2,6 +2,8 @@
   "frameworkId": "gdpr",
   "label": "EU GDPR",
   "version": "2016/679",
+  "description": "General Data Protection Regulation — EU regulation governing data protection and privacy for individuals in the EU and EEA, with extraterritorial scope for organizations processing EU residents' data.",
+  "homepageUrl": "https://gdpr.eu/",
   "css": "fw-gdpr",
   "totalControls": 99,
   "registryKey": "gdpr",

--- a/data/frameworks/hipaa.json
+++ b/data/frameworks/hipaa.json
@@ -2,6 +2,8 @@
   "frameworkId": "hipaa",
   "label": "HIPAA",
   "version": "Security Rule",
+  "description": "Health Insurance Portability and Accountability Act — US law governing the protection of protected health information (PHI) across healthcare entities and their business associates.",
+  "homepageUrl": "https://www.hhs.gov/hipaa/index.html",
   "css": "fw-hipaa",
   "totalControls": 59,
   "registryKey": "hipaa",

--- a/data/frameworks/iso-27001.json
+++ b/data/frameworks/iso-27001.json
@@ -2,6 +2,8 @@
   "frameworkId": "iso-27001",
   "label": "ISO 27001:2022",
   "version": "2022",
+  "description": "International standard for information security management systems (ISMS). Specifies requirements for establishing, implementing, maintaining, and continually improving organizational information security.",
+  "homepageUrl": "https://www.iso.org/standard/27001",
   "css": "fw-iso",
   "totalControls": 93,
   "registryKey": "iso-27001",

--- a/data/frameworks/iso-27017.json
+++ b/data/frameworks/iso-27017.json
@@ -2,6 +2,8 @@
   "frameworkId": "iso-27017",
   "label": "ISO 27017:2015",
   "version": "2015",
+  "description": "International standard providing cloud-specific information security control guidelines, supplementing ISO/IEC 27001 with control objectives and implementation guidance for cloud service providers and customers.",
+  "homepageUrl": "https://www.iso.org/standard/43757.html",
   "css": "fw-iso-cloud",
   "totalControls": 132,
   "registryKey": "iso-27017",

--- a/data/frameworks/mitre-attack.json
+++ b/data/frameworks/mitre-attack.json
@@ -2,6 +2,8 @@
   "frameworkId": "mitre-attack",
   "label": "MITRE ATT&CK",
   "version": "v10",
+  "description": "Globally accessible knowledge base of adversary tactics and techniques based on real-world observations. Foundation for threat modeling, detection engineering, and adversary emulation.",
+  "homepageUrl": "https://attack.mitre.org/",
   "css": "fw-mitre",
   "totalControls": 201,
   "registryKey": "mitre-attack",

--- a/data/frameworks/nis2.json
+++ b/data/frameworks/nis2.json
@@ -2,6 +2,8 @@
   "frameworkId": "nis2",
   "label": "EU NIS2",
   "version": "2022/2555",
+  "description": "Network and Information Security Directive 2 — EU directive requiring cybersecurity risk management measures and incident reporting obligations for essential and important entities across EU member states.",
+  "homepageUrl": "https://www.enisa.europa.eu/topics/cybersecurity-policy/nis-directive-new",
   "css": "fw-nis2",
   "totalControls": 30,
   "registryKey": "nis2",

--- a/data/frameworks/nist-800-171.json
+++ b/data/frameworks/nist-800-171.json
@@ -2,6 +2,8 @@
   "frameworkId": "nist-800-171",
   "label": "NIST 800-171 R2",
   "version": "R2",
+  "description": "NIST SP 800-171 — protecting Controlled Unclassified Information (CUI) in non-federal systems. Rev 3 aligns with SP 800-53 and forms the technical basis for CMMC Level 2 requirements.",
+  "homepageUrl": "https://csrc.nist.gov/pubs/sp/800/171/r3/final",
   "css": "fw-nist-cui",
   "totalControls": 110,
   "registryKey": "nist-800-171",

--- a/data/frameworks/nist-800-53-r5.json
+++ b/data/frameworks/nist-800-53-r5.json
@@ -2,6 +2,8 @@
   "frameworkId": "nist-800-53",
   "label": "NIST SP 800-53 Rev 5",
   "version": "5.2.0",
+  "description": "NIST SP 800-53 — comprehensive catalog of security and privacy controls for information systems. Foundation for FedRAMP and widely adopted across US federal and private-sector organizations.",
+  "homepageUrl": "https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final",
   "css": "fw-nist",
   "totalControls": 1189,
   "registryKey": "nist-800-53",
@@ -27,19 +29,43 @@
         "css": "fw-nist-high",
         "profileKey": "High",
         "controlCount": 370,
-        "colors": { "light": { "background": "#dbeafe", "color": "#1e40af" }, "dark": { "background": "#1E3A5F", "color": "#60A5FA" } }
+        "colors": {
+          "light": {
+            "background": "#dbeafe",
+            "color": "#1e40af"
+          },
+          "dark": {
+            "background": "#1E3A5F",
+            "color": "#60A5FA"
+          }
+        }
       },
       "Privacy": {
         "label": "NIST 800-53 Privacy",
         "css": "fw-nist-privacy",
         "profileKey": "Privacy",
         "controlCount": 96,
-        "colors": { "light": { "background": "#ede9fe", "color": "#5b21b6" }, "dark": { "background": "#4C1D95", "color": "#C4B5FD" } }
+        "colors": {
+          "light": {
+            "background": "#ede9fe",
+            "color": "#5b21b6"
+          },
+          "dark": {
+            "background": "#4C1D95",
+            "color": "#C4B5FD"
+          }
+        }
       }
     }
   },
   "colors": {
-    "light": { "background": "#e8f0fe", "color": "#1a56db" },
-    "dark": { "background": "#1E3A5F", "color": "#93C5FD" }
+    "light": {
+      "background": "#e8f0fe",
+      "color": "#1a56db"
+    },
+    "dark": {
+      "background": "#1E3A5F",
+      "color": "#93C5FD"
+    }
   }
 }

--- a/data/frameworks/nist-csf.json
+++ b/data/frameworks/nist-csf.json
@@ -2,6 +2,8 @@
   "frameworkId": "nist-csf",
   "label": "NIST CSF 2.0",
   "version": "2.0",
+  "description": "NIST Cybersecurity Framework — voluntary framework for managing and reducing cybersecurity risk, organized into six functions: Govern, Identify, Protect, Detect, Respond, and Recover.",
+  "homepageUrl": "https://www.nist.gov/cyberframework",
   "css": "fw-csf",
   "totalControls": 106,
   "registryKey": "nist-csf",

--- a/data/frameworks/pci-dss-v4.json
+++ b/data/frameworks/pci-dss-v4.json
@@ -2,6 +2,8 @@
   "frameworkId": "pci-dss",
   "label": "PCI DSS v4.0.1",
   "version": "4.0.1",
+  "description": "Payment Card Industry Data Security Standard — global security standard for organizations handling branded payment cards. Maintained by the PCI Security Standards Council.",
+  "homepageUrl": "https://www.pcisecuritystandards.org/",
   "css": "fw-pci",
   "totalControls": 63,
   "registryKey": "pci-dss",

--- a/data/frameworks/soc2-tsc.json
+++ b/data/frameworks/soc2-tsc.json
@@ -2,6 +2,8 @@
   "frameworkId": "soc2",
   "label": "SOC 2 Trust Services Criteria",
   "version": "2022",
+  "description": "System and Organization Controls 2 — AICPA trust services criteria for service organizations covering security, availability, processing integrity, confidentiality, and privacy.",
+  "homepageUrl": "https://www.aicpa-cima.com/resources/landing/system-and-organization-controls-soc-suite-of-services",
   "css": "fw-soc2",
   "totalControls": 11,
   "registryKey": "soc2",
@@ -59,7 +61,11 @@
   "licensingProfiles": {
     "E3": {
       "label": "Microsoft 365 E3",
-      "excludeChecks": ["ENTRA-PIM-001", "ENTRA-IDRISK-001", "ENTRA-USERRISK-001"]
+      "excludeChecks": [
+        "ENTRA-PIM-001",
+        "ENTRA-IDRISK-001",
+        "ENTRA-USERRISK-001"
+      ]
     },
     "E5": {
       "label": "Microsoft 365 E5",
@@ -67,14 +73,35 @@
     }
   },
   "nonAutomatableCriteria": {
-    "CC1": { "label": "Control Environment", "note": "Requires organizational governance documentation" },
-    "CC2": { "label": "Communication & Information", "note": "Requires policy documentation review" },
-    "CC3": { "label": "Risk Assessment", "note": "Partially automatable via Secure Score (Phase 2)" },
-    "CC4": { "label": "Monitoring Activities", "note": "Partially automatable via Compliance Manager" },
-    "CC9": { "label": "Risk Mitigation", "note": "Requires vendor management and business continuity review" }
+    "CC1": {
+      "label": "Control Environment",
+      "note": "Requires organizational governance documentation"
+    },
+    "CC2": {
+      "label": "Communication & Information",
+      "note": "Requires policy documentation review"
+    },
+    "CC3": {
+      "label": "Risk Assessment",
+      "note": "Partially automatable via Secure Score (Phase 2)"
+    },
+    "CC4": {
+      "label": "Monitoring Activities",
+      "note": "Partially automatable via Compliance Manager"
+    },
+    "CC9": {
+      "label": "Risk Mitigation",
+      "note": "Requires vendor management and business continuity review"
+    }
   },
   "colors": {
-    "light": { "background": "#eff6ff", "color": "#1e3a5f" },
-    "dark": { "background": "#1E3A5F", "color": "#60A5FA" }
+    "light": {
+      "background": "#eff6ff",
+      "color": "#1e3a5f"
+    },
+    "dark": {
+      "background": "#1E3A5F",
+      "color": "#60A5FA"
+    }
   }
 }

--- a/data/frameworks/stig.json
+++ b/data/frameworks/stig.json
@@ -2,6 +2,8 @@
   "frameworkId": "stig",
   "label": "DISA STIG",
   "version": "M365",
+  "description": "Security Technical Implementation Guides — prescriptive DoD hardening configuration requirements for software, hardware, and operating systems used in US defense and federal environments.",
+  "homepageUrl": "https://public.cyber.mil/stigs/",
   "css": "fw-stig",
   "totalControls": 148,
   "registryKey": "stig",


### PR DESCRIPTION
## Summary

- Adds `description` and `homepageUrl` fields to all 18 framework definition files
- Downstream consumers (M365-Assess) can display framework blurbs and official links without their own hardcoded lookup tables
- Normalizes `essential-eight.json`: renames `url` → `homepageUrl`, removes `publisher` (covered by `label`)
- Both fields are optional — existing consumers that don't use them are unaffected

## Frameworks updated (18)

`cis-m365-v6`, `cis-controls-v8`, `cisa-scuba`, `cmmc`, `essential-eight`, `fedramp`, `gdpr`, `hipaa`, `iso-27001`, `iso-27017`, `mitre-attack`, `nis2`, `nist-800-171`, `nist-800-53`, `nist-csf`, `pci-dss`, `soc2`, `stig`

## Test plan

- [x] All 18 framework files updated with correct `description` and `homepageUrl`
- [x] `essential-eight.json` legacy `url`/`publisher` fields removed; `homepageUrl` normalized
- [x] Existing Pester tests unaffected (only check `frameworkId` and `scoring` structure)
- [ ] CI validation on push

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)