### PR TITLE
fix(scuba): migrate stale MS.EXO.14–17 policy IDs to current baseline

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -76755,8 +76755,8 @@
           "controlId": "3.3.6"
         },
         "nist-800-53": {
-          "controlId": "AU-2;AU-7;AU-12;AU-07;AU-07(01)",
-          "title": "Event Logging; Audit Record Reduction and Report Generation; Audit Record Generation",
+          "controlId": "AU-12;AU-2;AU-7;AU-07;AU-07(01)",
+          "title": "Audit Record Generation; Event Logging; Audit Record Reduction and Report Generation",
           "profiles": [
             "Low",
             "Moderate",
@@ -76776,7 +76776,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.EXO.17.1v1;MS.EXO.17.2v1"
+          "controlId": "MS.EXO.13.1v1"
         },
         "nist-csf": {
           "controlId": "DE.AE-03",
@@ -76941,8 +76941,8 @@
           "controlId": "3.3.6"
         },
         "nist-800-53": {
-          "controlId": "AU-3;AU-3(1);AU-7;AU-12;AU-07;AU-07(01)",
-          "title": "Content of Audit Records; Additional Audit Information; Audit Record Reduction and Report Generation; Audit Record Generation",
+          "controlId": "AU-12;AU-3;AU-3(1);AU-7;AU-07;AU-07(01)",
+          "title": "Audit Record Generation; Content of Audit Records; Additional Audit Information; Audit Record Reduction and Report Generation",
           "profiles": [
             "Low",
             "Moderate",
@@ -76962,7 +76962,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.EXO.17.3v1"
+          "controlId": "MS.EXO.13.1v1"
         },
         "nist-csf": {
           "controlId": "DE.AE-03",
@@ -82151,7 +82151,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.EXO.1.1v1"
+          "controlId": "MS.EXO.1.1v2"
         },
         "nist-csf": {
           "controlId": "PR.DS-02",
@@ -91823,7 +91823,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.EXO.15.1v1;MS.EXO.15.2v1;MS.EXO.15.3v1"
+          "controlId": "MS.DEFENDER.1.3v1"
         }
       },
       "impactRating": {
@@ -92362,7 +92362,7 @@
           ]
         },
         "cisa-scuba": {
-          "controlId": "MS.EXO.14.1v2"
+          "controlId": "MS.DEFENDER.1.3v1;MS.DEFENDER.3.1v1"
         }
       },
       "impactRating": {

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -393,7 +393,7 @@
       "cisM365Profiles": [
         "E5-L2"
       ],
-      "cisaScubaControlId": "MS.EXO.15.1v1;MS.EXO.15.2v1;MS.EXO.15.3v1",
+      "cisaScubaControlId": "MS.DEFENDER.1.3v1",
       "remediation": "Run: New-SafeLinksPolicy -Name \"Safe Links\" -IsEnabled $true; New-SafeLinksRule -Name \"Safe Links\" -SafeLinksPolicy \"Safe Links\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Links > Create a policy covering all users."
     },
     {
@@ -466,7 +466,7 @@
       "cisM365Profiles": [
         "E5-L2"
       ],
-      "cisaScubaControlId": "MS.EXO.14.1v2",
+      "cisaScubaControlId": "MS.DEFENDER.1.3v1;MS.DEFENDER.3.1v1",
       "remediation": "Run: New-SafeAttachmentPolicy -Name \"Safe Attachments\" -Enable $true -Action Block; New-SafeAttachmentRule -Name \"Safe Attachments\" -SafeAttachmentPolicy \"Safe Attachments\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Attachments > Create a policy covering all users."
     },
     {
@@ -2193,7 +2193,7 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.EXO.17.1v1;MS.EXO.17.2v1",
+      "cisaScubaControlId": "MS.EXO.13.1v1",
       "remediation": "No user mailboxes found to sample."
     },
     {
@@ -2212,7 +2212,7 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.EXO.17.3v1",
+      "cisaScubaControlId": "MS.EXO.13.1v1",
       "remediation": "Run: Set-MailboxAuditBypassAssociation -Identity <user> -AuditBypassEnabled $false for each bypassed mailbox."
     },
     {
@@ -2267,7 +2267,7 @@
         "E3-L1",
         "E5-L1"
       ],
-      "cisaScubaControlId": "MS.EXO.1.1v1",
+      "cisaScubaControlId": "MS.EXO.1.1v2",
       "remediation": "Run: Set-RemoteDomain -Identity Default -AutoForwardEnabled $false. Also consider transport rules to block client-side forwarding."
     },
     {


### PR DESCRIPTION
## Summary

Five checks carried SCuBA policy IDs from EXO sections 8–17 that no longer exist in the current ScubaGear EXO baseline (which only runs through MS.EXO.13.1). Safe Attachments and Safe Links moved to the Defender product baseline; audit policies consolidated into MS.EXO.13.1.

## Changes

| Check | Before | After | Reason |
|---|---|---|---|
| EXO-FORWARD-001 | `MS.EXO.1.1v1` | `MS.EXO.1.1v2` | Version bump — policy still exists, advanced to v2 |
| DEFENDER-SAFEATTACH-001 | `MS.EXO.14.1v2` | `MS.DEFENDER.1.3v1;MS.DEFENDER.3.1v1` | Moved to Defender baseline (preset security + SharePoint/Teams) |
| DEFENDER-SAFELINKS-001 | `MS.EXO.15.1v1;MS.EXO.15.2v1;MS.EXO.15.3v1` | `MS.DEFENDER.1.3v1` | Moved to Defender baseline; consolidated into preset security policy |
| EXO-AUDIT-002 | `MS.EXO.17.3v1` | `MS.EXO.13.1v1` | Mailbox audit bypass → current mailbox auditing policy |
| EXO-AUDIT-003 | `MS.EXO.17.1v1;MS.EXO.17.2v1` | `MS.EXO.13.1v1` | Mailbox audit actions → current mailbox auditing policy |

## NIST enrichment note

NIST enrichment for the EXO.14–17 range was already non-functional — `scuba-nist-mapping.json` had no entries for those sections. The mapping file already reflects the current ScubaGear baseline (sections 1–7 and 13 only). Adding MS.DEFENDER entries to the mapping for the newly migrated Defender IDs is tracked in #215.

## Still open (#215)

Three checks still carry stale EXO IDs pending verification of their Defender equivalents:
- COMPLIANCE-DLP-001 (`MS.EXO.8.1v1`) — DLP location unclear
- DEFENDER-ANTIMALWARE-001 (`MS.EXO.9.1v2;MS.EXO.9.2v1`) — anti-malware Defender mapping TBD
- DEFENDER-ANTIPHISH-001 (`MS.EXO.11.1v1`) — anti-phishing Defender mapping TBD

## Test plan

- [x] `scf-check-mapping.json` parses as valid JSON
- [x] `registry.json` rebuilt cleanly (1,092 checks)
- [x] All 5 updated entries verified in rebuilt registry

Relates to #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)