### PR TITLE
feat: add L1/L2/L3 profile tags to CMMC framework entries

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -243,7 +243,12 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "CAL2.-3.12.1;CAL2.-3.12.3;RA.L3-3.11.1E;SI.L3-3.14.6E;SIL2.-3.14.3"
+          "controlId": "CAL2.-3.12.1;CAL2.-3.12.3;RA.L3-3.11.1E;SI.L3-3.14.6E;SIL2.-3.14.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "CA-07;CA-07(01);PM-14;PM-15;SI-05;SI-05(01)"
@@ -464,7 +469,12 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "CAL2.-3.12.1;RA.L3-3.11.1E;RA.L3-3.11.5E;RAL2.-3.11.1"
+          "controlId": "CAL2.-3.12.1;RA.L3-3.11.1E;RA.L3-3.11.5E;RAL2.-3.11.1",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "CA-02;CM-04(02);RA-03"
@@ -650,7 +660,11 @@
           "controlId": "15.4;15.5;5.6"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.5"
+          "controlId": "IAL2.-3.5.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-04;SA-09"
@@ -852,7 +866,11 @@
           "controlId": "12.5;5.5;5.6;6.1;6.2;6.7"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IAL2.-3.5.1;IAL2.-3.5.2"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IAL2.-3.5.1;IAL2.-3.5.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;IA-02;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -1047,7 +1065,11 @@
           "controlId": "10.3;10.4;10.5;12.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.5;5.6;6.3;6.4;6.7"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;ACL2.-3.1.1;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "AC.L1-B.1.I;ACL2.-3.1.1;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML1-P6;ML1-P7;ML2-P3;ML2-P5;ML2-P6;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -1247,7 +1269,12 @@
           "controlId": "12.5;5.2;5.5;5.6;6.3;6.4;6.7"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;ACL2.-3.1.1;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.3;IAL2.-3.5.4;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "AC.L1-B.1.I;ACL2.-3.1.1;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.3;IAL2.-3.5.4;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -1446,7 +1473,12 @@
           "controlId": "12.5;5.2;5.5;5.6;6.3;6.4;6.7"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;ACL2.-3.1.1;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.3;IAL2.-3.5.4;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "AC.L1-B.1.I;ACL2.-3.1.1;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.3;IAL2.-3.5.4;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -1633,7 +1665,11 @@
           "controlId": "12.5;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -1813,7 +1849,11 @@
           "controlId": "12.5;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -1993,7 +2033,11 @@
           "controlId": "12.5;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;IA-08;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -2190,7 +2234,12 @@
           "controlId": "12.6;13.4;3.3;4.6;5.2;6.3;6.4"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2263,7 +2312,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "AC.L2-3.1.1",
-          "title": "Limit system access to authorized users"
+          "title": "Limit system access to authorized users",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -2297,7 +2350,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "IA.L2-3.5.1",
-          "title": "Identify information system users, processes acting on behalf of users, and devices"
+          "title": "Identify information system users, processes acting on behalf of users, and devices",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -2332,7 +2389,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2395,7 +2456,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2458,7 +2523,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2521,7 +2590,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2584,7 +2657,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2647,7 +2724,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2710,7 +2791,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2773,7 +2858,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2836,7 +2925,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2899,7 +2992,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -2962,7 +3059,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -3025,7 +3126,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -3088,7 +3193,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -3151,7 +3260,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -3214,7 +3327,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -3375,7 +3492,11 @@
           "controlId": "5.2;6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -3567,7 +3688,11 @@
           "controlId": "5.2;6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -3759,7 +3884,11 @@
           "controlId": "4.3;5.2;6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.10;IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "ACL2.-3.1.10;IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -3948,7 +4077,11 @@
           "controlId": "5.2;6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -4134,7 +4267,11 @@
           "controlId": "5.2;6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -4320,7 +4457,11 @@
           "controlId": "5.2;5.4;6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "ACL2.-3.1.5;IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML1-P4;ML2-P3;ML2-P4;ML3-P3;ML3-P4"
@@ -4500,7 +4641,11 @@
           "controlId": "5.2;6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -4669,7 +4814,12 @@
           "controlId": "12.5;5.2;5.5;5.6;6.3;6.4;6.7"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;ACL2.-3.1.1;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.3;IAL2.-3.5.4;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "AC.L1-B.1.I;ACL2.-3.1.1;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L1-B.1.VI[a];IA.L1-B.1.VI[b];IA.L1-B.1.VI[c];IA.L1-B.1.V[a];IA.L1-B.1.V[c];IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.3;IAL2.-3.5.4;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -4749,7 +4899,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "IA.L2-3.5.2",
-          "title": "Authenticate the identities of users, processes, and devices"
+          "title": "Authenticate the identities of users, processes, and devices",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -5034,7 +5188,11 @@
           "controlId": "6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -5228,7 +5386,12 @@
           "controlId": "3.3;6.0;6.8"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L3-3.1.2E;ACL2.-3.1.1;ACL2.-3.1.2;ACL2.-3.1.3"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L3-3.1.2E;ACL2.-3.1.1;ACL2.-3.1.2;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -5425,7 +5588,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -5632,7 +5799,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -5837,7 +6008,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6042,7 +6217,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6123,7 +6302,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6190,7 +6373,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6257,7 +6444,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6323,7 +6514,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6389,7 +6584,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6456,7 +6655,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6523,7 +6726,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6590,7 +6797,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6657,7 +6868,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6724,7 +6939,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6791,7 +7010,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6858,7 +7081,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6925,7 +7152,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -6992,7 +7223,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -7059,7 +7294,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -7126,7 +7365,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -7193,7 +7436,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -7260,7 +7507,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -7327,7 +7578,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -7394,7 +7649,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01);IA-12(04)"
@@ -7461,7 +7720,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01);IA-12(04)"
@@ -7528,7 +7791,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01);IA-12(04)"
@@ -7595,7 +7862,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01);IA-12(04)"
@@ -7746,7 +8017,11 @@
           "controlId": "3.1;3.11;3.6;3.9;5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9;SCL2.-3.13.11"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9;SCL2.-3.13.11",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01);IA-05(07);SC-08(01);SC-08(02);SC-13"
@@ -7902,7 +8177,11 @@
           "controlId": "4.7;5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -8058,7 +8337,11 @@
           "controlId": "4.7;5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -8219,7 +8502,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.2;5.3"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.6;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.6;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P4;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -8529,7 +8816,11 @@
           "controlId": "4.3"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.10;ACL2.-3.1.11"
+          "controlId": "ACL2.-3.1.10;ACL2.-3.1.11",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02(05);AC-11;AC-12;IA-11"
@@ -8593,7 +8884,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "AC.L2-3.1.1; AC.L2-3.1.5",
-          "title": "Limit system access to authorized users and enforce least privilege"
+          "title": "Limit system access to authorized users and enforce least privilege",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -8627,7 +8922,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "AC.L2-3.1.5",
-          "title": "Employ the principle of least privilege"
+          "title": "Employ the principle of least privilege",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -8661,7 +8960,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "AC.L2-3.1.2",
-          "title": "Limit system access to the types of transactions and functions authorized users are permitted to execute"
+          "title": "Limit system access to the types of transactions and functions authorized users are permitted to execute",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -8999,7 +9302,11 @@
           "controlId": "6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -9386,7 +9693,11 @@
           "controlId": "6.1;6.2;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-08;SI-10"
@@ -9777,7 +10088,11 @@
           "controlId": "5.4;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -10166,7 +10481,11 @@
           "controlId": "5.4;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -10561,7 +10880,11 @@
           "controlId": "5.3;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;IAL2.-3.5.6"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;IAL2.-3.5.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P4;ML3-P4"
@@ -10940,7 +11263,11 @@
           "controlId": "5.4;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -11298,7 +11625,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.3"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.6"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P4;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -11659,7 +11990,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-06"
@@ -11727,7 +12062,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02"
@@ -11873,7 +12212,11 @@
           "controlId": "5.0;5.3;5.6;6.0"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V;IA.L1-B.1.VI;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.6"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V;IA.L1-B.1.VI;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P4;ML3-P4"
@@ -12040,7 +12383,11 @@
           "controlId": "5.0;5.3;5.6;6.0"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V;IA.L1-B.1.VI;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.6"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.1;ACL2.-3.1.2;IA.L1-B.1.V;IA.L1-B.1.VI;IAL2.-3.5.1;IAL2.-3.5.2;IAL2.-3.5.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P4;ML3-P4"
@@ -12228,7 +12575,11 @@
           "controlId": "6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-02(02);AC-03;AC-05;IA-12(04);SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -12421,7 +12772,11 @@
           "controlId": "11.0;11.1"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-02(02);CP-01;CP-02;CP-10;IR-04(03);PM-08"
@@ -12585,7 +12940,11 @@
           "controlId": "5.3"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;IAL2.-3.5.6"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;IAL2.-3.5.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P4;ML3-P4"
@@ -12736,7 +13095,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -12910,7 +13273,11 @@
           "controlId": "4.7;5.2;5.3"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;IAL2.-3.5.6;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;IAL2.-3.5.6;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P4;ML3-P4"
@@ -13074,7 +13441,11 @@
           "controlId": "5.3;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5;IAL2.-3.5.6"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5;IAL2.-3.5.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13264,7 +13635,11 @@
           "controlId": "10.3;10.4;10.5;13.0;13.1;13.6;16.7;3.14;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;8.0;8.1;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;AUL2.-3.3.1;AUL2.-3.3.2;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;CML2.-3.4.1;CML2.-3.4.2;SIL2.-3.14.3;SIL2.-3.14.6"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;AUL2.-3.3.1;AUL2.-3.3.2;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;CML2.-3.4.1;CML2.-3.4.2;SIL2.-3.14.3;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P3;ML2-P5;ML2-P6;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -13341,7 +13716,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13396,7 +13775,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13451,7 +13834,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13506,7 +13893,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13561,7 +13952,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13616,7 +14011,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13671,7 +14070,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13725,7 +14128,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13779,7 +14186,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13833,7 +14244,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13887,7 +14302,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13942,7 +14361,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -13996,7 +14419,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -14163,7 +14590,11 @@
           "controlId": "15.4;15.5;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -14374,7 +14805,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -14593,7 +15028,11 @@
           "controlId": "12.7"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.12;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.12;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;AC-17;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -14794,7 +15233,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -15010,7 +15453,11 @@
           "controlId": "12.7"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.12;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.12;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;AC-17;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -15211,7 +15658,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -15422,7 +15873,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -15616,7 +16071,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -15802,7 +16261,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -16009,7 +16472,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -16217,7 +16684,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -16422,7 +16893,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -16612,7 +17087,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -16807,7 +17286,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -16997,7 +17480,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17084,7 +17571,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17160,7 +17651,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17236,7 +17731,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17312,7 +17811,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17388,7 +17891,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17464,7 +17971,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17540,7 +18051,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17616,7 +18131,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17692,7 +18211,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17768,7 +18291,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17844,7 +18371,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17920,7 +18451,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -17996,7 +18531,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18072,7 +18611,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18148,7 +18691,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18224,7 +18771,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18300,7 +18851,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18376,7 +18931,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18452,7 +19011,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18528,7 +19091,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18604,7 +19171,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18680,7 +19251,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18756,7 +19331,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18832,7 +19411,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18908,7 +19491,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -18984,7 +19571,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19060,7 +19651,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19136,7 +19731,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19212,7 +19811,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19288,7 +19891,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19364,7 +19971,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19440,7 +20051,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19516,7 +20131,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19592,7 +20211,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19668,7 +20291,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19744,7 +20371,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19820,7 +20451,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19896,7 +20531,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -19972,7 +20611,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20048,7 +20691,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20124,7 +20771,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20200,7 +20851,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20276,7 +20931,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20352,7 +21011,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20428,7 +21091,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20504,7 +21171,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20580,7 +21251,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20656,7 +21331,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20732,7 +21411,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20808,7 +21491,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20884,7 +21571,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -20960,7 +21651,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21036,7 +21731,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21112,7 +21811,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21188,7 +21891,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21264,7 +21971,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21340,7 +22051,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21416,7 +22131,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21492,7 +22211,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21568,7 +22291,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21644,7 +22371,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21720,7 +22451,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21796,7 +22531,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21872,7 +22611,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -21948,7 +22691,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22024,7 +22771,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22100,7 +22851,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22176,7 +22931,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22252,7 +23011,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22328,7 +23091,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22404,7 +23171,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22480,7 +23251,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22556,7 +23331,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22632,7 +23411,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22708,7 +23491,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22784,7 +23571,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22860,7 +23651,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -22936,7 +23731,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23012,7 +23811,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23088,7 +23891,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23164,7 +23971,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23240,7 +24051,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23316,7 +24131,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23392,7 +24211,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23468,7 +24291,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23544,7 +24371,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23620,7 +24451,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23696,7 +24531,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23772,7 +24611,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23848,7 +24691,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -23924,7 +24771,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24000,7 +24851,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24076,7 +24931,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24152,7 +25011,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24228,7 +25091,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24304,7 +25171,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24380,7 +25251,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24456,7 +25331,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24532,7 +25411,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24608,7 +25491,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24684,7 +25571,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24760,7 +25651,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24836,7 +25731,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24912,7 +25811,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -24988,7 +25891,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25064,7 +25971,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25140,7 +26051,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25216,7 +26131,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25292,7 +26211,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25368,7 +26291,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25444,7 +26371,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25520,7 +26451,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25596,7 +26531,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25672,7 +26611,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25748,7 +26691,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25824,7 +26771,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25900,7 +26851,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -25976,7 +26931,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -26052,7 +27011,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -26128,7 +27091,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -26204,7 +27171,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -26383,7 +27354,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -26575,7 +27550,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -26770,7 +27749,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.6"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -26977,7 +27960,11 @@
           "controlId": "15.4;15.5;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -27185,7 +28172,11 @@
           "controlId": "15.4;15.5;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -27368,7 +28359,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -27548,7 +28543,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -27728,7 +28727,11 @@
           "controlId": "2.7;5.1;5.4;5.5"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -27913,7 +28916,11 @@
           "controlId": "2.7;5.1;5.4;5.5"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -28099,7 +29106,11 @@
           "controlId": "2.7;5.1;5.4;5.5"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -28259,7 +29270,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.6;SC.L2-3.13.3"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.6;SC.L2-3.13.3",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -28434,7 +29449,11 @@
           "controlId": "5.4;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -28626,7 +29645,11 @@
           "controlId": "5.4;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -28785,7 +29808,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -28957,7 +29984,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -29142,7 +30173,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -29309,7 +30344,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "ACL2.-3.1.5;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML1-P6;ML1-P7;ML2-P4;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -29480,7 +30519,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "ACL2.-3.1.5;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML1-P6;ML1-P7;ML2-P4;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -29650,7 +30693,12 @@
           "controlId": "12.6;13.4;3.3;4.6;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;ACL2.-3.1.5"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -29815,7 +30863,12 @@
           "controlId": "12.6;13.4;3.3;4.6;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;ACL2.-3.1.5"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -29976,7 +31029,12 @@
           "controlId": "12.6;13.4;3.3;4.6;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;ACL2.-3.1.5"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -30137,7 +31195,12 @@
           "controlId": "12.6;13.4;3.3;4.6;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;ACL2.-3.1.5"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -30302,7 +31365,11 @@
           "controlId": "4.7;5.2;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "ACL2.-3.1.5;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -30472,7 +31539,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -30655,7 +31726,11 @@
           "controlId": "15.4;15.5;5.4;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -30830,7 +31905,11 @@
           "controlId": "5.4;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -31001,7 +32080,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -31173,7 +32256,11 @@
           "controlId": "5.4;6.1;6.2"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -31326,7 +32413,11 @@
           "controlId": "2.7;5.1;5.2;5.4;5.5"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "ACL2.-3.1.5;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -31488,7 +32579,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -31682,7 +32777,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;ACL2.-3.1.7;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;ACL2.-3.1.7;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -31875,7 +32974,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;ACL2.-3.1.7;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;ACL2.-3.1.7;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -32068,7 +33171,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;ACL2.-3.1.7;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;ACL2.-3.1.7;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -32244,7 +33351,11 @@
           "controlId": "2.3;2.5;2.6;2.7;4.0;4.6;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.6;CML2.-3.4.8"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.6;CML2.-3.4.8",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML1-P5;ML2-P4;ML2-P5;ML3-P4;ML3-P5"
@@ -32427,7 +33538,11 @@
           "controlId": "4.1"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.8"
+          "controlId": "ACL2.-3.1.8",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-07"
@@ -32628,7 +33743,11 @@
           "controlId": "13.0;13.1;13.6;3.14;4.1;8.0;8.1;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.8;AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;SIL2.-3.14.6"
+          "controlId": "ACL2.-3.1.8;AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-07;AU-01;AU-02;AU-06;IR-04(04);SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -32802,7 +33921,11 @@
           "controlId": "4.3"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.10;ACL2.-3.1.11"
+          "controlId": "ACL2.-3.1.10;ACL2.-3.1.11",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02(05);AC-11;AC-12"
@@ -32981,7 +34104,11 @@
           "controlId": "4.3"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.10;ACL2.-3.1.11"
+          "controlId": "ACL2.-3.1.10;ACL2.-3.1.11",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02(05);AC-11;AC-12"
@@ -33159,7 +34286,11 @@
           "controlId": "4.3"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.10;ACL2.-3.1.11"
+          "controlId": "ACL2.-3.1.10;ACL2.-3.1.11",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02(05);AC-11;AC-12"
@@ -33353,7 +34484,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)"
@@ -33557,7 +34692,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)"
@@ -33761,7 +34900,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;PSL2.-3.9.2;SIL2.-3.14.7",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-02(12);AC-02(13);IR-04(13);PS-04;SI-04(11)"
@@ -33941,7 +35084,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "ACL2.-3.1.4"
+          "controlId": "ACL2.-3.1.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-05"
@@ -34165,7 +35312,11 @@
           "controlId": "14.3;14.7;14.8"
         },
         "cmmc": {
-          "controlId": "ATL2.-3.2.1"
+          "controlId": "ATL2.-3.2.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AT-02"
@@ -34350,7 +35501,12 @@
           "controlId": "1.0;1.1;1.3;10.3;10.4;10.5;16.7;2.0;2.1;2.2;2.4;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AC.L3-3.1.2E;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML1-P6;ML1-P7;ML2-P1;ML2-P2;ML2-P5;ML2-P6;ML2-P7;ML3-P1;ML3-P2;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -34548,7 +35704,12 @@
           "controlId": "1.0;1.1;1.3;12.5;2.0;2.1;2.2;2.4;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2"
+          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -34730,7 +35891,12 @@
           "controlId": "1.0;1.1;1.3;2.0;2.1;2.2;2.4;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1"
+          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -34889,7 +36055,12 @@
           "controlId": "1.0;1.1;2.0;2.1;2.2;2.4;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;CM.L3-3.4.1E;CM.L3-3.4.3E;CML2.-3.4.1"
+          "controlId": "AC.L3-3.1.2E;CM.L3-3.4.1E;CM.L3-3.4.3E;CML2.-3.4.1",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -35052,7 +36223,12 @@
           "controlId": "1.0;1.1;2.0;2.1;2.2;2.4;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;CM.L3-3.4.1E;CM.L3-3.4.3E;CML2.-3.4.1"
+          "controlId": "AC.L3-3.1.2E;CM.L3-3.4.1E;CM.L3-3.4.3E;CML2.-3.4.1",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -35261,7 +36437,11 @@
           "controlId": "11.0;11.3;2.7;3.0;3.1;3.3;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;MP.L1-B.1.VII;MPL2.-3.8.1;MPL2.-3.8.3"
+          "controlId": "ACL2.-3.1.5;MP.L1-B.1.VII;MPL2.-3.8.1;MPL2.-3.8.3",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -35452,7 +36632,11 @@
           "controlId": "13.5;3.1;3.3;9.6"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.3;MPL2.-3.8.2;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "ACL2.-3.1.3;MPL2.-3.8.2;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "MP-02;SC-07;SC-07(09);SC-07(10);SC-07(11)"
@@ -35599,7 +36783,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.4;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "MPL2.-3.8.4;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "MP-03;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -35808,7 +36996,11 @@
           "controlId": "11.0;11.3;2.7;3.0;3.1;3.3;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;MP.L1-B.1.VII;MPL2.-3.8.1;MPL2.-3.8.3"
+          "controlId": "ACL2.-3.1.5;MP.L1-B.1.VII;MPL2.-3.8.1;MPL2.-3.8.3",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -35969,7 +37161,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "MPL2.-3.8.7"
+          "controlId": "MPL2.-3.8.7",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "MP-07;SC-08(02)"
@@ -36189,7 +37385,12 @@
           "controlId": "12.5"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.III;AC.L1-B.1.III[a];AC.L1-B.1.III[b];AC.L1-B.1.III[c];AC.L1-B.1.III[d];AC.L1-B.1.III[e];AC.L1-B.1.III[f];ACL2.-3.1.20;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2"
+          "controlId": "AC.L1-B.1.III;AC.L1-B.1.III[a];AC.L1-B.1.III[b];AC.L1-B.1.III[c];AC.L1-B.1.III[d];AC.L1-B.1.III[e];AC.L1-B.1.III[f];ACL2.-3.1.20;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-20;IA-03;IA-03(04)"
@@ -36423,7 +37624,12 @@
           "controlId": "12.5"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.III;AC.L1-B.1.III[a];AC.L1-B.1.III[b];AC.L1-B.1.III[c];AC.L1-B.1.III[d];AC.L1-B.1.III[e];AC.L1-B.1.III[f];ACL2.-3.1.20;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2"
+          "controlId": "AC.L1-B.1.III;AC.L1-B.1.III[a];AC.L1-B.1.III[b];AC.L1-B.1.III[c];AC.L1-B.1.III[d];AC.L1-B.1.III[e];AC.L1-B.1.III[f];ACL2.-3.1.20;IA.L1-B.1.V;IA.L1-B.1.VI;IA.L3-3.5.1E;IAL2.-3.5.1;IAL2.-3.5.2",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-20;IA-03;IA-03(04)"
@@ -36599,7 +37805,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.III;AC.L1-B.1.III[a];AC.L1-B.1.III[b];AC.L1-B.1.III[c];AC.L1-B.1.III[d];AC.L1-B.1.III[e];AC.L1-B.1.III[f];ACL2.-3.1.20;ACL2.-3.1.21"
+          "controlId": "AC.L1-B.1.III;AC.L1-B.1.III[a];AC.L1-B.1.III[b];AC.L1-B.1.III[c];AC.L1-B.1.III[d];AC.L1-B.1.III[e];AC.L1-B.1.III[f];ACL2.-3.1.20;ACL2.-3.1.21",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-20;AC-20(02)"
@@ -36764,7 +37974,11 @@
           "controlId": "3.3"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;AC-21;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -36951,7 +38165,11 @@
           "controlId": "3.3"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;AC-21;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -37174,7 +38392,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.IV;AC.L1-B.1.IV[a];AC.L1-B.1.IV[b];AC.L1-B.1.IV[c];AC.L1-B.1.IV[d];AC.L1-B.1.IV[e];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.22;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.IV;AC.L1-B.1.IV[a];AC.L1-B.1.IV[b];AC.L1-B.1.IV[c];AC.L1-B.1.IV[d];AC.L1-B.1.IV[e];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.22;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;AC-22;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -37388,7 +38610,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.IV;AC.L1-B.1.IV[a];AC.L1-B.1.IV[b];AC.L1-B.1.IV[c];AC.L1-B.1.IV[d];AC.L1-B.1.IV[e];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.22;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.IV;AC.L1-B.1.IV[a];AC.L1-B.1.IV[b];AC.L1-B.1.IV[c];AC.L1-B.1.IV[d];AC.L1-B.1.IV[e];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.22;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;AC-22;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -37602,7 +38828,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.IV;AC.L1-B.1.IV[a];AC.L1-B.1.IV[b];AC.L1-B.1.IV[c];AC.L1-B.1.IV[d];AC.L1-B.1.IV[e];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.22;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.IV;AC.L1-B.1.IV[a];AC.L1-B.1.IV[b];AC.L1-B.1.IV[c];AC.L1-B.1.IV[d];AC.L1-B.1.IV[e];AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.22;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;AC-22;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -37806,7 +39036,11 @@
           "controlId": "13.5;9.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.IV;AC.L1-B.1.IV[a];AC.L1-B.1.IV[b];AC.L1-B.1.IV[c];AC.L1-B.1.IV[d];AC.L1-B.1.IV[e];ACL2.-3.1.22;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "AC.L1-B.1.IV;AC.L1-B.1.IV[a];AC.L1-B.1.IV[b];AC.L1-B.1.IV[c];AC.L1-B.1.IV[d];AC.L1-B.1.IV[e];ACL2.-3.1.22;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-22;SC-07;SC-07(09);SC-07(11)"
@@ -37873,7 +39107,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "CM.L2-3.4.1",
-          "title": "Establish and maintain baseline configurations and inventories"
+          "title": "Establish and maintain baseline configurations and inventories",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -38120,7 +39358,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;AUL2.-3.3.3;AUL2.-3.3.6;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AC.L1-B.1.II;AC.L1-B.1.II[a];AC.L1-B.1.II[b];ACL2.-3.1.2;AUL2.-3.3.3;AUL2.-3.3.6;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38200,7 +39442,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "CM.L2-3.4.2",
-          "title": "Establish and enforce security configuration settings"
+          "title": "Establish and enforce security configuration settings",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -38235,7 +39481,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38315,7 +39565,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38396,7 +39650,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38476,7 +39734,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38556,7 +39818,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38636,7 +39902,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38716,7 +39986,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38797,7 +40071,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38878,7 +40156,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -38959,7 +40241,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39040,7 +40326,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39121,7 +40411,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39202,7 +40496,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39283,7 +40581,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39364,7 +40666,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39445,7 +40751,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39526,7 +40836,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39607,7 +40921,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39688,7 +41006,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39769,7 +41091,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39850,7 +41176,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -39931,7 +41261,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40012,7 +41346,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40093,7 +41431,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40174,7 +41516,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40255,7 +41601,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40336,7 +41686,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40416,7 +41770,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40496,7 +41854,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40576,7 +41938,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40656,7 +42022,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40736,7 +42106,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40816,7 +42190,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40896,7 +42274,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -40977,7 +42359,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41058,7 +42444,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41138,7 +42528,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41218,7 +42612,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41299,7 +42697,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41380,7 +42782,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41461,7 +42867,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41542,7 +42952,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41622,7 +43036,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41702,7 +43120,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41782,7 +43204,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41863,7 +43289,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -41944,7 +43374,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42024,7 +43458,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42105,7 +43543,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42186,7 +43628,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42266,7 +43712,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42347,7 +43797,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42428,7 +43882,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42509,7 +43967,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42589,7 +44051,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42670,7 +44136,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42750,7 +44220,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42831,7 +44305,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42911,7 +44389,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -42991,7 +44473,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43072,7 +44558,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43153,7 +44643,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43234,7 +44728,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43315,7 +44813,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43395,7 +44897,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43475,7 +44981,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43556,7 +45066,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43637,7 +45151,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43718,7 +45236,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43799,7 +45321,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43880,7 +45406,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -43961,7 +45491,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44042,7 +45576,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44123,7 +45661,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44204,7 +45746,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44285,7 +45831,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44366,7 +45916,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44447,7 +46001,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44527,7 +46085,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44607,7 +46169,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44687,7 +46253,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44768,7 +46338,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44848,7 +46422,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -44928,7 +46506,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45009,7 +46591,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45089,7 +46675,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45169,7 +46759,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45249,7 +46843,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45329,7 +46927,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45409,7 +47011,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45489,7 +47095,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45569,7 +47179,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45649,7 +47263,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45729,7 +47347,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45809,7 +47431,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45889,7 +47515,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -45969,7 +47599,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46050,7 +47684,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46131,7 +47769,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46212,7 +47854,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46293,7 +47939,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46373,7 +48023,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46453,7 +48107,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46534,7 +48192,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46614,7 +48276,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46694,7 +48360,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46774,7 +48444,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46854,7 +48528,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -46934,7 +48612,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47014,7 +48696,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47095,7 +48781,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47176,7 +48866,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47257,7 +48951,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47338,7 +49036,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47418,7 +49120,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47498,7 +49204,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47578,7 +49288,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47658,7 +49372,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47738,7 +49456,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47818,7 +49540,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47898,7 +49624,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -47979,7 +49709,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48060,7 +49794,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48141,7 +49879,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48222,7 +49964,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48302,7 +50048,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48382,7 +50132,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48462,7 +50216,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48543,7 +50301,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48624,7 +50386,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48704,7 +50470,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48785,7 +50555,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48865,7 +50639,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -48945,7 +50723,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49025,7 +50807,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49105,7 +50891,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49185,7 +50975,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49265,7 +51059,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49345,7 +51143,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49425,7 +51227,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49505,7 +51311,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49585,7 +51395,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49665,7 +51479,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49745,7 +51563,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49825,7 +51647,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49905,7 +51731,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -49985,7 +51815,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50065,7 +51899,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50145,7 +51983,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50226,7 +52068,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50307,7 +52153,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50387,7 +52237,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50467,7 +52321,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50547,7 +52405,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50627,7 +52489,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50707,7 +52573,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50787,7 +52657,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50867,7 +52741,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -50947,7 +52825,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51027,7 +52909,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51107,7 +52993,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51187,7 +53077,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51267,7 +53161,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51347,7 +53245,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51427,7 +53329,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51507,7 +53413,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51587,7 +53497,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51667,7 +53581,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51747,7 +53665,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51827,7 +53749,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51907,7 +53833,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -51987,7 +53917,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52068,7 +54002,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52148,7 +54086,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52229,7 +54171,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52309,7 +54255,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52390,7 +54340,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52470,7 +54424,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52551,7 +54509,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52631,7 +54593,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52711,7 +54677,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52791,7 +54761,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52871,7 +54845,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -52951,7 +54929,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -53129,7 +55111,12 @@
           "controlId": "10.3;10.4;10.5;16.7;2.3;2.4;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CM.L3-3.4.2E;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CM.L3-3.4.2E;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -53315,7 +55302,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -53528,7 +55519,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.2;6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.3;IAL2.-3.5.8;IAL2.-3.5.9;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML1-P6;ML1-P7;ML2-P3;ML2-P5;ML2-P6;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -53724,7 +55719,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.2"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -53919,7 +55918,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.0;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;CML2.-3.4.6"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -54109,7 +56112,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.2"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -54290,7 +56297,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.0;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;CML2.-3.4.6"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -54471,7 +56482,11 @@
           "controlId": "10.3;10.4;10.5;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;5.2"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -54682,7 +56697,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;CML2.-3.4.9"
+          "controlId": "CML2.-3.4.6;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;CM-11;CM-11(02)"
@@ -54894,7 +56913,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -55120,7 +57143,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.18;CML2.-3.4.6"
+          "controlId": "ACL2.-3.1.18;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-19;CM-07"
@@ -55323,7 +57350,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -55547,7 +57578,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;CML2.-3.4.6;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;CML2.-3.4.6;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;CM-07;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -55752,7 +57787,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -55960,7 +57999,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -56164,7 +58207,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -56372,7 +58419,11 @@
           "controlId": "4.0;4.6;4.7;4.8;5.2"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;IA-05;IA-05(01)"
@@ -56585,7 +58636,11 @@
           "controlId": "4.0;4.6;4.7;4.8;5.2"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;IA-05;IA-05(01)"
@@ -56796,7 +58851,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;CML2.-3.4.9"
+          "controlId": "CML2.-3.4.6;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;CM-11;CM-11(02)"
@@ -57000,7 +59059,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -57211,7 +59274,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -57415,7 +59482,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -57641,7 +59712,11 @@
           "controlId": "12.5;4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;IA-08"
@@ -57866,7 +59941,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.18;CML2.-3.4.6"
+          "controlId": "ACL2.-3.1.18;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-19;CM-07"
@@ -58075,7 +60154,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;CML2.-3.4.9"
+          "controlId": "CML2.-3.4.6;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;CM-11;CM-11(02)"
@@ -58280,7 +60363,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;CML2.-3.4.9"
+          "controlId": "CML2.-3.4.6;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;CM-11;CM-11(02)"
@@ -58487,7 +60574,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -58700,7 +60791,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -58908,7 +61003,11 @@
           "controlId": "4.0;4.6;4.8;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SI-08"
@@ -59110,7 +61209,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -59320,7 +61423,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -59525,7 +61632,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -59733,7 +61844,11 @@
           "controlId": "4.0;4.6;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -59944,7 +62059,11 @@
           "controlId": "4.0;4.6;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -60159,7 +62278,11 @@
           "controlId": "4.0;4.6;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -60370,7 +62493,11 @@
           "controlId": "4.0;4.6;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -60585,7 +62712,11 @@
           "controlId": "4.0;4.6;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -60800,7 +62931,11 @@
           "controlId": "4.0;4.6;4.8;5.4"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;ACL2.-3.1.5;CML2.-3.4.6;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -61014,7 +63149,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -61222,7 +63361,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -61460,7 +63603,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;4.0;4.6;4.8;7.0;7.1;7.3;7.4"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "CML2.-3.4.6;RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -61704,7 +63851,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;4.0;4.6;4.8;7.0;7.1;7.3;7.4"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "CML2.-3.4.6;RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -61918,7 +64069,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -62126,7 +64281,11 @@
           "controlId": "13.5;3.13;4.0;4.6;4.8;9.6"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -62335,7 +64494,11 @@
           "controlId": "4.0;4.6;4.7;4.8;5.2"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;IA-05;IA-05(01)"
@@ -62544,7 +64707,11 @@
           "controlId": "4.0;4.6;4.7;4.8;5.2"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "CML2.-3.4.6;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;IA-05;IA-05(01)"
@@ -62744,7 +64911,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -62957,7 +65128,12 @@
           "controlId": "1.0;1.1;1.3;2.0;2.1;2.2;2.4;4.0;4.6;4.8;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1;CML2.-3.4.6"
+          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -63176,7 +65352,12 @@
           "controlId": "1.0;1.1;1.3;2.0;2.1;2.2;2.4;4.0;4.6;4.8;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1;CML2.-3.4.6"
+          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -63395,7 +65576,12 @@
           "controlId": "1.0;1.1;1.3;2.0;2.1;2.2;2.4;4.0;4.6;4.8;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1;CML2.-3.4.6"
+          "controlId": "AC.L3-3.1.2E;CML2.-3.4.1;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -63594,7 +65780,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6"
+          "controlId": "CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07"
@@ -63813,7 +66003,11 @@
           "controlId": "15.4;15.5;4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;CML2.-3.4.6;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;CML2.-3.4.6;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-03;AC-06;CM-07;SA-09"
@@ -63969,7 +66163,11 @@
           "controlId": "2.5;4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;CML2.-3.4.7"
+          "controlId": "CML2.-3.4.6;CML2.-3.4.7",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P5;ML3-P5"
@@ -64102,7 +66300,11 @@
           "controlId": "4.0;4.6;4.8"
         },
         "cmmc": {
-          "controlId": "CML2.-3.4.6;SCL2.-3.13.7"
+          "controlId": "CML2.-3.4.6;SCL2.-3.13.7",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-07;SC-07(07)"
@@ -64261,7 +66463,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "CML2.-3.4.9"
+          "controlId": "CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CM-11;CM-11(02)"
@@ -64452,7 +66658,12 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.6;CM.L3-3.4.2E;IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "AUL2.-3.3.6;CM.L3-3.4.2E;IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -64693,7 +66904,11 @@
           "controlId": "8.1"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;CML2.-3.4.3"
+          "controlId": "AUL2.-3.3.1;CML2.-3.4.3",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-11;CM-03;SA-08(31)"
@@ -64846,7 +67061,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.4"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -65034,7 +67253,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;CML2.-3.4.5;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;CML2.-3.4.5;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-03;AC-03(02);AC-06;CM-05;CM-05(01)"
@@ -65101,7 +67324,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SI.L2-3.14.6",
-          "title": "Monitor organizational systems to detect attacks and indicators of potential attacks"
+          "title": "Monitor organizational systems to detect attacks and indicators of potential attacks",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -65135,7 +67362,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "AU.L2-3.3.1",
-          "title": "Create and retain system audit logs to enable monitoring, analysis, investigation, and reporting"
+          "title": "Create and retain system audit logs to enable monitoring, analysis, investigation, and reporting",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -65169,7 +67400,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "AU.L2-3.3.1",
-          "title": "Create and retain system audit logs"
+          "title": "Create and retain system audit logs",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -65316,7 +67551,11 @@
           "controlId": "13.0;13.1;13.6;3.14;8.0;8.1;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;SIL2.-3.14.6"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-01;AU-02;AU-06;IR-04(04);IR-06;SI-04;SI-04(04)"
@@ -65518,7 +67757,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;13.0;13.6;18.0;18.3;7.0;7.1;7.3;7.4;8.0;8.2"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4;SIL2.-3.14.6"
+          "controlId": "AUL2.-3.3.3;RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -65703,7 +67946,11 @@
           "controlId": "13.0;13.6;8.0;8.2;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;SIL2.-3.14.6"
+          "controlId": "AUL2.-3.3.3;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-01;SI-04;SI-04(05);SI-08"
@@ -65879,7 +68126,11 @@
           "controlId": "13.0;13.6;8.0;8.2"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;SIL2.-3.14.6"
+          "controlId": "AUL2.-3.3.3;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-01;SI-04;SI-04(05)"
@@ -66053,7 +68304,11 @@
           "controlId": "13.0;13.6;8.0;8.2"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;AUL2.-3.3.4;SIL2.-3.14.6"
+          "controlId": "AUL2.-3.3.3;AUL2.-3.3.4;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-01;AU-05;AU-05(02);SI-04;SI-04(05);SI-04(12)"
@@ -66268,7 +68523,11 @@
           "controlId": "10.3;10.4;10.5;13.0;13.1;13.6;16.7;3.14;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;8.0;8.1;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.2;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;CML2.-3.4.1;CML2.-3.4.2;SIL2.-3.14.3;SIL2.-3.14.6"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.2;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;CML2.-3.4.1;CML2.-3.4.2;SIL2.-3.14.3;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P3;ML2-P5;ML2-P6;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -66346,7 +68605,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66416,7 +68679,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66486,7 +68753,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66556,7 +68827,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66626,7 +68901,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66696,7 +68975,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66766,7 +69049,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66836,7 +69123,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66906,7 +69197,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -66976,7 +69271,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67046,7 +69345,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67116,7 +69419,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67186,7 +69493,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67256,7 +69567,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67327,7 +69642,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67398,7 +69717,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67469,7 +69792,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67540,7 +69867,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67611,7 +69942,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67681,7 +70016,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67751,7 +70090,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67821,7 +70164,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67891,7 +70238,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -67962,7 +70313,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68032,7 +70387,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68102,7 +70461,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68172,7 +70535,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68242,7 +70609,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68313,7 +70684,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68383,7 +70758,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68453,7 +70832,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68523,7 +70906,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68593,7 +70980,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68663,7 +71054,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68733,7 +71128,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68803,7 +71202,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68873,7 +71276,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -68943,7 +71350,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69013,7 +71424,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69083,7 +71498,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69153,7 +71572,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69223,7 +71646,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69293,7 +71720,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69363,7 +71794,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69433,7 +71868,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69503,7 +71942,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69573,7 +72016,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69643,7 +72090,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69713,7 +72164,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69783,7 +72238,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69853,7 +72312,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69923,7 +72386,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -69993,7 +72460,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70063,7 +72534,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70133,7 +72608,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70203,7 +72682,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70273,7 +72756,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70343,7 +72830,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70413,7 +72904,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70483,7 +72978,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70553,7 +73052,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70623,7 +73126,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70693,7 +73200,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70763,7 +73274,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70833,7 +73348,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70903,7 +73422,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -70973,7 +73496,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71043,7 +73570,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71113,7 +73644,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71183,7 +73718,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71253,7 +73792,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71323,7 +73866,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71393,7 +73940,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71463,7 +74014,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71533,7 +74088,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71603,7 +74162,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71673,7 +74236,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71743,7 +74310,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71813,7 +74384,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71883,7 +74458,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -71953,7 +74532,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72023,7 +74606,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72093,7 +74680,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72163,7 +74754,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72233,7 +74828,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72303,7 +74902,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72373,7 +74976,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72443,7 +75050,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72513,7 +75124,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72583,7 +75198,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72653,7 +75272,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -72838,7 +75461,11 @@
           "controlId": "10.3;10.4;10.5;13.0;13.1;13.6;16.7;3.14;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;8.0;8.1;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.2;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;CML2.-3.4.1;CML2.-3.4.2;SIL2.-3.14.3;SIL2.-3.14.6"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.2;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;CML2.-3.4.1;CML2.-3.4.2;SIL2.-3.14.3;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P3;ML2-P5;ML2-P6;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -73038,7 +75665,11 @@
           "controlId": "13.1;17.0;17.1;17.2;17.3;17.4;17.5;17.6;17.9;2.3;3.14;8.1;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;IRL2.-3.6.1;IRL2.-3.6.2"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;IRL2.-3.6.1;IRL2.-3.6.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -73234,7 +75865,11 @@
           "controlId": "13.1;17.2;17.6;3.14;8.1;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-02;AU-06;IR-04(04);IR-05;SI-04"
@@ -73433,7 +76068,11 @@
           "controlId": "13.0;13.1;13.6;17.0;17.1;17.3;17.4;17.5;17.6;17.9;2.3;3.14;8.0;8.1;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;IRL2.-3.6.1;IRL2.-3.6.2;SIL2.-3.14.6"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9;IRL2.-3.6.1;IRL2.-3.6.2;SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -73510,7 +76149,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "AU.L2-3.3.5",
-          "title": "Correlate audit record review, analysis, and reporting processes"
+          "title": "Correlate audit record review, analysis, and reporting processes",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -73545,7 +76188,11 @@
           "controlId": "3.14;8.2;8.5"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.2"
+          "controlId": "AUL2.-3.3.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P5;ML3-P3;ML3-P5"
@@ -73722,7 +76369,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AUL2.-3.3.6"
+          "controlId": "AUL2.-3.3.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-07;AU-07(01);AU-12"
@@ -73905,7 +76556,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AUL2.-3.3.6"
+          "controlId": "AUL2.-3.3.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-07;AU-07(01);AU-12"
@@ -74087,7 +76742,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AUL2.-3.3.6"
+          "controlId": "AUL2.-3.3.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-07;AU-07(01);AU-12"
@@ -74269,7 +76928,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AUL2.-3.3.6"
+          "controlId": "AUL2.-3.3.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-07;AU-07(01);AU-12"
@@ -74442,7 +77105,11 @@
           "controlId": "3.1;3.4;3.5;8.1"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1"
+          "controlId": "AUL2.-3.3.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-11;MP-07;SI-12;SI-12(03)"
@@ -74619,7 +77286,11 @@
           "controlId": "3.1;3.4;3.5;8.1"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1"
+          "controlId": "AUL2.-3.3.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-11;MP-07;SI-12;SI-12(03)"
@@ -74788,7 +77459,11 @@
           "controlId": "3.1;3.4;3.5;8.1"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1"
+          "controlId": "AUL2.-3.3.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-11;MP-07;SI-12;SI-12(03)"
@@ -74957,7 +77632,11 @@
           "controlId": "3.1;3.4;3.5;8.1"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1"
+          "controlId": "AUL2.-3.3.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AU-11;MP-07;SI-12;SI-12(03)"
@@ -75134,7 +77813,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "ACL2.-3.1.9"
+          "controlId": "ACL2.-3.1.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-08"
@@ -75269,7 +77952,11 @@
           "controlId": "10.3;10.4;10.5;16.4;16.7;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.IV;ACL2.-3.1.22;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2"
+          "controlId": "AC.L1-B.1.IV;ACL2.-3.1.22;AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -75477,7 +78164,11 @@
           "controlId": "15.4;15.5;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.9"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -75686,7 +78377,11 @@
           "controlId": "15.4;15.5;3.1;3.3;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.3;ACL2.-3.1.5;MPL2.-3.8.2"
+          "controlId": "ACL2.-3.1.3;ACL2.-3.1.5;MPL2.-3.8.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -75765,7 +78460,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.1",
-          "title": "Monitor, control, and protect organizational communications"
+          "title": "Monitor, control, and protect organizational communications",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -75801,7 +78500,11 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-01"
@@ -75874,7 +78577,11 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-01"
@@ -75948,7 +78655,11 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-01"
@@ -76022,7 +78733,11 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-01"
@@ -76096,7 +78811,11 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-01"
@@ -76170,7 +78889,11 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-01"
@@ -76244,7 +78967,11 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-01"
@@ -76318,7 +79045,11 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-01"
@@ -76487,7 +79218,12 @@
           "controlId": "12.0;12.1;12.2;12.3;12.6;13.4;13.5;3.3;4.6;6.3;6.4"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;IAL2.-3.5.3;MAL2.-3.7.5;SC.L1-B.1.X;SCL2.-3.13.1"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;IAL2.-3.5.3;MAL2.-3.7.5;SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -76567,7 +79303,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.1",
-          "title": "Monitor, control, and protect organizational communications"
+          "title": "Monitor, control, and protect organizational communications",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -76601,7 +79341,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.1",
-          "title": "Monitor, control, and protect organizational communications"
+          "title": "Monitor, control, and protect organizational communications",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -76635,7 +79379,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.1",
-          "title": "Monitor, control, and protect organizational communications"
+          "title": "Monitor, control, and protect organizational communications",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -76668,7 +79416,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.1",
-          "title": "Monitor, control, and protect organizational communications"
+          "title": "Monitor, control, and protect organizational communications",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -76805,7 +79557,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
@@ -76988,7 +79744,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
@@ -77133,7 +79893,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -77281,7 +80045,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -77463,7 +80231,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
@@ -77633,7 +80405,12 @@
           "controlId": "12.6;13.4;13.5;3.13;3.3;4.6;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18);SI-08"
@@ -77815,7 +80592,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
@@ -77994,7 +80775,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-03;SI-04;SI-04(18);SI-05;SI-07;SI-10"
@@ -78173,7 +80958,11 @@
           "controlId": "13.5;3.13;3.3;9.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-21;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -78351,7 +81140,11 @@
           "controlId": "13.5;3.13;3.3;9.6"
         },
         "cmmc": {
-          "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-21;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)"
@@ -78512,7 +81305,11 @@
           "controlId": "13.5;3.13;9.6"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.7;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "MPL2.-3.8.7;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "MP-07;SC-07;SC-07(09);SC-07(10);SC-07(11);SC-08(02);SI-04(18)"
@@ -78699,7 +81496,12 @@
           "controlId": "12.6;13.4;3.3;4.6;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SI-08"
@@ -78898,7 +81700,12 @@
           "controlId": "12.6;13.4;3.3;4.6;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SI-08"
@@ -79112,7 +81919,12 @@
           "controlId": "12.6;13.4;13.5;3.3;4.6;9.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07;SC-07(09);SC-07(11)"
@@ -79299,7 +82111,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -79519,7 +82336,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];AC.L3-3.1.3E;ACL2.-3.1.1;ACL2.-3.1.3;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];AC.L3-3.1.3E;ACL2.-3.1.1;ACL2.-3.1.3;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-04;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -79728,7 +82550,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];AC.L3-3.1.3E;ACL2.-3.1.1;ACL2.-3.1.3;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];AC.L3-3.1.3E;ACL2.-3.1.1;ACL2.-3.1.3;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-04;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -79937,7 +82764,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];AC.L3-3.1.3E;ACL2.-3.1.1;ACL2.-3.1.3;IA.L1-B.1.V[b]"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];AC.L3-3.1.3E;ACL2.-3.1.1;ACL2.-3.1.3;IA.L1-B.1.V[b]",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-04;AC-05;AC-06;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -80001,7 +82833,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80067,7 +82904,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80133,7 +82975,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80199,7 +83046,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80265,7 +83117,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80331,7 +83188,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80397,7 +83259,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80463,7 +83330,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80529,7 +83401,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80595,7 +83472,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80661,7 +83543,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80727,7 +83614,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80793,7 +83685,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80859,7 +83756,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80925,7 +83827,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -80991,7 +83898,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81057,7 +83969,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81123,7 +84040,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81189,7 +84111,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81255,7 +84182,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81321,7 +84253,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81387,7 +84324,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81453,7 +84395,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81519,7 +84466,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81585,7 +84537,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81651,7 +84608,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81717,7 +84679,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81783,7 +84750,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81849,7 +84821,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81915,7 +84892,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -81981,7 +84963,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82047,7 +85034,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82113,7 +85105,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82179,7 +85176,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82245,7 +85247,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82311,7 +85318,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82377,7 +85389,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82443,7 +85460,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82509,7 +85531,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82575,7 +85602,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82641,7 +85673,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82707,7 +85744,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82773,7 +85815,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82839,7 +85886,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82905,7 +85957,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -82971,7 +86028,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83037,7 +86099,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83103,7 +86170,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83169,7 +86241,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83235,7 +86312,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83301,7 +86383,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83367,7 +86454,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83433,7 +86525,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83499,7 +86596,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83565,7 +86667,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83631,7 +86738,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83697,7 +86809,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83763,7 +86880,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83829,7 +86951,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83895,7 +87022,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -83961,7 +87093,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3;SCL2.-3.13.6",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04;SC-07(05);SC-07(11)"
@@ -84027,7 +87164,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84092,7 +87234,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84157,7 +87304,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84222,7 +87374,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84287,7 +87444,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84352,7 +87514,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84417,7 +87584,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84482,7 +87654,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84547,7 +87724,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84612,7 +87794,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84677,7 +87864,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84742,7 +87934,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84807,7 +88004,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84872,7 +88074,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -84937,7 +88144,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85002,7 +88214,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85067,7 +88284,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85132,7 +88354,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85197,7 +88424,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85262,7 +88494,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85327,7 +88564,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85392,7 +88634,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85457,7 +88704,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85522,7 +88774,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85587,7 +88844,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85652,7 +88914,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85717,7 +88984,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85782,7 +89054,12 @@
           "controlId": "12.6;13.4;3.3;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3"
+          "controlId": "AC.L3-3.1.3E;ACL2.-3.1.3",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "fedramp": {
           "controlId": "AC-04"
@@ -85923,7 +89200,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.9"
+          "controlId": "SCL2.-3.13.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-10"
@@ -85984,7 +89265,11 @@
           "controlId": "13.3;13.8;9.6"
         },
         "cmmc": {
-          "controlId": "SIL2.-3.14.6"
+          "controlId": "SIL2.-3.14.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "iso-27001": {
           "controlId": "8.21"
@@ -86101,7 +89386,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.15"
+          "controlId": "SCL2.-3.13.15",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-23"
@@ -86298,7 +89587,11 @@
           "controlId": "12.7;13.5;9.6"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.12;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1"
+          "controlId": "ACL2.-3.1.12;SC.L1-B.1.X;SC.L1-B.1.X[a];SC.L1-B.1.X[b];SC.L1-B.1.X[c];SC.L1-B.1.X[d];SC.L1-B.1.X[e];SC.L1-B.1.X[f];SC.L1-B.1.X[g];SC.L1-B.1.X[h];SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-17;SC-07;SC-07(09);SC-07(11)"
@@ -86493,7 +89786,11 @@
           "controlId": "12.7"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.12"
+          "controlId": "ACL2.-3.1.12",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-17"
@@ -86635,7 +89932,11 @@
           "controlId": "12.7"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.12;ACL2.-3.1.13"
+          "controlId": "ACL2.-3.1.12;ACL2.-3.1.13",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-17;AC-17(02)"
@@ -86780,7 +90081,11 @@
           "controlId": "12.7"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.12;ACL2.-3.1.14"
+          "controlId": "ACL2.-3.1.12;ACL2.-3.1.14",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-17;AC-17(03)"
@@ -86929,7 +90234,11 @@
           "controlId": "12.7"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.12;ACL2.-3.1.15"
+          "controlId": "ACL2.-3.1.12;ACL2.-3.1.15",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-17;AC-17(04)"
@@ -87089,7 +90398,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "ACL2.-3.1.16;ACL2.-3.1.17"
+          "controlId": "ACL2.-3.1.16;ACL2.-3.1.17",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-18;AC-18(01)"
@@ -87253,7 +90566,11 @@
           "controlId": "10.0;10.3;10.4;10.5;11.0;3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -87429,7 +90746,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -87614,7 +90935,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -87802,7 +91127,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -87986,7 +91315,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -88170,7 +91503,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9"
+          "controlId": "ACL2.-3.1.5;ACL2.-3.1.7;CML2.-3.4.5;CML2.-3.4.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -88433,7 +91770,11 @@
           "controlId": "10.0;10.1;10.2;10.3;10.4;10.5;10.7;16.7;18.0;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;7.0;7.1;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -88698,7 +92039,11 @@
           "controlId": "10.0;10.1;10.2;10.3;10.4;10.5;10.7;16.7;18.0;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;7.0;7.1;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -88964,7 +92309,11 @@
           "controlId": "10.0;10.1;10.2;10.3;10.4;10.5;10.7;16.7;18.0;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;7.0;7.1;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -89229,7 +92578,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;7.0;7.1;7.3;7.4"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -89489,7 +92842,11 @@
           "controlId": "10.0;10.1;10.2;10.3;10.4;10.5;10.7;16.7;18.0;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;7.0;7.1;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -89752,7 +93109,11 @@
           "controlId": "10.0;10.1;10.2;10.3;10.4;10.5;10.7;12.1;16.7;18.0;18.3;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;7.0;7.1;7.3;7.4"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML1-P6;ML1-P7;ML2-P1;ML2-P2;ML2-P5;ML2-P6;ML2-P7;ML3-P1;ML3-P2;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -90014,7 +93375,11 @@
           "controlId": "10.0;10.1;10.2;10.3;10.4;10.5;10.7;16.7;18.0;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;7.0;7.1;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -90277,7 +93642,11 @@
           "controlId": "10.0;10.1;10.2;10.3;10.4;10.5;10.7;16.7;18.0;4.1;4.2;4.3;4.4;4.5;4.6;4.7;4.8;7.0;7.1;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "AUL2.-3.3.3;CML2.-3.4.1;CML2.-3.4.2;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P6;ML1-P7;ML2-P5;ML2-P6;ML2-P7;ML3-P4;ML3-P5;ML3-P6;ML3-P7"
@@ -90540,7 +93909,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;7.0;7.1;7.3;7.4;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -90800,7 +94173,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;7.0;7.1;7.3;7.4;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -91054,7 +94431,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;7.0;7.1;7.3;7.4;9.0;9.6;9.7"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -91310,7 +94691,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;3.1;7.0;7.1;7.3;7.4"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.3;SCL2.-3.13.8;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "RAL2.-3.11.3;SCL2.-3.13.8;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -91566,7 +94951,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;7.0;7.1;7.3;7.4"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -91821,7 +95210,11 @@
           "controlId": "10.0;10.1;10.2;10.4;10.7;12.1;18.0;18.3;7.0;7.1;7.3;7.4"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -92069,7 +95462,11 @@
           "controlId": "10.0;10.1;10.4;13.2;13.7;2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "ACL2.-3.1.5;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -92143,7 +95540,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SI.L2-3.14.2",
-          "title": "Provide protection from malicious code at appropriate locations within organizational systems"
+          "title": "Provide protection from malicious code at appropriate locations within organizational systems",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -92179,7 +95580,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92250,7 +95655,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92321,7 +95730,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92392,7 +95805,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92463,7 +95880,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92534,7 +95955,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92605,7 +96030,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92676,7 +96105,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92747,7 +96180,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92818,7 +96255,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92889,7 +96330,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -92960,7 +96405,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93031,7 +96480,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93102,7 +96555,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93173,7 +96630,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93244,7 +96705,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93315,7 +96780,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93386,7 +96855,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93457,7 +96930,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93528,7 +97005,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93599,7 +97080,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93670,7 +97155,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93741,7 +97230,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93812,7 +97305,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93883,7 +97380,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -93954,7 +97455,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -94025,7 +97530,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -94096,7 +97605,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -94167,7 +97680,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -94238,7 +97755,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -94309,7 +97830,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -94490,7 +98015,11 @@
           "controlId": "10.0;10.1;10.2;10.4;12.1;18.0;18.3;7.0;7.1;7.3;7.4"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4"
+          "controlId": "RAL2.-3.11.3;SI.L1-B.1.XII;SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XII[a];SI.L1-B.1.XII[b];SI.L1-B.1.XII[c];SI.L1-B.1.XII[d];SI.L1-B.1.XII[e];SI.L1-B.1.XII[f];SI.L1-B.1.XIV;SI.L1-B.1.XIV[a];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SIL2.-3.14.1;SIL2.-3.14.2;SIL2.-3.14.4",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -94659,7 +98188,11 @@
           "controlId": "10.0;10.1;10.4"
         },
         "cmmc": {
-          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SI.L1-B.1.XV[c];SIL2.-3.14.2;SIL2.-3.14.5"
+          "controlId": "SI.L1-B.1.XIII;SI.L1-B.1.XIII[a];SI.L1-B.1.XIII[b];SI.L1-B.1.XV;SI.L1-B.1.XV[a];SI.L1-B.1.XV[b];SI.L1-B.1.XV[c];SIL2.-3.14.2;SIL2.-3.14.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SI-03"
@@ -95779,7 +99312,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.13"
+          "controlId": "SCL2.-3.13.13",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-18;SC-18(01);SC-18(02);SC-18(03);SC-18(04)"
@@ -95960,7 +99497,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SCL2.-3.13.12"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SCL2.-3.13.12",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SC-15;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -96143,7 +99684,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.12"
+          "controlId": "SCL2.-3.13.12",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-15"
@@ -96313,7 +99858,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.12"
+          "controlId": "SCL2.-3.13.12",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-15"
@@ -96504,7 +100053,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SCL2.-3.13.12"
+          "controlId": "AC.L1-B.1.I;AC.L1-B.1.I[a];AC.L1-B.1.I[b];AC.L1-B.1.I[d];AC.L1-B.1.I[e];AC.L1-B.1.I[f];AC.L1-B.1.Ic];ACL2.-3.1.1;IA.L1-B.1.V[b];SCL2.-3.13.12",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-02;AC-03;AC-05;AC-06;SC-15;SI-03;SI-04;SI-05;SI-07;SI-10"
@@ -96698,7 +100251,12 @@
           "controlId": "1.0;1.1;1.3;2.0;2.1;2.2;2.4;6.6"
         },
         "cmmc": {
-          "controlId": "AC.L3-3.1.2E;ACL2.-3.1.18;CML2.-3.4.1"
+          "controlId": "AC.L3-3.1.2E;ACL2.-3.1.18;CML2.-3.4.1",
+          "profiles": [
+            "L1",
+            "L2",
+            "L3"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -96852,7 +100410,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "ACL2.-3.1.19"
+          "controlId": "ACL2.-3.1.19",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "AC-19(05)"
@@ -96981,7 +100543,11 @@
           "controlId": "16.4;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.IV;ACL2.-3.1.22"
+          "controlId": "AC.L1-B.1.IV;ACL2.-3.1.22",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SA-04"
@@ -97185,7 +100751,11 @@
           "controlId": "3.1;3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "SCL2.-3.13.11"
+          "controlId": "SCL2.-3.13.11",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-08(01);SC-08(02);SC-13"
@@ -97266,7 +100836,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.10",
-          "title": "Employ FIPS-validated cryptography"
+          "title": "Employ FIPS-validated cryptography",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -97299,7 +100873,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.10",
-          "title": "Employ FIPS-validated cryptography"
+          "title": "Employ FIPS-validated cryptography",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -97333,7 +100911,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "IA.L2-3.5.10",
-          "title": "Store and transmit only cryptographically-protected passwords"
+          "title": "Store and transmit only cryptographically-protected passwords",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -97445,7 +101027,11 @@
           "controlId": "3.1"
         },
         "cmmc": {
-          "controlId": "SCL2.-3.13.8"
+          "controlId": "SCL2.-3.13.8",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-08;SC-08(01);SC-16(01);SC-28(01)"
@@ -97627,7 +101213,11 @@
           "controlId": "16.4;3.1;4.6"
         },
         "cmmc": {
-          "controlId": "AC.L1-B.1.IV;ACL2.-3.1.22;SCL2.-3.13.8"
+          "controlId": "AC.L1-B.1.IV;ACL2.-3.1.22;SCL2.-3.13.8",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SA-04;SC-08;SC-08(01)"
@@ -97700,7 +101290,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.8",
-          "title": "Implement cryptographic mechanisms to prevent unauthorized disclosure"
+          "title": "Implement cryptographic mechanisms to prevent unauthorized disclosure",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -97734,7 +101328,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.8",
-          "title": "Implement cryptographic mechanisms to prevent unauthorized disclosure"
+          "title": "Implement cryptographic mechanisms to prevent unauthorized disclosure",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -97767,7 +101365,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.3",
-          "title": "Employ architectural designs and implement security functionality"
+          "title": "Employ architectural designs and implement security functionality",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -97801,7 +101403,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.16",
-          "title": "Protect the confidentiality of CUI at rest"
+          "title": "Protect the confidentiality of CUI at rest",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -97835,7 +101441,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "SC.L2-3.13.16",
-          "title": "Protect the confidentiality of CUI at rest"
+          "title": "Protect the confidentiality of CUI at rest",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -97871,7 +101481,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -97943,7 +101557,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -98015,7 +101633,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -98087,7 +101709,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -98159,7 +101785,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -98231,7 +101861,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -98303,7 +101937,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -98375,7 +102013,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -98447,7 +102089,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -98519,7 +102165,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -98591,7 +102241,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -98663,7 +102317,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -98735,7 +102393,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -98807,7 +102469,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -98879,7 +102545,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -98951,7 +102621,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99023,7 +102697,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99095,7 +102773,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99167,7 +102849,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99239,7 +102925,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99311,7 +103001,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99383,7 +103077,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99455,7 +103153,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99527,7 +103229,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99599,7 +103305,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99671,7 +103381,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99743,7 +103457,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99815,7 +103533,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99887,7 +103609,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -99959,7 +103685,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100031,7 +103761,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100103,7 +103837,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100175,7 +103913,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100247,7 +103989,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100319,7 +104065,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100391,7 +104141,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100463,7 +104217,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100535,7 +104293,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100607,7 +104369,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100679,7 +104445,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100751,7 +104521,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100823,7 +104597,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100895,7 +104673,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -100967,7 +104749,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101039,7 +104825,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101111,7 +104901,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101183,7 +104977,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101255,7 +105053,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101327,7 +105129,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101399,7 +105205,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101471,7 +105281,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101543,7 +105357,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101615,7 +105433,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101687,7 +105509,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101759,7 +105585,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101831,7 +105661,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101903,7 +105737,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -101975,7 +105813,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102047,7 +105889,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102119,7 +105965,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102191,7 +106041,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102263,7 +106117,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102335,7 +106193,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102407,7 +106269,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102479,7 +106345,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102551,7 +106421,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102623,7 +106497,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102695,7 +106573,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102767,7 +106649,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102839,7 +106725,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102911,7 +106801,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -102983,7 +106877,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -103055,7 +106953,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -103127,7 +107029,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -103196,7 +107102,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103251,7 +107161,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103306,7 +107220,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103361,7 +107279,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103416,7 +107338,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103471,7 +107397,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103526,7 +107456,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103581,7 +107515,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103636,7 +107574,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103691,7 +107633,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103746,7 +107692,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103801,7 +107751,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103856,7 +107810,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103911,7 +107869,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -103966,7 +107928,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -104119,7 +108085,11 @@
           "controlId": "3.1;3.5"
         },
         "cmmc": {
-          "controlId": "MAL2.-3.7.3;MP.L1-B.1.VII;MP.L1-B.1.VII[a];MP.L1-B.1.VII[b];MPL2.-3.8.3"
+          "controlId": "MAL2.-3.7.3;MP.L1-B.1.VII;MP.L1-B.1.VII[a];MP.L1-B.1.VII[b];MPL2.-3.8.3",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "CP-04;MP-06;MP-06(03)"
@@ -105193,7 +109163,11 @@
           "controlId": "11.2;11.3"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.9"
+          "controlId": "MPL2.-3.8.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P8;ML2-P8;ML3-P8"
@@ -105434,7 +109408,11 @@
           "controlId": "7.5;7.6"
         },
         "cmmc": {
-          "controlId": "RAL2.-3.11.2"
+          "controlId": "RAL2.-3.11.2",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P1;ML1-P2;ML2-P1;ML2-P2;ML3-P1;ML3-P2"
@@ -105504,7 +109482,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "RA.L2-3.11.2",
-          "title": "Scan for vulnerabilities in organizational systems"
+          "title": "Scan for vulnerabilities in organizational systems",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -105538,7 +109520,11 @@
       "frameworks": {
         "cmmc": {
           "controlId": "RA.L2-3.11.2",
-          "title": "Scan for vulnerabilities in organizational systems"
+          "title": "Scan for vulnerabilities in organizational systems",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         }
       },
       "impactRating": {
@@ -105574,7 +109560,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01)"
@@ -105646,7 +109636,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -105717,7 +109711,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -105789,7 +109787,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -105861,7 +109863,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -105932,7 +109938,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106004,7 +110014,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106075,7 +110089,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106147,7 +110165,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106218,7 +110240,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106290,7 +110316,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106361,7 +110391,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106433,7 +110467,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106505,7 +110543,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106577,7 +110619,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106649,7 +110695,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106721,7 +110771,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106793,7 +110847,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106865,7 +110923,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -106937,7 +110999,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -107009,7 +111075,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -107081,7 +111151,11 @@
           "controlId": "3.11;3.6;3.9"
         },
         "cmmc": {
-          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16"
+          "controlId": "MPL2.-3.8.6;SCL2.-3.13.16",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-13;SC-28;SC-28(01);SC-28(02)"
@@ -107150,7 +111224,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -107205,7 +111283,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -107260,7 +111342,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -107315,7 +111401,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -107370,7 +111460,11 @@
       },
       "frameworks": {
         "cmmc": {
-          "controlId": "SCL2.-3.13.10"
+          "controlId": "SCL2.-3.13.10",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "SC-12;SC-17"
@@ -107479,7 +111573,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -107542,7 +111640,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -107605,7 +111707,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -107668,7 +111774,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -107731,7 +111841,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -107794,7 +111908,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -107857,7 +111975,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -107920,7 +112042,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -107983,7 +112109,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108046,7 +112176,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108109,7 +112243,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108172,7 +112310,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108235,7 +112377,11 @@
           "controlId": "6.3;6.4"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108298,7 +112444,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108361,7 +112511,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108424,7 +112578,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108487,7 +112645,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108550,7 +112712,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108613,7 +112779,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108676,7 +112846,11 @@
           "controlId": "6.3;6.4;6.5"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5"
+          "controlId": "IAL2.-3.5.3;MAL2.-3.7.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P3;ML2-P3;ML3-P3"
@@ -108739,7 +112913,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -108806,7 +112984,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -108873,7 +113055,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -108940,7 +113126,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -109007,7 +113197,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -109074,7 +113268,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -109140,7 +113338,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -109207,7 +113409,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -109274,7 +113480,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -109341,7 +113551,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.7;IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01)"
@@ -109408,7 +113622,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01);IA-12(04)"
@@ -109475,7 +113693,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01);IA-12(04)"
@@ -109542,7 +113764,11 @@
           "controlId": "5.2"
         },
         "cmmc": {
-          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9"
+          "controlId": "IAL2.-3.5.8;IAL2.-3.5.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "fedramp": {
           "controlId": "IA-05;IA-05(01);IA-12(04)"
@@ -109609,7 +113835,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -109664,7 +113894,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -109719,7 +113953,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -109774,7 +114012,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -109829,7 +114071,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -109884,7 +114130,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -109939,7 +114189,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -109994,7 +114248,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110049,7 +114307,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110104,7 +114366,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110159,7 +114425,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110214,7 +114484,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110269,7 +114543,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110324,7 +114602,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110379,7 +114661,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110434,7 +114720,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110489,7 +114779,11 @@
           "controlId": "2.7;5.1;5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110544,7 +114838,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110620,7 +114918,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110696,7 +114998,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110772,7 +115078,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110848,7 +115158,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -110924,7 +115238,11 @@
           "controlId": "5.4"
         },
         "cmmc": {
-          "controlId": "ACL2.-3.1.5"
+          "controlId": "ACL2.-3.1.5",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML1-P4;ML2-P4;ML3-P4"
@@ -111000,7 +115318,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111071,7 +115393,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111141,7 +115467,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111211,7 +115541,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111281,7 +115615,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111352,7 +115690,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111422,7 +115764,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111492,7 +115838,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111562,7 +115912,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111632,7 +115986,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111703,7 +116061,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111774,7 +116136,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111844,7 +116210,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111915,7 +116285,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -111986,7 +116360,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -112057,7 +116435,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -112128,7 +116510,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"
@@ -112199,7 +116585,11 @@
           "controlId": "13.1;3.14;8.1;8.11;8.12;8.2;8.3;8.4;8.5;8.6;8.7;8.8;8.9"
         },
         "cmmc": {
-          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9"
+          "controlId": "AUL2.-3.3.1;AUL2.-3.3.3;AUL2.-3.3.5;AUL2.-3.3.6;AUL2.-3.3.8;AUL2.-3.3.9",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
         },
         "essential-eight": {
           "controlId": "ML2-P3;ML2-P4;ML2-P5;ML2-P7;ML3-P3;ML3-P4;ML3-P5;ML3-P7"

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -352,6 +352,32 @@ def load_az_assess_source_checks(repo_root: Path) -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# CMMC profile derivation
+# ---------------------------------------------------------------------------
+
+_CMMC_L1 = re.compile(r"\.L1-")
+_CMMC_L2 = re.compile(r"\.L2-|L2\.-")
+_CMMC_L3 = re.compile(r"\.L3-|L3\.-")
+
+
+def derive_cmmc_profiles(control_id: str) -> list[str]:
+    """Derive CMMC level profiles from a semicolon-delimited practice ID string.
+
+    CMMC is cumulative (L3 ⊇ L2 ⊇ L1): if the highest level found is L3,
+    returns ['L1','L2','L3']; if L2, returns ['L1','L2']; if L1, ['L1'].
+    """
+    if not control_id:
+        return []
+    if _CMMC_L3.search(control_id):
+        return ["L1", "L2", "L3"]
+    if _CMMC_L2.search(control_id):
+        return ["L1", "L2"]
+    if _CMMC_L1.search(control_id):
+        return ["L1"]
+    return []
+
+
+# ---------------------------------------------------------------------------
 # Effort derivation
 # ---------------------------------------------------------------------------
 
@@ -610,6 +636,12 @@ def derive_frameworks(
             profiles = [p for p in order if p in profiles]
             frameworks[fw_key]["profiles"] = profiles
 
+    # Derive CMMC L1/L2/L3 profiles from practice ID patterns in controlId
+    if "cmmc" in frameworks:
+        cmmc_profiles = derive_cmmc_profiles(frameworks["cmmc"].get("controlId", ""))
+        if cmmc_profiles:
+            frameworks["cmmc"]["profiles"] = cmmc_profiles
+
     return frameworks
 
 
@@ -845,6 +877,14 @@ def main():
         az["effort"] = derive_effort(az, effort_overrides)
     checks.extend(az_checks)
     checks.sort(key=scf_sort_key)
+
+    # Ensure CMMC profiles are set on all checks (AZ checks bypass derive_frameworks)
+    for check in checks:
+        fw = check.get("frameworks", {})
+        if "cmmc" in fw and "profiles" not in fw["cmmc"]:
+            p = derive_cmmc_profiles(fw["cmmc"].get("controlId", ""))
+            if p:
+                fw["cmmc"]["profiles"] = p
     if az_checks:
         print(f"Merged {len(az_checks)} AZ-* checks from az-assess-source-checks.json")
     if fw_derived:


### PR DESCRIPTION
## Summary

Derives CMMC maturity level profiles from practice ID patterns in each check's `cmmc.controlId` string. Enables level-scoped compliance scoring downstream without string-parsing practice IDs.

CMMC is cumulative (L3 ⊇ L2 ⊇ L1): highest level found determines the profiles array.

- Adds `derive_cmmc_profiles()` with regex patterns covering both practice ID formats in the registry (`.L2-` and `L2.-` variants)
- Applied inside `derive_frameworks()` for M365 checks
- Applied as a post-processing pass covering AZ checks (which bypass `derive_frameworks()` since they load frameworks directly from `az-assess-source-checks.json`)
- Mirrors the existing NIST 800-53 `profiles: ["Low","Moderate","High"]` pattern

## Results

- **1,067 / 1,067** CMMC checks have profiles (100%)
- `["L1","L2"]`: 945 checks
- `["L1","L2","L3"]`: 122 checks
- No pure `["L1"]` — all L1 practices in the registry co-appear with L2 practices

## Test plan

- [x] Build runs cleanly — 1,092 checks total, 1,067 CMMC with profiles
- [x] Zero CMMC checks without profiles after fix
- [x] Sample spot-check: L1+L2 (ENTRA-ENTAPP-020), L1+L2+L3 (DEFENDER-SECUREMON-001)
- [ ] CI validation on push

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)