### PR TITLE
fix(scuba): update MS.EXO.2.2 to v3 and remove retired MS.EXO.16.1 mapping

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -68000,7 +68000,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.EXO.2.1v2;MS.EXO.2.2v1"
+          "controlId": "MS.EXO.2.1v2;MS.EXO.2.2v3"
         }
       },
       "impactRating": {
@@ -76408,9 +76408,6 @@
             "E5-L1"
           ]
         },
-        "cisa-scuba": {
-          "controlId": "MS.EXO.16.1v1"
-        },
         "nist-csf": {
           "controlId": "DE.AE-03",
           "title": "Information is correlated from multiple sources"
@@ -76594,9 +76591,6 @@
             "E3-L1",
             "E5-L1"
           ]
-        },
-        "cisa-scuba": {
-          "controlId": "MS.EXO.16.1v1"
         },
         "nist-csf": {
           "controlId": "DE.AE-03",

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -597,7 +597,7 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.EXO.2.1v2;MS.EXO.2.2v1",
+      "cisaScubaControlId": "MS.EXO.2.1v2;MS.EXO.2.2v3",
       "remediation": "Connect to Exchange Online and verify accepted domains."
     },
     {
@@ -802,7 +802,6 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.EXO.16.1v1",
       "remediation": "Run: Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true. Microsoft Purview > Audit > Start recording user and admin activity."
     },
     {
@@ -1667,7 +1666,7 @@
         "MON-16"
       ],
       "impactSeverity": "High",
-      "impactRationale": "Failure to expedite the process of removing \"high risk\" individual\u2019s access to Technology Assets, Applications, Services and/or Data (TAASD) upon termination, as determined by management exposes the tenant to: Improper assignment of privileged functions, Unauthorized access.",
+      "impactRationale": "Failure to expedite the process of removing \"high risk\" individual’s access to Technology Assets, Applications, Services and/or Data (TAASD) upon termination, as determined by management exposes the tenant to: Improper assignment of privileged functions, Unauthorized access.",
       "cisM365ControlId": "5.2.2.6",
       "cisM365Profiles": [
         "E5-L1"
@@ -1689,7 +1688,7 @@
         "MON-16"
       ],
       "impactSeverity": "High",
-      "impactRationale": "Failure to expedite the process of removing \"high risk\" individual\u2019s access to Technology Assets, Applications, Services and/or Data (TAASD) upon termination, as determined by management exposes the tenant to: Improper assignment of privileged functions, Unauthorized access.",
+      "impactRationale": "Failure to expedite the process of removing \"high risk\" individual’s access to Technology Assets, Applications, Services and/or Data (TAASD) upon termination, as determined by management exposes the tenant to: Improper assignment of privileged functions, Unauthorized access.",
       "cisM365ControlId": "5.2.2.7",
       "cisM365Profiles": [
         "E5-L1"
@@ -1711,7 +1710,7 @@
         "MON-16"
       ],
       "impactSeverity": "High",
-      "impactRationale": "Failure to expedite the process of removing \"high risk\" individual\u2019s access to Technology Assets, Applications, Services and/or Data (TAASD) upon termination, as determined by management exposes the tenant to: Improper assignment of privileged functions, Unauthorized access.",
+      "impactRationale": "Failure to expedite the process of removing \"high risk\" individual’s access to Technology Assets, Applications, Services and/or Data (TAASD) upon termination, as determined by management exposes the tenant to: Improper assignment of privileged functions, Unauthorized access.",
       "cisM365ControlId": "5.2.2.8",
       "cisM365Profiles": [
         "E5-L2"
@@ -2176,7 +2175,6 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.EXO.16.1v1",
       "remediation": "Run: Set-OrganizationConfig -AuditDisabled $false. Note: this is the Exchange org-level audit flag and is a pre-condition for UAL, but does not guarantee UAL ingestion is active. Verify UAL separately (COMPLIANCE-AUDIT-001)."
     },
     {
@@ -3984,7 +3982,7 @@
       ],
       "impactSeverity": "",
       "impactRationale": "Failure to revoke user access rights in a timely manner, upon termination of employment or contract exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
-      "remediation": "Informational \u2014 review and remove stale guest accounts periodically. Entra admin center > Users > Guest users."
+      "remediation": "Informational — review and remove stale guest accounts periodically. Entra admin center > Users > Guest users."
     },
     {
       "checkId": "ENTRA-CA-002",
@@ -4000,7 +3998,7 @@
       ],
       "impactSeverity": "",
       "impactRationale": "Failure to enforce Logical Access Control (LAC) permissions that conform to the principle of \"least privilege?\" exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
-      "remediation": "Informational \u2014 review Conditional Access policy coverage for your organization."
+      "remediation": "Informational — review Conditional Access policy coverage for your organization."
     },
     {
       "checkId": "ENTRA-CA-003",
@@ -4120,7 +4118,7 @@
       ],
       "impactSeverity": "",
       "impactRationale": "Failure to establish and maintain an authoritative source and repository to provide a trusted source and accountability for approved and implemented system components that prevents assets from being duplicated in other asset inventories exposes the tenant to: Emergent properties.",
-      "remediation": "Informational \u2014 confirms Teams service connectivity."
+      "remediation": "Informational — confirms Teams service connectivity."
     },
     {
       "checkId": "CA-RISKPOLICY-001",


### PR DESCRIPTION
## Summary

Follow-up to #213 — resolves the two EXO findings left open pending verification.

## Changes

| Check | Field | Before | After |
|---|---|---|---|
| DNS-DMARC-001 | `cisa-scuba.controlId` | `MS.EXO.2.1v2;MS.EXO.2.2v1` | `MS.EXO.2.1v2;MS.EXO.2.2v3` |
| COMPLIANCE-AUDIT-001 | `cisa-scuba.controlId` | `MS.EXO.16.1v1` | *(removed)* |
| EXO-AUDIT-001 | `cisa-scuba.controlId` | `MS.EXO.16.1v1` | *(removed)* |

## Rationale

**MS.EXO.2.2v1 → v3:** The SPF policy requirement advanced two versions in the current ScubaGear EXO baseline. Verified against the ScubaGear repo.

**MS.EXO.16.1v1 retired:** The current ScubaGear EXO baseline only runs through MS.EXO.13.1. Policies MS.EXO.14–17 are no longer active in the automated baseline. Removing the stale mappings prevents COMPLIANCE-AUDIT-001 and EXO-AUDIT-001 from claiming SCuBA coverage they no longer have.

## Open: MS.EXO.14–17 range investigation

The MS.EXO.14.x (Safe Attachments), 15.x (Safe Links), and 17.x (audit) mappings still exist on several checks. Some of these may have migrated to the Defender product baseline rather than being fully retired. A separate issue will track this investigation.

## Test plan

- [x] `scf-check-mapping.json` parses as valid JSON
- [x] `registry.json` rebuilt cleanly (1,092 checks)
- [x] DNS-DMARC-001 shows `MS.EXO.2.2v3` in rebuilt registry
- [x] COMPLIANCE-AUDIT-001 and EXO-AUDIT-001 have no `cisa-scuba` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)