### PR TITLE
docs: update effort design doc to reflect final shipped state

### DIFF
--- a/docs/2026-04-19-effort-estimates-design.md
+++ b/docs/2026-04-19-effort-estimates-design.md
@@ -1,7 +1,7 @@
 # Design: Effort Estimation Field for CheckID Registry
 
 **Date:** 2026-04-19
-**Status:** Approved
+**Status:** Complete (v2.9.0)
 **Schema version:** v2.0.0 → v2.1.0
 
 ## Context
@@ -9,8 +9,6 @@
 CheckID checks vary enormously in implementation complexity. Some are a single config toggle; others (DMARC enforcement, MFA rollout, Conditional Access) require multi-phase rollouts spanning weeks with real risk of disrupting users or mail flow if rushed. Today the registry has no way to communicate this — consumers see severity and weighting but nothing about rollout complexity or disruption risk.
 
 This design adds a first-class `effort` object to every check entry. It is not a bolt-on annotation; it is a core differentiator that informs security admins planning remediation timelines and provides downstream tooling (M365-Assess, M365-Remediate) with structured rollout guidance.
-
-Execution is multi-sprint and research-first. Each sprint has a manual validation gate before data is committed.
 
 ## Problem Statement
 
@@ -54,9 +52,11 @@ Every check entry in `registry.json` gains an `effort` top-level field:
 | 4 | Org-wide policy change, staged rollout advisable | Block legacy authentication |
 | 5 | Multi-team project, mandatory phasing | DMARC enforcement, MFA for all users |
 
-### Derivation Logic
+### Derivation Logic (Final — as Shipped)
 
 `Build-Registry.py` derives `effort` from existing check fields so no check is ever blank. The derivation is intentionally conservative — it under-flags rather than over-flags, because an incorrect `isPhased: true` confuses admins more than a missed flag.
+
+**Null severity handling:** 65 AZ-prefixed checks have no `impactRating.severity`. These default to `"Medium"` in the derivation, giving a complexity base of 2. This is intentional — it produces a conservative, non-zero effort estimate rather than an error or a hard-coded fallback that might mislead.
 
 **Complexity base (from severity):**
 
@@ -67,6 +67,7 @@ Every check entry in `registry.json` gains an `effort` top-level field:
 | Medium | 2 |
 | Low | 1 |
 | Informational | 1 |
+| null / missing | 2 (Medium default) |
 
 **Adjustments:**
 
@@ -79,21 +80,30 @@ Every check entry in `registry.json` gains an `effort` top-level field:
 
 Floor: 1, Ceiling: 5.
 
-**isPhased detection (conservative):**
+**isPhased detection (conservative — final keyword set):**
 
 - Collector is `DNS` (SPF/DKIM/DMARC always require phased deployment)
-- Check name contains `enforcement`, `quarantine`, `reject`, or `block`
+- Check name contains any of: `enforcement`, `quarantine`, `reject`
 - Derived `complexity >= 4`
 
-**disruptionRisk + disruptionScope:**
+> **Design decision (Sprint 4):** `"block"` was removed from the keyword list. Windows GPO check names routinely use "Block" as a setting value (e.g., "Enabled: Block All", "Block untrusted fonts"), not as a deployment phase verb. This caused ~20 WIN-CONFIG and WIN-FIREWALL checks to be incorrectly flagged as phased. The one legitimate case — CA-LEGACYAUTH-001 ("Block Legacy Authentication") — is handled via an explicit override.
+
+`phaseCount` defaults to 3 when phased (monitor → quarantine/warn → enforce), 1 otherwise. Overrides correct known checks.
+
+**disruptionRisk + disruptionScope (final rules):**
 
 | Condition | Risk | Scope |
 |---|---|---|
-| severity High/Critical + auth collector (Entra, CAEvaluator) | true | `user-facing` |
+| severity High/Critical + `_USER_FACING_COLLECTORS` | true | `user-facing` |
+| severity **Medium** + `_USER_FACING_COLLECTORS` | true | `user-facing` |
 | severity High/Critical + email/DNS collector (ExchangeOnline, DNS) | true | `service` |
 | severity High/Critical + audit/admin category | true | `admin-only` |
 | severity High/Critical + Azure collector (AzAssess) | true | `service` |
-| severity Medium/Low | false | null |
+| severity Medium/Low + non-user-facing | false | null |
+
+`_USER_FACING_COLLECTORS` (final set): `{"Entra", "CAEvaluator", "SharePoint", "Teams", "Forms", "PowerBI", "Intune"}`
+
+> **Design decision (Sprint 3):** The original rules only flagged user-facing disruption for High/Critical severity + auth collectors (Entra, CAEvaluator). This missed a class of real risk: a Medium-severity SharePoint external-sharing policy, a Teams meeting setting, or an Intune enrollment restriction can disrupt thousands of users even without being rated High. The collector set was expanded (`_AUTH_COLLECTORS` → `_USER_FACING_COLLECTORS`) and Medium severity was added as a trigger for user-facing collectors specifically. Non-user-facing Medium checks remain `disruptionRisk: false`.
 
 ### Override Mechanism
 
@@ -114,29 +124,42 @@ Manual corrections live in `data/effort-overrides.json`, keyed by `checkId`. The
 }
 ```
 
-## Phased Research & Rollout Plan
+### AZ Check Post-Processing
 
-### Sprint 1 — Foundation (this PR)
-- Schema v2.1.0 with `effort` block
-- Derivation logic in `Build-Registry.py`
-- `data/effort-overrides.json` with 8 seed entries for known-complex checks
-- Research gate: 8 known-complex checks validated ✓
+AZ-prefixed checks (CIS Azure / Windows Server 2025) bypass `derive_frameworks()` — their framework mappings are loaded directly from source JSON, not derived by the build script. As a result, CMMC `profiles` (L1/L2/L3 level tags) are not populated during the main derivation pass.
 
-### Sprint 2 — Critical/High Severity (~250 checks)
-- Human review of all Critical/High check effort scores
-- Author overrides with `_rationale` for corrections
-- Refine derivation rules from observed patterns
-- Research gate: spot-check 20 random Medium checks
+A second pass in `main()` handles this:
 
-### Sprint 3 — Medium + Known-Complex Deep Dives (~350 checks)
-- Extend to Medium severity
-- Deep research on top 20–30 known-complex checks — documents phase rationale for future structured `phases` array
-- Research gate: override rate should trend down sprint-over-sprint
+```python
+for check in checks:
+    fw = check.get("frameworks", {})
+    if "cmmc" in fw and "profiles" not in fw["cmmc"]:
+        p = derive_cmmc_profiles(fw["cmmc"].get("controlId", ""))
+        if p:
+            fw["cmmc"]["profiles"] = p
+```
 
-### Sprint 4 — Low/Informational + Full QA (~200 checks)
-- Complete remaining checks
-- Cross-reference against M365-Assess remediation flows
-- Tag v2.1.0 release
+This same pattern applies to any future check source that loads frameworks externally.
+
+## Sprint Outcomes
+
+| Sprint | Scope | Overrides Added | Key Rule Changes |
+|---|---|---|---|
+| 1 | Foundation: schema, derivation logic, seed overrides | 10 | Initial rules established |
+| 2 | Critical/High severity (~250 checks) | 18 | Expanded `disruptionScope` to include AzAssess/service scope |
+| 3 | Medium severity + known-complex deep dives | 15 | `_AUTH_COLLECTORS` → `_USER_FACING_COLLECTORS` (expanded); Medium severity added as user-facing disruption trigger |
+| 4 | Low/Informational + full QA; false-positive cleanup | 5 | Removed `"block"` from `_PHASED_NAME_KEYWORDS`; restored CA-LEGACYAUTH-001 via override |
+| **Total** | **All 1,092 checks** | **48** | — |
+
+**Final registry stats (v2.9.0):**
+
+| Metric | Count |
+|---|---|
+| Total checks | 1,092 |
+| `isPhased: true` | 80 |
+| `disruptionRisk: true` | 776 |
+| Checks with manual overrides | 48 |
+| Override rate | 4.4% |
 
 ## Future: Structured Phases (v2.2.0)
 
@@ -155,7 +178,8 @@ The `_rationale` annotations written during Sprint 3 deep-dives directly seed th
 ## Verification
 
 - All 1,092 checks have a valid `effort` object in `registry.json` output ✓
-- Schema version bumped to 2.1.0 ✓
-- 8 known-complex checks pass Sprint 1 research gate ✓
-- No downstream consumer breakage — `effort` is additive only
-- Override rate tracked per sprint as derivation quality metric
+- Schema validation passes (`registry.schema.json` v2.1.0) ✓
+- 30 known-complex checks validated manually against expected values (Sprint 1 gate) ✓
+- Override rate tracked per sprint: 10 → 28 → 43 → 48 (rate declining relative to sprint scope = derivation improving) ✓
+- No downstream consumer breakage — `effort` is additive only ✓
+- False-positive `isPhased` count reduced from ~20 to 0 by Sprint 4 rule correction ✓


### PR DESCRIPTION
## Summary

- Status: Approved → Complete (v2.9.0)
- Final `_PHASED_NAME_KEYWORDS`: removed `"block"` (Sprint 4 false-positive fix)
- Final `_USER_FACING_COLLECTORS`: expanded set + Medium severity trigger (Sprint 3)
- Documents null severity defaulting to Medium (65 AZ checks)
- Documents AZ check post-processing pass for CMMC profiles
- Sprint outcomes table: 48 overrides, 80 phased, 776 disruption risk
- Verification checklist updated to completed state

The doc was written to a gitignored path (`docs/superpowers/specs/`) during the sprint and never made it into PR #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)