### PR TITLE
fix: expand truncated framework labels to official names

### DIFF
--- a/data/frameworks/cis-m365-v6.json
+++ b/data/frameworks/cis-m365-v6.json
@@ -1,6 +1,6 @@
 {
   "frameworkId": "cis-m365-v6",
-  "label": "CIS Microsoft 365 v6.0.1",
+  "label": "CIS Microsoft 365 Foundations Benchmark v6.0.1",
   "version": "6.0.1",
   "description": "Prescriptive configuration recommendations for Microsoft 365 services, organized into L1/L2 profiles and E3/E5 licensing tiers. Maintained by the Center for Internet Security.",
   "homepageUrl": "https://www.cisecurity.org/benchmark/microsoft_365",

--- a/data/frameworks/cisa-scuba.json
+++ b/data/frameworks/cisa-scuba.json
@@ -1,6 +1,6 @@
 {
   "frameworkId": "cisa-scuba",
-  "label": "CISA SCuBA",
+  "label": "CISA Secure Cloud Business Applications (SCuBA)",
   "version": "Baselines",
   "description": "CISA Secure Cloud Business Applications (SCuBA) project — configuration baselines and assessment tooling for cloud services used by US federal civilian agencies, including Microsoft 365.",
   "homepageUrl": "https://www.cisa.gov/resources-tools/services/secure-cloud-business-applications-scuba-project",

--- a/data/frameworks/iso-27001.json
+++ b/data/frameworks/iso-27001.json
@@ -1,6 +1,6 @@
 {
   "frameworkId": "iso-27001",
-  "label": "ISO 27001:2022",
+  "label": "ISO/IEC 27001:2022",
   "version": "2022",
   "description": "International standard for information security management systems (ISMS). Specifies requirements for establishing, implementing, maintaining, and continually improving organizational information security.",
   "homepageUrl": "https://www.iso.org/standard/27001",

--- a/data/frameworks/iso-27017.json
+++ b/data/frameworks/iso-27017.json
@@ -1,6 +1,6 @@
 {
   "frameworkId": "iso-27017",
-  "label": "ISO 27017:2015",
+  "label": "ISO/IEC 27017:2015",
   "version": "2015",
   "description": "International standard providing cloud-specific information security control guidelines, supplementing ISO/IEC 27001 with control objectives and implementation guidance for cloud service providers and customers.",
   "homepageUrl": "https://www.iso.org/standard/43757.html",

--- a/data/frameworks/nist-800-171.json
+++ b/data/frameworks/nist-800-171.json
@@ -1,9 +1,9 @@
 {
   "frameworkId": "nist-800-171",
-  "label": "NIST 800-171 R2",
+  "label": "NIST SP 800-171 Rev. 2",
   "version": "R2",
-  "description": "NIST SP 800-171 — protecting Controlled Unclassified Information (CUI) in non-federal systems. Rev 3 aligns with SP 800-53 and forms the technical basis for CMMC Level 2 requirements.",
-  "homepageUrl": "https://csrc.nist.gov/pubs/sp/800/171/r3/final",
+  "description": "NIST SP 800-171 Rev. 2 — protecting Controlled Unclassified Information (CUI) in non-federal systems. 110 security requirements forming the technical basis for CMMC Level 2.",
+  "homepageUrl": "https://csrc.nist.gov/pubs/sp/800/171/r2/upd1/final",
   "css": "fw-nist-cui",
   "totalControls": 110,
   "registryKey": "nist-800-171",

--- a/data/frameworks/nist-csf.json
+++ b/data/frameworks/nist-csf.json
@@ -1,6 +1,6 @@
 {
   "frameworkId": "nist-csf",
-  "label": "NIST CSF 2.0",
+  "label": "NIST Cybersecurity Framework 2.0",
   "version": "2.0",
   "description": "NIST Cybersecurity Framework — voluntary framework for managing and reducing cybersecurity risk, organized into six functions: Govern, Identify, Protect, Detect, Respond, and Recover.",
   "homepageUrl": "https://www.nist.gov/cyberframework",


### PR DESCRIPTION
## Summary

- Framework `label` fields updated to match official published names
- Fixes abbreviations that hide framework identity in reports and artifacts

## Changes

| Framework | Before | After |
|---|---|---|
| cisa-scuba | CISA SCuBA | CISA Secure Cloud Business Applications (SCuBA) |
| iso-27001 | ISO 27001:2022 | ISO/IEC 27001:2022 |
| iso-27017 | ISO 27017:2015 | ISO/IEC 27017:2015 |
| nist-800-171 | NIST 800-171 R2 | NIST SP 800-171 Rev. 2 |
| nist-csf | NIST CSF 2.0 | NIST Cybersecurity Framework 2.0 |
| cis-m365-v6 | CIS Microsoft 365 v6.0.1 | CIS Microsoft 365 Foundations Benchmark v6.0.1 |

Also fixes a `nist-800-171` data bug: description mentioned "Rev 3" and `homepageUrl` pointed to the r3 final — both incorrect since CheckID maps to Rev 2 (which CMMC 2.0 uses). Corrected to the r2 upd1 final URL.

## No registry rebuild needed

`label` is framework metadata only — not a field derived into check entries. No `registry.json` rebuild required.

## Test plan

- [x] All 6 files parse as valid JSON
- [x] `label` values match official framework documentation
- [x] `nist-800-171` URL resolves to Rev. 2 final publication

🤖 Generated with [Claude Code](https://claude.com/claude-code)