### PR TITLE
fix(scuba): update stale SCuBA policy IDs to current v2 baseline

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -1534,7 +1534,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.AAD.3.5v1"
+          "controlId": "MS.AAD.3.5v2"
         }
       },
       "impactRating": {
@@ -3741,7 +3741,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.AAD.3.2v1;MS.AAD.3.3v1"
+          "controlId": "MS.AAD.3.2v2;MS.AAD.3.3v2"
         },
         "stig": {
           "controlId": "V-260337"
@@ -16741,7 +16741,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.AAD.3.1v1;MS.AAD.3.2v1"
+          "controlId": "MS.AAD.3.1v1;MS.AAD.3.2v2"
         }
       },
       "effort": {

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -1096,7 +1096,7 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.AAD.3.1v1;MS.AAD.3.2v1"
+      "cisaScubaControlId": "MS.AAD.3.1v1;MS.AAD.3.2v2"
     },
     {
       "checkId": "ENTRA-APPS-001",
@@ -1564,7 +1564,7 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.AAD.3.2v1;MS.AAD.3.3v1",
+      "cisaScubaControlId": "MS.AAD.3.2v2;MS.AAD.3.3v2",
       "stigControlId": "V-260337",
       "remediation": "Security Defaults enforces MFA for all users. For granular control, disable Security Defaults and create Conditional Access policies."
     },
@@ -1827,7 +1827,7 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.AAD.3.5v1",
+      "cisaScubaControlId": "MS.AAD.3.5v2",
       "remediation": "Entra admin center > Protection > Authentication methods > Microsoft Authenticator > Configure > Require number matching = Enabled, Show application name = Enabled."
     },
     {


### PR DESCRIPTION
## Summary

- Three MS.AAD policies updated from v1 to v2 in `scf-check-mapping.json`
- Registry rebuilt to propagate corrected `cisa-scuba.controlId` values

## Changes

| Check | Before | After |
|---|---|---|
| CA-EXCLUSION-001 | `MS.AAD.3.1v1;MS.AAD.3.2v1` | `MS.AAD.3.1v1;MS.AAD.3.2v2` |
| CA-MFA-ALL-001 | `MS.AAD.3.2v1;MS.AAD.3.3v1` | `MS.AAD.3.2v2;MS.AAD.3.3v2` |
| ENTRA-AUTHMETHOD-003 | `MS.AAD.3.5v1` | `MS.AAD.3.5v2` |

**NIST enrichment was not broken.** `Build-Registry.py` strips the version suffix before querying `scuba-nist-mapping.json`, so the NIST 800-53 mappings derived from ScubaGear have always been correct. Only the stored `controlId` string was stale.

## Open findings (not changed in this PR)

**MS.EXO.16.1v1** (`COMPLIANCE-AUDIT-001`, `EXO-AUDIT-001`) — Research indicates the current ScubaGear EXO baseline may not include policies beyond MS.EXO.13.1 in the automated tool. These two entries may reference a retired or documentation-only policy. Removing the mapping requires confirming the policy is fully retired, not just unautomated. Left unchanged pending verification.

**MS.EXO.2.2v1** (`DNS-DMARC-001`) — Unconfirmed whether this has advanced to v2 or v3. Already paired with `MS.EXO.2.1v2` in the same check. Left unchanged pending direct CSV verification.

## Test plan

- [x] `scf-check-mapping.json` parses as valid JSON
- [x] `registry.json` rebuilt cleanly (1,092 checks, no errors)
- [x] Updated `cisa-scuba.controlId` values confirmed in rebuilt registry
- [x] Unchanged checks (MS.EXO.16.1, MS.EXO.2.2) verified still present

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)