### PR TITLE
feat(schema): add impact, rationale, references, tags fields (v2.2.0)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -100,7 +100,7 @@ jobs:
           $reg = Get-Content data/registry.json -Raw | ConvertFrom-Json
           $errors = @()
 
-          if ($reg.schemaVersion -ne '2.1.0') { $errors += "Expected schemaVersion 2.1.0, got '$($reg.schemaVersion)'" }
+          if ($reg.schemaVersion -ne '2.2.0') { $errors += "Expected schemaVersion 2.2.0, got '$($reg.schemaVersion)'" }
           if (-not $reg.dataVersion) { $errors += "Missing 'dataVersion' field" }
           if (-not $reg.checks) { $errors += "Missing 'checks' array" }
           if ($reg.checks.Count -lt 160) { $errors += "Expected at least 160 checks, got $($reg.checks.Count)" }
@@ -128,7 +128,7 @@ jobs:
             $errors | ForEach-Object { Write-Host "::error::$_" }
             exit 1
           }
-          Write-Host "  registry.json: $($reg.checks.Count) checks, schema v2.1.0 valid"
+          Write-Host "  registry.json: $($reg.checks.Count) checks, schema v2.2.0 valid"
 
       - name: Validate registry against JSON Schema
         run: |

--- a/data/registry.json
+++ b/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "2.1.0",
+  "schemaVersion": "2.2.0",
   "dataVersion": "2026-04-19",
   "generatedFrom": "data/scf-check-mapping.json + SecFrame/SCF/scf.db + data/scf-framework-map.json + data/az-assess-source-checks.json",
   "checks": [
@@ -304,7 +304,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Access Microsoft Secure Score at security.microsoft.com/securescore. Review and act on improvement recommendations regularly."
+      "remediation": "Access Microsoft Secure Score at security.microsoft.com/securescore. Review and act on improvement recommendations regularly.",
+      "tags": [
+        "compliance",
+        "defender",
+        "email"
+      ]
     },
     {
       "checkId": "DEFENDER-SECURESCORE-001",
@@ -531,7 +536,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "compliance",
+        "defender",
+        "email"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-020",
@@ -721,7 +731,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Investigate foreign apps using Microsoft product names -- they may be social engineering attempts. Verify the publisher and appId against known Microsoft first-party apps. Remove if suspicious."
+      "remediation": "Investigate foreign apps using Microsoft product names -- they may be social engineering attempts. Verify the publisher and appId against known Microsoft first-party apps. Remove if suspicious.",
+      "tags": [
+        "app-registration",
+        "identity",
+        "threat-management"
+      ]
     },
     {
       "checkId": "ENTRA-SECDEFAULT-001",
@@ -915,14 +930,24 @@
           "controlId": "MS.AAD.1.1v1"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to uniquely identify and centrally Authenticate, Authorize and Audit (AAA) organizational users and processes acting on behalf of organizational users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Update-MgPolicyIdentitySecurityDefaultsEnforcementPolicy -IsEnabled $true. Entra admin center > Properties > Manage security defaults."
+      "remediation": "Run: Update-MgPolicyIdentitySecurityDefaultsEnforcementPolicy -IsEnabled $true. Entra admin center > Properties > Manage security defaults.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-SECDEFAULT-002",
@@ -1128,7 +1153,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "No action needed. Conditional Access policies provide equivalent coverage to Security Defaults."
+      "remediation": "No action needed. Conditional Access policies provide equivalent coverage to Security Defaults.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-PHISHRES-001",
@@ -1348,7 +1378,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Create a CA policy: Target admin roles > Grant > Require authentication strength > Phishing-resistant MFA. Entra admin center > Protection > Conditional Access."
+      "remediation": "Create a CA policy: Target admin roles > Grant > Require authentication strength > Phishing-resistant MFA. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-AUTHMETHOD-003",
@@ -1548,7 +1583,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Protection > Authentication methods > Microsoft Authenticator > Configure > Require number matching = Enabled, Show application name = Enabled."
+      "remediation": "Entra admin center > Protection > Authentication methods > Microsoft Authenticator > Configure > Require number matching = Enabled, Show application name = Enabled.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "SPO-B2B-001",
@@ -1731,7 +1771,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Enable B2B integration in SharePoint admin center > Policies > Sharing > More external sharing settings > Enable integration with Azure AD B2B."
+      "remediation": "Enable B2B integration in SharePoint admin center > Policies > Sharing > More external sharing settings > Enable integration with Azure AD B2B.",
+      "tags": [
+        "collaboration",
+        "identification-authentication",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-SHARING-001",
@@ -1915,7 +1960,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -SharingCapability ExistingExternalUserSharingOnly. SharePoint admin center > Policies > Sharing."
+      "remediation": "Run: Set-SPOTenant -SharingCapability ExistingExternalUserSharingOnly. SharePoint admin center > Policies > Sharing.",
+      "tags": [
+        "collaboration",
+        "data",
+        "identification-authentication",
+        "sharepoint",
+        "sharing"
+      ]
     },
     {
       "checkId": "SPO-OD-001",
@@ -2099,7 +2151,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "SharePoint admin center > Policies > Sharing > OneDrive > set to \"Existing guests\" or more restrictive."
+      "remediation": "SharePoint admin center > Policies > Sharing > OneDrive > set to \"Existing guests\" or more restrictive.",
+      "tags": [
+        "collaboration",
+        "identification-authentication",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-ACCESS-001",
@@ -2291,7 +2348,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Ensure Policy.Read.All permission is consented. Create a CA policy targeting SharePoint Online (00000003-0000-0ff1-ce00-000000000000) or All Cloud Apps."
+      "remediation": "Ensure Policy.Read.All permission is consented. Create a CA policy targeting SharePoint Online (00000003-0000-0ff1-ce00-000000000000) or All Cloud Apps.",
+      "tags": [
+        "collaboration",
+        "identification-authentication",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-001",
@@ -2329,7 +2391,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-003",
@@ -2366,7 +2432,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "conditional-access",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "AZ-COMPUTE-001",
@@ -2433,7 +2505,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-022",
@@ -2500,7 +2576,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-030",
@@ -2567,7 +2647,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-031",
@@ -2634,7 +2718,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-035",
@@ -2701,7 +2789,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-036",
@@ -2768,7 +2860,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-037",
@@ -2835,7 +2931,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-038",
@@ -2902,7 +3002,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-VM-011",
@@ -2969,7 +3073,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-COSMOS-003",
@@ -3036,7 +3144,11 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-029",
@@ -3103,7 +3215,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-032",
@@ -3170,7 +3286,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-033",
@@ -3237,7 +3357,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-034",
@@ -3304,7 +3428,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-039",
@@ -3371,7 +3499,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "CA-MFA-ADMIN-001",
@@ -3567,7 +3699,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Security Defaults enforces MFA for all admin roles. For granular control, disable Security Defaults and create Conditional Access policies."
+      "remediation": "Security Defaults enforces MFA for all admin roles. For granular control, disable Security Defaults and create Conditional Access policies.",
+      "tags": [
+        "authentication",
+        "conditional-access",
+        "identification-authentication",
+        "identity",
+        "mfa"
+      ]
     },
     {
       "checkId": "CA-MFA-ALL-001",
@@ -3763,7 +3902,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Security Defaults enforces MFA for all users. For granular control, disable Security Defaults and create Conditional Access policies."
+      "remediation": "Security Defaults enforces MFA for all users. For granular control, disable Security Defaults and create Conditional Access policies.",
+      "tags": [
+        "authentication",
+        "conditional-access",
+        "identification-authentication",
+        "identity",
+        "mfa"
+      ]
     },
     {
       "checkId": "CA-INTUNE-001",
@@ -3956,7 +4102,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Create a CA policy: Target Microsoft Intune enrollment app > Session > Sign-in frequency = Every time. Entra admin center > Protection > Conditional Access."
+      "remediation": "Create a CA policy: Target Microsoft Intune enrollment app > Session > Sign-in frequency = Every time. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-MFA-001",
@@ -4146,7 +4297,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Update-MgBetaPolicyAuthenticationMethodPolicy with RegistrationEnforcement settings. Entra admin center > Protection > Authentication methods > Registration campaign."
+      "remediation": "Run: Update-MgBetaPolicyAuthenticationMethodPolicy with RegistrationEnforcement settings. Entra admin center > Protection > Authentication methods > Registration campaign.",
+      "tags": [
+        "authentication",
+        "entra-id",
+        "identification-authentication",
+        "identity",
+        "mfa"
+      ]
     },
     {
       "checkId": "ENTRA-AUTHMETHOD-004",
@@ -4336,7 +4494,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Protection > Authentication methods > Settings > System-preferred multifactor authentication > Enabled."
+      "remediation": "Entra admin center > Protection > Authentication methods > Settings > System-preferred multifactor authentication > Enabled.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-008",
@@ -4514,13 +4677,23 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to utilize Multi-Factor Authentication (MFA) to authenticate local access for privileged accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 5
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-MFA-002",
@@ -4689,13 +4862,25 @@
           "title": "Users, services, and hardware are authenticated"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to utilize Multi-Factor Authentication (MFA) to authenticate local access for privileged accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 5
+      },
       "effort": {
-        "complexity": 2,
+        "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "authentication",
+        "entra-id",
+        "identification-authentication",
+        "identity",
+        "mfa"
+      ]
     },
     {
       "checkId": "ENTRA-ADMIN-004",
@@ -4878,7 +5063,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Enroll all Global Administrators in phishing-resistant MFA (FIDO2, Windows Hello for Business, or certificate-based). Entra admin center > Protection > Authentication methods > Policies."
+      "remediation": "Enroll all Global Administrators in phishing-resistant MFA (FIDO2, Windows Hello for Business, or certificate-based). Entra admin center > Protection > Authentication methods > Policies.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-002",
@@ -4916,7 +5106,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "ENTRA-GUEST-003",
@@ -5230,6 +5424,11 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to revoke user access rights in a timely manner, upon termination of employment or contract exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -5237,7 +5436,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Informational — review and remove stale guest accounts periodically. Entra admin center > Users > Guest users."
+      "remediation": "Informational — review and remove stale guest accounts periodically. Entra admin center > Users > Guest users.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ROLEGROUP-001",
@@ -5437,12 +5641,23 @@
           "controlId": "MS.AAD.7.2v1"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to enforce Role-Based Access Control (RBAC) for Technology Assets, Applications, Services and/or Data (TAASD) to restrict access to individuals assigned specific roles with legitimate business needs exposes the tenant to: Inability to maintain individual accountability.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
-        "disruptionRisk": false
-      }
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
+        "disruptionRisk": true,
+        "disruptionScope": "admin-only"
+      },
+      "tags": [
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-PASSWORD-001",
@@ -5653,7 +5868,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Update-MgDomain -DomainId {domain} -PasswordValidityPeriodInDays 2147483647. M365 admin center > Settings > Password expiration policy."
+      "remediation": "Run: Update-MgDomain -DomainId {domain} -PasswordValidityPeriodInDays 2147483647. M365 admin center > Settings > Password expiration policy.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PASSWORD-002",
@@ -5862,7 +6082,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Update-MgBetaDirectorySetting for Password Rule Settings with CustomBannedPasswordsEnforced = true. Entra admin center > Protection > Password protection."
+      "remediation": "Run: Update-MgBetaDirectorySetting for Password Rule Settings with CustomBannedPasswordsEnforced = true. Entra admin center > Protection > Password protection.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PASSWORD-005",
@@ -6071,7 +6296,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Not applicable for cloud-only tenants. If you configure hybrid identity in the future, enable on-premises password protection."
+      "remediation": "Not applicable for cloud-only tenants. If you configure hybrid identity in the future, enable on-premises password protection.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-SSPR-001",
@@ -6279,7 +6509,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Protection > Authentication methods > Registration campaign > Enable and target All Users."
+      "remediation": "Entra admin center > Protection > Authentication methods > Registration campaign > Enable and target All Users.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-005",
@@ -6350,7 +6585,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-008",
@@ -6421,7 +6660,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-009",
@@ -6491,7 +6734,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-010",
@@ -6561,7 +6808,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-001",
@@ -6632,7 +6883,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-002",
@@ -6703,7 +6958,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-003",
@@ -6774,7 +7033,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-004",
@@ -6845,7 +7108,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-005",
@@ -6916,7 +7183,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-006",
@@ -6987,7 +7258,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-007",
@@ -7058,7 +7333,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-008",
@@ -7129,7 +7408,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-009",
@@ -7200,7 +7483,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-011",
@@ -7271,7 +7558,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-049",
@@ -7342,7 +7633,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-065",
@@ -7413,7 +7710,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-125",
@@ -7484,7 +7787,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-107",
@@ -7555,7 +7864,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-108",
@@ -7626,7 +7940,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-006",
@@ -7697,7 +8016,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-007",
@@ -7768,7 +8091,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-ACCOUNT-010",
@@ -7839,7 +8166,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-132",
@@ -7910,7 +8241,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-012",
@@ -8080,7 +8417,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Migrate app credentials from client secrets to certificates or managed identities. Secrets are extractable from memory and logs. Entra admin center > App registrations > Certificates & secrets."
+      "remediation": "Migrate app credentials from client secrets to certificates or managed identities. Secrets are extractable from memory and logs. Entra admin center > App registrations > Certificates & secrets.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-HYBRID-001",
@@ -8240,7 +8582,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Verify Password Hash Sync status in Azure AD Connect. Entra admin center > Identity > Hybrid management > Azure AD Connect."
+      "remediation": "Verify Password Hash Sync status in Azure AD Connect. Entra admin center > Identity > Hybrid management > Azure AD Connect.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PASSWORD-004",
@@ -8375,6 +8722,11 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to ensure default authenticators are changed as part of account creation or system installation exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -8382,7 +8734,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Update-MgBetaDirectorySetting for Password Rule Settings to add organization-specific terms. Entra admin center > Protection > Password protection."
+      "remediation": "Run: Update-MgBetaDirectorySetting for Password Rule Settings to add organization-specific terms. Entra admin center > Protection > Password protection.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-013",
@@ -8565,7 +8922,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Remove expired credentials. Expired secrets/certs are attack surface -- they indicate poor credential lifecycle management. Entra admin center > App registrations > Certificates & secrets."
+      "remediation": "Remove expired credentials. Expired secrets/certs are attack surface -- they indicate poor credential lifecycle management. Entra admin center > App registrations > Certificates & secrets.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "SPO-SHARING-006",
@@ -8710,7 +9072,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -EmailAttestationRequired $true -EmailAttestationReAuthDays 30. SharePoint admin center > Policies > Sharing > Verification code reauthentication."
+      "remediation": "Run: Set-SPOTenant -EmailAttestationRequired $true -EmailAttestationReAuthDays 30. SharePoint admin center > Policies > Sharing > Verification code reauthentication.",
+      "tags": [
+        "collaboration",
+        "data",
+        "identification-authentication",
+        "sharepoint",
+        "sharing"
+      ]
     },
     {
       "checkId": "CA-SESSION-001",
@@ -8863,7 +9232,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Persistent browser sessions on unmanaged devices increase the risk of session hijacking. Require device compliance or remove persistent browser grants. Entra admin center > Protection > Conditional Access."
+      "remediation": "Persistent browser sessions on unmanaged devices increase the risk of session hijacking. Require device compliance or remove persistent browser grants. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-001",
@@ -8901,7 +9275,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-003",
@@ -8939,7 +9317,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-001",
@@ -8977,7 +9359,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "EXO-SHAREDMBX-001",
@@ -9368,7 +9754,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Block sign-in for shared mailbox accounts: Set-AzureADUser -ObjectId <UPN> -AccountEnabled $false. Entra admin center > Users > select shared mailbox user > Properties > Account enabled > No."
+      "remediation": "Block sign-in for shared mailbox accounts: Set-AzureADUser -ObjectId <UPN> -AccountEnabled $false. Entra admin center > Users > select shared mailbox user > Properties > Account enabled > No.",
+      "tags": [
+        "email",
+        "exchange-online",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "DNS-SPF-001",
@@ -9762,7 +10153,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Connect to Exchange Online and verify accepted domains."
+      "remediation": "Connect to Exchange Online and verify accepted domains.",
+      "tags": [
+        "dns",
+        "email",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "ENTRA-GROUP-002",
@@ -10156,7 +10552,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Groups > New group > Membership type = Dynamic User > Rule: (user.userType -eq \"Guest\"). This enables targeted policies for guest users."
+      "remediation": "Entra admin center > Groups > New group > Membership type = Dynamic User > Rule: (user.userType -eq \"Guest\"). This enables targeted policies for guest users.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-001",
@@ -10555,7 +10956,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles > Global Administrator > Remove permanent active assignments. Use eligible assignments with time-bound activation."
+      "remediation": "Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles > Global Administrator > Remove permanent active assignments. Use eligible assignments with time-bound activation.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-STALEADMIN-001",
@@ -10932,12 +11338,23 @@
           "title": "Identities and credentials for authorized users, services, and hardware are managed by the organization; Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to proactively govern account management of individual, group, system, service, application, guest and temporary accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
-        "disruptionRisk": false
-      }
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
+        "disruptionRisk": true,
+        "disruptionScope": "admin-only"
+      },
+      "tags": [
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-GROUP-004",
@@ -11312,13 +11729,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to proactively govern account management of individual, group, system, service, application, guest and temporary accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-018",
@@ -11688,7 +12115,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Assign owners to orphaned app registrations. Without owners, no one is accountable for credential rotation or permission review. Entra admin center > App registrations > Owners > Add owner."
+      "remediation": "Assign owners to orphaned app registrations. Without owners, no one is accountable for credential rotation or permission review. Entra admin center > App registrations > Owners > Add owner.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "SPO-SITE-003",
@@ -12042,7 +12474,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Get-SPOSite | ForEach-Object { Get-SPOSiteAdministrator -Site $_.Url } to enumerate site administrators."
+      "remediation": "Run: Get-SPOSite | ForEach-Object { Get-SPOSiteAdministrator -Site $_.Url } to enumerate site administrators.",
+      "tags": [
+        "collaboration",
+        "identification-authentication",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-004",
@@ -12112,7 +12549,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-002",
@@ -12283,7 +12724,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Identity Governance > Access reviews > New access review > Review type: Guest users only. Schedule recurring reviews."
+      "remediation": "Entra admin center > Identity Governance > Access reviews > New access review > Review type: Guest users only. Schedule recurring reviews.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-003",
@@ -12454,7 +12900,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Entra admin center > Identity Governance > Access reviews > New access review > Review type: Members of a group or Users assigned to a privileged role."
+      "remediation": "Entra admin center > Identity Governance > Access reviews > New access review > Review type: Members of a group or Users assigned to a privileged role.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ADMIN-003",
@@ -12644,7 +13095,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Maintain at least two cloud-only emergency access accounts excluded from all Conditional Access policies."
+      "remediation": "Maintain at least two cloud-only emergency access accounts excluded from all Conditional Access policies.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-BREAKGLASS-001",
@@ -12835,12 +13291,22 @@
           "controlId": "MS.AAD.1.1v1"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to use automated mechanisms to disable or remove temporary and emergency accounts after an organization-defined time period for each type of account exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-009",
@@ -12988,13 +13454,23 @@
           "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to use automated mechanisms to disable or remove temporary and emergency accounts after an organization-defined time period for each type of account exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 4,
+        "complexity": 5,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-006",
@@ -13149,13 +13625,23 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to use automated mechanisms to disable or remove temporary and emergency accounts after an organization-defined time period for each type of account exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 9
+      },
       "effort": {
         "complexity": 4,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-002",
@@ -13317,13 +13803,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to use automated mechanisms to disable inactive accounts after an organization-defined time period exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Review the following inactive apps and remove their credentials or disable them: Entra admin center > Enterprise applications > filter by last sign-in > remove secrets/certificates."
+      "remediation": "Review the following inactive apps and remove their credentials or disable them: Entra admin center > Enterprise applications > filter by last sign-in > remove secrets/certificates.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-019",
@@ -13501,7 +13997,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Review apps with Tier 0 permissions that show no sign-in activity. These permissions may have been granted but never used -- remove them to reduce attack surface. Entra admin center > Enterprise applications > Sign-in logs."
+      "remediation": "Review apps with Tier 0 permissions that show no sign-in activity. These permissions may have been granted but never used -- remove them to reduce attack surface. Entra admin center > Enterprise applications > Sign-in logs.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-007",
@@ -13687,13 +14188,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Changes to Infrastructure, Data, Software, and Procedures"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to use automated mechanisms to audit account creation, modification, enabling, disabling and removal actions and notify organization-defined personnel or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged.",
+        "scfWeighting": 5
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-006",
@@ -13752,7 +14263,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-020",
@@ -13811,7 +14326,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-014",
@@ -13870,7 +14389,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-031",
@@ -13929,7 +14454,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-032",
@@ -13988,7 +14519,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-044",
@@ -14047,7 +14584,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-069",
@@ -14105,7 +14648,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-078",
@@ -14163,7 +14712,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-002",
@@ -14221,7 +14776,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-003",
@@ -14279,7 +14839,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-005",
@@ -14338,7 +14903,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-119",
@@ -14396,7 +14966,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-256",
@@ -14454,7 +15029,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "ENTRA-CONSENT-004",
@@ -14653,7 +15233,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Review tenant-wide admin consent grants. These grants apply to all users in the tenant. Remove overly broad grants that are no longer needed. Entra admin center > Enterprise applications > filter by Admin consent."
+      "remediation": "Review tenant-wide admin consent grants. These grants apply to all users in the tenant. Remove overly broad grants that are no longer needed. Entra admin center > Enterprise applications > filter by Admin consent.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-GUEST-004",
@@ -14871,7 +15456,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > External Identities > External collaboration settings > Collaboration restrictions > Allow invitations only to the specified domains."
+      "remediation": "Entra admin center > External Identities > External collaboration settings > Collaboration restrictions > Allow invitations only to the specified domains.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "TEAMS-GUEST-001",
@@ -15081,7 +15671,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "collaboration",
+        "identification-authentication",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-EXTACCESS-003",
@@ -15296,7 +15891,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTenantFederationConfiguration -AllowFederatedUsers $false (or restrict with -AllowedDomains). Teams admin center > Users > External access > Choose which external domains your users have access to > Allow only specific external domains."
+      "remediation": "Run: Set-CsTenantFederationConfiguration -AllowFederatedUsers $false (or restrict with -AllowedDomains). Teams admin center > Users > External access > Choose which external domains your users have access to > Allow only specific external domains.",
+      "tags": [
+        "collaboration",
+        "identification-authentication",
+        "teams"
+      ]
     },
     {
       "checkId": "PBI-TENANT-003",
@@ -15506,7 +16106,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "data",
+        "identification-authentication",
+        "power-bi"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-003",
@@ -15721,7 +16326,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AutoAdmittedUsers EveryoneInCompanyExcludingGuests. Teams admin center > Meetings > Meeting policies > Global > Who can bypass the lobby > People in my org."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AutoAdmittedUsers EveryoneInCompanyExcludingGuests. Teams admin center > Meetings > Meeting policies > Global > Who can bypass the lobby > People in my org.",
+      "tags": [
+        "collaboration",
+        "identification-authentication",
+        "teams"
+      ]
     },
     {
       "checkId": "ENTRA-CA-002",
@@ -15912,6 +16522,11 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to enforce Logical Access Control (LAC) permissions that conform to the principle of \"least privilege?\" exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -15919,7 +16534,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Informational — review Conditional Access policy coverage for your organization."
+      "remediation": "Informational — review Conditional Access policy coverage for your organization.",
+      "tags": [
+        "conditional-access",
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-CA-003",
@@ -16110,6 +16731,11 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to enforce Logical Access Control (LAC) permissions that conform to the principle of \"least privilege?\" exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -16117,7 +16743,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Get-MgIdentityConditionalAccessPolicy | Where-Object {$_.State -eq ''enabled''}. Ensure policies are set to On, not Report-only."
+      "remediation": "Run: Get-MgIdentityConditionalAccessPolicy | Where-Object {$_.State -eq ''enabled''}. Ensure policies are set to On, not Report-only.",
+      "tags": [
+        "conditional-access",
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "EXO-LOCKBOX-001",
@@ -16328,7 +16960,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "M365 admin center > Settings > Org settings > Security & privacy > Customer Lockbox > Require approval. Requires E5 or equivalent."
+      "remediation": "M365 admin center > Settings > Org settings > Security & privacy > Customer Lockbox > Require approval. Requires E5 or equivalent.",
+      "tags": [
+        "email",
+        "exchange-online",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "ENTRA-ORGSETTING-004",
@@ -16540,7 +17177,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "M365 admin center > Settings > Org settings > Bookings > restrict shared booking pages to selected staff members."
+      "remediation": "M365 admin center > Settings > Org settings > Bookings > restrict shared booking pages to selected staff members.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-EXCLUSION-001",
@@ -16744,12 +17386,23 @@
           "controlId": "MS.AAD.3.1v1;MS.AAD.3.2v2"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to utilize the concept of least privilege, allowing only authorized access to processes necessary to accomplish assigned tasks in accordance with organizational business functions exposes the tenant to: Inability to maintain individual accountability, Improper assignment.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-DEVICE-006",
@@ -16962,7 +17615,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Devices > Device settings > Restrict users from recovering the BitLocker key(s) for their owned devices > Yes."
+      "remediation": "Entra admin center > Devices > Device settings > Restrict users from recovering the BitLocker key(s) for their owned devices > Yes.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-GUEST-001",
@@ -17161,7 +17819,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -GuestUserRoleId ''2af84b1e-32c8-42b7-82bc-daa82404023b''. Entra admin center > External Identities > External collaboration settings."
+      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -GuestUserRoleId ''2af84b1e-32c8-42b7-82bc-daa82404023b''. Entra admin center > External Identities > External collaboration settings.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "SPO-SHARING-004",
@@ -17355,7 +18018,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -DefaultSharingLinkType Direct. SharePoint admin center > Policies > Sharing > File and folder links > Default link type > Specific people."
+      "remediation": "Run: Set-SPOTenant -DefaultSharingLinkType Direct. SharePoint admin center > Policies > Sharing > File and folder links > Default link type > Specific people.",
+      "tags": [
+        "collaboration",
+        "data",
+        "identification-authentication",
+        "sharepoint",
+        "sharing"
+      ]
     },
     {
       "checkId": "SPO-SHARING-007",
@@ -17548,7 +18218,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -DefaultLinkPermission View. SharePoint admin center > Policies > Sharing > File and folder links > Default permission > View."
+      "remediation": "Run: Set-SPOTenant -DefaultLinkPermission View. SharePoint admin center > Policies > Sharing > File and folder links > Default permission > View.",
+      "tags": [
+        "collaboration",
+        "data",
+        "identification-authentication",
+        "sharepoint",
+        "sharing"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-004",
@@ -17628,7 +18305,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-011",
@@ -17708,7 +18389,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-012",
@@ -17788,7 +18473,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-013",
@@ -17868,7 +18557,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-014",
@@ -17948,7 +18641,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-015",
@@ -18028,7 +18725,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-017",
@@ -18108,7 +18809,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-018",
@@ -18188,7 +18893,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-019",
@@ -18268,7 +18977,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-020",
@@ -18348,7 +19061,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-021",
@@ -18428,7 +19145,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-023",
@@ -18508,7 +19229,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-026",
@@ -18588,7 +19313,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-041",
@@ -18668,7 +19397,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-042",
@@ -18748,7 +19481,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-043",
@@ -18828,7 +19565,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-044",
@@ -18908,7 +19649,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-045",
@@ -18988,7 +19733,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-046",
@@ -19068,7 +19817,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-004",
@@ -19148,7 +19901,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-030",
@@ -19228,7 +19985,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-031",
@@ -19308,7 +20069,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-032",
@@ -19388,7 +20153,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-033",
@@ -19468,7 +20237,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-034",
@@ -19548,7 +20321,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-035",
@@ -19628,7 +20405,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-018",
@@ -19708,7 +20489,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-024",
@@ -19788,7 +20573,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-019",
@@ -19868,7 +20657,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-039",
@@ -19948,7 +20741,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-056",
@@ -20028,7 +20825,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-072",
@@ -20108,7 +20909,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-CONTAINER-002",
@@ -20188,7 +20993,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-CONTAINER-003",
@@ -20268,7 +21077,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-005",
@@ -20348,7 +21161,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-006",
@@ -20428,7 +21245,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-010",
@@ -20508,7 +21329,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-018",
@@ -20588,7 +21413,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-020",
@@ -20668,7 +21497,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-021",
@@ -20748,7 +21581,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-022",
@@ -20828,7 +21665,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-023",
@@ -20908,7 +21749,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-024",
@@ -20988,7 +21833,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-025",
@@ -21068,7 +21917,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-027",
@@ -21148,7 +22001,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-028",
@@ -21228,7 +22085,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-029",
@@ -21308,7 +22169,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-030",
@@ -21388,7 +22253,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-031",
@@ -21468,7 +22337,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-032",
@@ -21548,7 +22421,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-034",
@@ -21628,7 +22505,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-040",
@@ -21708,7 +22589,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-041",
@@ -21788,7 +22673,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-043",
@@ -21868,7 +22757,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-044",
@@ -21948,7 +22841,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-046",
@@ -22028,7 +22925,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-051",
@@ -22108,7 +23009,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-053",
@@ -22188,7 +23093,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "AZ-AKS-054",
@@ -22268,7 +23177,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-002",
@@ -22348,7 +23261,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-003",
@@ -22428,7 +23347,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-004",
@@ -22508,7 +23433,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-005",
@@ -22588,7 +23519,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-006",
@@ -22668,7 +23605,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-009",
@@ -22748,7 +23691,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-010",
@@ -22828,7 +23777,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-012",
@@ -22908,7 +23863,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-013",
@@ -22988,7 +23949,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-015",
@@ -23068,7 +24035,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-016",
@@ -23148,7 +24121,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-017",
@@ -23228,7 +24207,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-018",
@@ -23308,7 +24293,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-019",
@@ -23388,7 +24379,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-020",
@@ -23468,7 +24465,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-021",
@@ -23548,7 +24551,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-022",
@@ -23628,7 +24637,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-023",
@@ -23708,7 +24723,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-024",
@@ -23788,7 +24809,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-025",
@@ -23868,7 +24895,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-026",
@@ -23948,7 +24981,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-029",
@@ -24028,7 +25067,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-033",
@@ -24108,7 +25153,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-034",
@@ -24188,7 +25239,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-035",
@@ -24268,7 +25325,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-036",
@@ -24348,7 +25411,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-039",
@@ -24428,7 +25497,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-040",
@@ -24508,7 +25583,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-041",
@@ -24588,7 +25669,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-042",
@@ -24668,7 +25755,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-043",
@@ -24748,7 +25841,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-046",
@@ -24828,7 +25927,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-047",
@@ -24908,7 +26013,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-048",
@@ -24988,7 +26099,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-052",
@@ -25068,7 +26185,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-064",
@@ -25148,7 +26271,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-067",
@@ -25228,7 +26357,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-077",
@@ -25308,7 +26443,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-082",
@@ -25388,7 +26529,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-083",
@@ -25468,7 +26615,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-084",
@@ -25548,7 +26701,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-085",
@@ -25628,7 +26787,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-086",
@@ -25708,7 +26873,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-087",
@@ -25788,7 +26959,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-088",
@@ -25868,7 +27045,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-089",
@@ -25948,7 +27131,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-090",
@@ -26028,7 +27217,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-091",
@@ -26108,7 +27303,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-093",
@@ -26188,7 +27389,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-094",
@@ -26268,7 +27475,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-096",
@@ -26348,7 +27561,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-111",
@@ -26428,7 +27647,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-112",
@@ -26508,7 +27733,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-113",
@@ -26588,7 +27819,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-114",
@@ -26668,7 +27905,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-115",
@@ -26748,7 +27991,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-116",
@@ -26828,7 +28077,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-117",
@@ -26908,7 +28163,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-118",
@@ -26988,7 +28249,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-122",
@@ -27068,7 +28335,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identification-authentication",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-142",
@@ -27148,7 +28421,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-180",
@@ -27228,7 +28506,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identification-authentication"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-004",
@@ -27424,7 +28707,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Entra admin center > Identity Governance > PIM > Azure AD roles > Settings > Global Administrator > Require approval to activate > Yes."
+      "remediation": "Entra admin center > Identity Governance > PIM > Azure AD roles > Settings > Global Administrator > Require approval to activate > Yes.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-005",
@@ -27620,7 +28908,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Entra admin center > Identity Governance > PIM > Azure AD roles > Settings > Privileged Role Administrator > Require approval to activate > Yes."
+      "remediation": "Entra admin center > Identity Governance > PIM > Azure AD roles > Settings > Privileged Role Administrator > Require approval to activate > Yes.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "INTUNE-RBAC-001",
@@ -27799,12 +29092,22 @@
           "controlId": "MS.INTUNE.1.2v1"
         }
       },
+      "impactRating": {
+        "severity": "Low",
+        "rationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 3,
+        "complexity": 2,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-003",
@@ -28011,13 +29314,23 @@
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Enterprise applications > review foreign apps with Tier 0 permissions. These permissions have documented attack paths to Global Administrator. Remove or replace with least-privilege alternatives."
+      "remediation": "Entra admin center > Enterprise applications > review foreign apps with Tier 0 permissions. These permissions have documented attack paths to Global Administrator. Remove or replace with least-privilege alternatives.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-004",
@@ -28223,13 +29536,23 @@
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Enterprise applications > review foreign apps with high-privilege delegated permissions. Revoke admin consent or remove the app."
+      "remediation": "Entra admin center > Enterprise applications > review foreign apps with high-privilege delegated permissions. Revoke admin consent or remove the app.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-006",
@@ -28407,13 +29730,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 9
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Review apps with > 10 application permissions. Remove unnecessary permissions to follow least-privilege. Entra admin center > App registrations > [app] > API permissions."
+      "remediation": "Review apps with > 10 application permissions. Remove unnecessary permissions to follow least-privilege. Entra admin center > App registrations > [app] > API permissions.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-008",
@@ -28591,13 +29924,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Review managed identity permissions. Use narrower permissions (e.g., Mail.Read instead of Mail.ReadWrite). Azure portal > Managed Identity > API permissions."
+      "remediation": "Review managed identity permissions. Use narrower permissions (e.g., Mail.Read instead of Mail.ReadWrite). Azure portal > Managed Identity > API permissions.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-010",
@@ -28786,7 +30129,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Entra admin center > App registrations > review internal apps with Tier 0 permissions. Each has a documented path to Global Administrator. Replace with narrower permissions or use managed identities where possible."
+      "remediation": "Entra admin center > App registrations > review internal apps with Tier 0 permissions. Each has a documented path to Global Administrator. Replace with narrower permissions or use managed identities where possible.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-016",
@@ -28976,7 +30324,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Remove owners from apps with Tier 0 permissions. An owner of a Tier 0 app can add credentials and impersonate it to escalate to Global Admin. Entra admin center > App registrations > Owners."
+      "remediation": "Remove owners from apps with Tier 0 permissions. An owner of a Tier 0 app can add credentials and impersonate it to escalate to Global Admin. Entra admin center > App registrations > Owners.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-017",
@@ -29165,7 +30518,12 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Remove owners from apps holding Entra directory roles. Owners can add credentials and impersonate the SP to exercise those roles. Entra admin center > App registrations > Owners."
+      "remediation": "Remove owners from apps holding Entra directory roles. Owners can add credentials and impersonate the SP to exercise those roles. Entra admin center > App registrations > Owners.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ADMINROLE-SEPARATION-001",
@@ -29328,7 +30686,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-CLOUDADMIN-001",
@@ -29524,7 +30887,14 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Create cloud-only admin accounts instead of using on-premises synced accounts. Entra admin center > Users > New user > Create user (cloud identity)."
+      "remediation": "Create cloud-only admin accounts instead of using on-premises synced accounts. Entra admin center > Users > New user > Create user (cloud identity).",
+      "tags": [
+        "admin",
+        "entra-id",
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-SYNCADMIN-001",
@@ -29705,12 +31075,24 @@
           "controlId": "MS.AAD.7.4v1"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
-        "disruptionRisk": false
-      }
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
+        "disruptionRisk": true,
+        "disruptionScope": "admin-only"
+      },
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-ADMIN-001",
@@ -29882,7 +31264,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "The Global Administrator directory role is not activated in this tenant. Activate the role by assigning at least one user, then re-run the assessment."
+      "remediation": "The Global Administrator directory role is not activated in this tenant. Activate the role by assigning at least one user, then re-run the assessment.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-CLOUDADMIN-002",
@@ -30053,7 +31440,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Assign admin accounts minimal licenses (Entra ID P2). Do not assign E3/E5 productivity suites. M365 admin center > Users > Active users > Licenses."
+      "remediation": "Assign admin accounts minimal licenses (Entra ID P2). Do not assign E3/E5 productivity suites. M365 admin center > Users > Active users > Licenses.",
+      "tags": [
+        "admin",
+        "entra-id",
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-ADMIN-002",
@@ -30241,7 +31635,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Identity > Users > User settings > Administration center > set \"Restrict access to Microsoft Entra admin center\" to Yes."
+      "remediation": "Entra admin center > Identity > Users > User settings > Administration center > set \"Restrict access to Microsoft Entra admin center\" to Yes.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-DEVICE-003",
@@ -30416,7 +31815,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Devices > Device settings > Global administrator is added as local administrator on the device during Azure AD Join > No."
+      "remediation": "Entra admin center > Devices > Device settings > Global administrator is added as local administrator on the device during Azure AD Join > No.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-DEVICE-004",
@@ -30591,7 +31995,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Devices > Device settings > Manage Additional local administrators on all Azure AD joined devices. Minimize additional local admins."
+      "remediation": "Entra admin center > Devices > Device settings > Manage Additional local administrators on all Azure AD joined devices. Minimize additional local admins.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "PBI-API-001",
@@ -30761,7 +32170,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "data",
+        "identification-authentication",
+        "power-bi"
+      ]
     },
     {
       "checkId": "POWERBI-AUTH-002",
@@ -30920,6 +32334,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -30927,7 +32346,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Developer settings > Allow service principals to use Power BI APIs > Disabled or restricted to specific security groups"
+      "remediation": "Power BI Admin Portal > Tenant settings > Developer settings > Allow service principals to use Power BI APIs > Disabled or restricted to specific security groups",
+      "tags": [
+        "conditional-access",
+        "data",
+        "identification-authentication",
+        "identity",
+        "power-bi"
+      ]
     },
     {
       "checkId": "POWERBI-AUTH-003",
@@ -31086,6 +32512,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -31093,7 +32524,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Developer settings > Allow service principals to create and use profiles > Disabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Developer settings > Allow service principals to create and use profiles > Disabled",
+      "tags": [
+        "conditional-access",
+        "data",
+        "identification-authentication",
+        "identity",
+        "power-bi"
+      ]
     },
     {
       "checkId": "PBI-PROFILE-001",
@@ -31263,7 +32701,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "data",
+        "identification-authentication",
+        "power-bi"
+      ]
     },
     {
       "checkId": "ENTRA-SSPR-002",
@@ -31413,13 +32856,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-ROLECOVERAGE-001",
@@ -31588,14 +33041,24 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Consider creating CA policies that specifically target privileged directory roles with stricter controls (phishing-resistant MFA, compliant devices)."
+      "remediation": "Consider creating CA policies that specifically target privileged directory roles with stricter controls (phishing-resistant MFA, compliant devices).",
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-005",
@@ -31778,13 +33241,23 @@
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Roles and administrators > review roles assigned to foreign service principals. Remove role assignments from untrusted external apps."
+      "remediation": "Entra admin center > Roles and administrators > review roles assigned to foreign service principals. Remove role assignments from untrusted external apps.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-009",
@@ -31954,13 +33427,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Review managed identities with directory roles. Use Graph API permissions instead of directory roles where possible. Entra admin center > Roles and administrators."
+      "remediation": "Review managed identities with directory roles. Use Graph API permissions instead of directory roles where possible. Entra admin center > Roles and administrators.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-GROUP-005",
@@ -32129,13 +33612,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-HYBRID-002",
@@ -32305,13 +33798,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-015",
@@ -32473,7 +33976,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Migrate privileged service principals from client secrets to certificates or managed identities. A secret on a permanently privileged SP is a persistent backdoor risk."
+      "remediation": "Migrate privileged service principals from client secrets to certificates or managed identities. A secret on a permanently privileged SP is a persistent backdoor risk.",
+      "tags": [
+        "app-registration",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-GUEST-002",
@@ -32649,7 +34157,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -AllowInvitesFrom ''adminsAndGuestInviters''. Entra admin center > External Identities > External collaboration settings."
+      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -AllowInvitesFrom ''adminsAndGuestInviters''. Entra admin center > External Identities > External collaboration settings.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "SPO-SHARING-002",
@@ -32846,7 +34359,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -PreventExternalUsersFromResharing $true. SharePoint admin center > Policies > Sharing."
+      "remediation": "Run: Set-SPOTenant -PreventExternalUsersFromResharing $true. SharePoint admin center > Policies > Sharing.",
+      "tags": [
+        "collaboration",
+        "data",
+        "identification-authentication",
+        "sharepoint",
+        "sharing"
+      ]
     },
     {
       "checkId": "SPO-SHARING-003",
@@ -33043,7 +34563,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -SharingDomainRestrictionMode AllowList -SharingAllowedDomainList \"partner.com\". SharePoint admin center > Policies > Sharing > Limit sharing by domain."
+      "remediation": "Run: Set-SPOTenant -SharingDomainRestrictionMode AllowList -SharingAllowedDomainList \"partner.com\". SharePoint admin center > Policies > Sharing > Limit sharing by domain.",
+      "tags": [
+        "collaboration",
+        "data",
+        "identification-authentication",
+        "sharepoint",
+        "sharing"
+      ]
     },
     {
       "checkId": "SPO-SHARING-008",
@@ -33240,7 +34767,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Verify in SharePoint Admin Center or use Get-SPOTenant. SharePoint admin center > Policies > Sharing > More external sharing settings > \"Allow only users in specific security groups to share externally\"."
+      "remediation": "Verify in SharePoint Admin Center or use Get-SPOTenant. SharePoint admin center > Policies > Sharing > More external sharing settings > \"Allow only users in specific security groups to share externally\".",
+      "tags": [
+        "collaboration",
+        "data",
+        "identification-authentication",
+        "sharepoint",
+        "sharing"
+      ]
     },
     {
       "checkId": "ENTRA-APPS-002",
@@ -33403,12 +34937,22 @@
           "controlId": "MS.AAD.6.1v1"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to prevent non-privileged users from executing privileged functions to include disabling, circumventing or altering implemented security safeguards / countermeasures exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged.",
+        "scfWeighting": 9
+      },
       "effort": {
-        "complexity": 3,
-        "isPhased": false,
-        "phaseCount": 1,
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "identification-authentication",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "ENTRA-PASSWORD-003",
@@ -33575,6 +35119,11 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to enforce a limit for consecutive invalid login attempts by a user during an organization-defined time period and automatically locks the account when the maximum number of unsuccessful attempts is exceeded exposes the tenant to: Inability to maintain individual.",
+        "scfWeighting": 9
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -33582,7 +35131,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Update-MgBetaDirectorySetting for Password Rule Settings with LockoutThreshold. Entra admin center > Protection > Password protection."
+      "remediation": "Run: Update-MgBetaDirectorySetting for Password Rule Settings with LockoutThreshold. Entra admin center > Protection > Password protection.",
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-RISKPOLICY-001",
@@ -33789,6 +35343,11 @@
           "title": "Restriction of Access to System Boundaries; Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to enforce a limit for consecutive invalid login attempts by a user during an organization-defined time period and automatically locks the account when the maximum number of unsuccessful attempts is exceeded exposes the tenant to: Inability to maintain individual.",
+        "scfWeighting": 9
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -33796,7 +35355,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Combining sign-in risk and user risk in one CA policy creates an AND condition -- both must be true to trigger. Microsoft recommends separate policies for each risk type. Entra admin center > Protection > Conditional Access."
+      "remediation": "Combining sign-in risk and user risk in one CA policy creates an AND condition -- both must be true to trigger. Microsoft recommends separate policies for each risk type. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "SPO-SESSION-001",
@@ -33979,7 +35543,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOBrowserIdleSignOut -Enabled $true -SignOutAfter ''01:00:00''. M365 admin center > Settings > Org settings > Idle session timeout."
+      "remediation": "Run: Set-SPOBrowserIdleSignOut -Enabled $true -SignOutAfter ''01:00:00''. M365 admin center > Settings > Org settings > Idle session timeout.",
+      "tags": [
+        "collaboration",
+        "identification-authentication",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "ENTRA-SESSION-001",
@@ -34161,7 +35730,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-SIGNIN-FREQ-001",
@@ -34347,7 +35921,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Create a CA policy: Target admin roles > Session > Sign-in frequency (e.g., 4 hours) + Persistent browser session = Never. Entra admin center > Protection > Conditional Access."
+      "remediation": "Create a CA policy: Target admin roles > Session > Sign-in frequency (e.g., 4 hours) + Persistent browser session = Never. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-USERRISK-001",
@@ -34555,7 +36134,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Create a CA policy: Target All users > Conditions > User risk > High > Grant > Require password change + MFA. Entra admin center > Protection > Conditional Access."
+      "remediation": "Create a CA policy: Target All users > Conditions > User risk > High > Grant > Require password change + MFA. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "human-resources-security",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-SIGNINRISK-001",
@@ -34763,7 +36347,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Create a CA policy: Target All users > Conditions > Sign-in risk > High, Medium > Grant > Require MFA. Entra admin center > Protection > Conditional Access."
+      "remediation": "Create a CA policy: Target All users > Conditions > Sign-in risk > High, Medium > Grant > Require MFA. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "human-resources-security",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-SIGNINRISK-002",
@@ -34971,7 +36560,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Security Defaults blocks high-risk sign-ins but does not provide granular medium-risk controls. For full coverage, disable Security Defaults and create Conditional Access policies with Entra ID P2."
+      "remediation": "Security Defaults blocks high-risk sign-ins but does not provide granular medium-risk controls. For full coverage, disable Security Defaults and create Conditional Access policies with Entra ID P2.",
+      "tags": [
+        "conditional-access",
+        "human-resources-security",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-SOD-001",
@@ -35137,7 +36731,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Ensure Global Administrator and Privileged Role Administrator roles are assigned to separate accounts. Entra admin center > Identity > Roles & admins. Enable PIM approval workflows for role activation."
+      "remediation": "Ensure Global Administrator and Privileged Role Administrator roles are assigned to separate accounts. Entra admin center > Identity > Roles & admins. Enable PIM approval workflows for role activation.",
+      "tags": [
+        "entra-id",
+        "human-resources-security",
+        "identity"
+      ]
     },
     {
       "checkId": "EXO-MAILTIPS-001",
@@ -35369,7 +36968,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-OrganizationConfig -MailTipsAllTipsEnabled $true"
+      "remediation": "Run: Set-OrganizationConfig -MailTipsAllTipsEnabled $true",
+      "tags": [
+        "email",
+        "exchange-online",
+        "security-awareness-training"
+      ]
     },
     {
       "checkId": "INTUNE-COMPLIANCE-001",
@@ -35574,7 +37178,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Intune admin center > Devices > Compliance > Compliance policy settings > Mark devices with no compliance policy assigned as > Not compliant."
+      "remediation": "Intune admin center > Devices > Compliance > Compliance policy settings > Mark devices with no compliance policy assigned as > Not compliant.",
+      "tags": [
+        "asset-management",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "INTUNE-ENROLLMENT-001",
@@ -35770,7 +37379,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "asset-management",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "TEAMS-INFO-001",
@@ -35942,14 +37556,23 @@
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC6.1-POF1"
         }
       },
+      "impactRating": {
+        "severity": "Informational",
+        "rationale": "Failure to establish and maintain an authoritative source and repository to provide a trusted source and accountability for approved and implemented system components that prevents assets from being duplicated in other asset inventories exposes the tenant to: Emergent properties.",
+        "scfWeighting": 2
+      },
       "effort": {
-        "complexity": 2,
+        "complexity": 1,
         "isPhased": false,
         "phaseCount": 1,
-        "disruptionRisk": true,
-        "disruptionScope": "user-facing"
+        "disruptionRisk": false
       },
-      "remediation": "Informational — confirms Teams service connectivity."
+      "remediation": "Informational — confirms Teams service connectivity.",
+      "tags": [
+        "asset-management",
+        "collaboration",
+        "teams"
+      ]
     },
     {
       "checkId": "INTUNE-INVENTORY-001",
@@ -36117,7 +37740,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Ensure devices are enrolled in Intune. Configure device categories: Intune admin center > Devices > Device categories > Create category."
+      "remediation": "Ensure devices are enrolled in Intune. Configure device categories: Intune admin center > Devices > Device categories > Create category.",
+      "tags": [
+        "asset-management",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "INTUNE-AUTODISC-001",
@@ -36285,7 +37913,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Configure Intune automatic enrollment: Entra admin center > Mobility (MDM and WIP) > Microsoft Intune > MDM user scope: All or Some. Consider configuring Windows Autopilot for zero-touch provisioning."
+      "remediation": "Configure Intune automatic enrollment: Entra admin center > Mobility (MDM and WIP) > Microsoft Intune > MDM user scope: All or Some. Consider configuring Windows Autopilot for zero-touch provisioning.",
+      "tags": [
+        "asset-management",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "SPO-SITE-001",
@@ -36494,7 +38127,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Ensure SharePointTenantSettings.Read.All permission is consented. Review site sharing levels in SharePoint admin center > Active sites."
+      "remediation": "Ensure SharePointTenantSettings.Read.All permission is consented. Review site sharing levels in SharePoint admin center > Active sites.",
+      "tags": [
+        "collaboration",
+        "data-classification-handling",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-CUIACCESS-001",
@@ -36688,7 +38326,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "collaboration",
+        "data-classification-handling",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "COMPLIANCE-LABELS-002",
@@ -36832,7 +38475,12 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Information protection > Auto-labeling > Create a policy to automatically classify sensitive content. Requires Azure Information Protection P2 (E5 or E5 Compliance)."
+      "remediation": "Microsoft Purview > Information protection > Auto-labeling > Create a policy to automatically classify sensitive content. Requires Azure Information Protection P2 (E5 or E5 Compliance).",
+      "tags": [
+        "compliance",
+        "data-classification-handling",
+        "purview"
+      ]
     },
     {
       "checkId": "SPO-SITE-002",
@@ -37053,7 +38701,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Review site sharing manually in SharePoint admin center > Active sites."
+      "remediation": "Review site sharing manually in SharePoint admin center > Active sites.",
+      "tags": [
+        "collaboration",
+        "data-classification-handling",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "INTUNE-REMOVABLEMEDIA-001",
@@ -37207,7 +38860,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "data-classification-handling",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "CA-DEVICE-001",
@@ -37446,7 +39104,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Create a CA policy: Target All users > All cloud apps > Grant > Require device to be marked as compliant (or Hybrid Azure AD joined). Entra admin center > Protection > Conditional Access."
+      "remediation": "Create a CA policy: Target All users > All cloud apps > Grant > Require device to be marked as compliant (or Hybrid Azure AD joined). Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "data-classification-handling",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-DEVICE-002",
@@ -37685,7 +39348,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Create a CA policy: User actions > Register security information > Grant > Require compliant device. Entra admin center > Protection > Conditional Access."
+      "remediation": "Create a CA policy: User actions > Register security information > Grant > Require compliant device. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "data-classification-handling",
+        "identity"
+      ]
     },
     {
       "checkId": "INTUNE-PORTSTORAGE-001",
@@ -37849,7 +39517,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Intune admin center > Devices > Configuration > Create profile > Windows 10 and later > Device restrictions > General > Removable storage: Block."
+      "remediation": "Intune admin center > Devices > Configuration > Create profile > Windows 10 and later > Device restrictions > General > Removable storage: Block.",
+      "tags": [
+        "data-classification-handling",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "SPO-SHARING-005",
@@ -38040,7 +39713,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -ExternalUserExpirationRequired $true -ExternalUserExpireInDays 30. SharePoint admin center > Policies > Sharing > Guest access expiration."
+      "remediation": "Run: Set-SPOTenant -ExternalUserExpirationRequired $true -ExternalUserExpireInDays 30. SharePoint admin center > Policies > Sharing > Guest access expiration.",
+      "tags": [
+        "collaboration",
+        "data",
+        "data-classification-handling",
+        "sharepoint",
+        "sharing"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-007",
@@ -38231,7 +39911,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -DesignatedPresenterRoleMode OrganizerOnlyUserOverride. Teams admin center > Meetings > Meeting policies > Global > Who can present > Only organizers."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -DesignatedPresenterRoleMode OrganizerOnlyUserOverride. Teams admin center > Meetings > Meeting policies > Global > Who can present > Only organizers.",
+      "tags": [
+        "collaboration",
+        "data-classification-handling",
+        "teams"
+      ]
     },
     {
       "checkId": "FORMS-CONFIG-002",
@@ -38442,6 +40127,11 @@
           "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to control publicly-accessible content exposes the tenant to: Inability to maintain individual accountability, Unauthorized access, Lost, damaged or stolen asset(s).",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -38449,7 +40139,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"People outside your organization can share and collaborate on forms\"."
+      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"People outside your organization can share and collaborate on forms\".",
+      "tags": [
+        "collaboration",
+        "configuration",
+        "data-classification-handling",
+        "forms"
+      ]
     },
     {
       "checkId": "FORMS-CONFIG-001",
@@ -38660,6 +40356,11 @@
           "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to control publicly-accessible content exposes the tenant to: Inability to maintain individual accountability, Unauthorized access, Lost, damaged or stolen asset(s).",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -38667,7 +40368,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"People outside your organization can respond\"."
+      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"People outside your organization can respond\".",
+      "tags": [
+        "collaboration",
+        "configuration",
+        "data-classification-handling",
+        "forms"
+      ]
     },
     {
       "checkId": "FORMS-CONFIG-003",
@@ -38867,6 +40574,11 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to control publicly-accessible content exposes the tenant to: Inability to maintain individual accountability, Unauthorized access, Lost, damaged or stolen asset(s).",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -38874,7 +40586,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"People outside your organization can see results summary and individual responses\"."
+      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"People outside your organization can see results summary and individual responses\".",
+      "tags": [
+        "collaboration",
+        "configuration",
+        "data-classification-handling",
+        "forms"
+      ]
     },
     {
       "checkId": "FORMS-CONFIG-006",
@@ -39079,14 +40797,24 @@
           "title": "The risks posed by a supplier, their products and services, and other third parties are understood, recorded, prioritized, assessed, responded to, and monitored over the course of the relationship"
         }
       },
+      "impactRating": {
+        "severity": "Low",
+        "rationale": "Failure to control publicly-accessible content exposes the tenant to: Inability to maintain individual accountability, Unauthorized access, Lost, damaged or stolen asset(s).",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 2,
+        "complexity": 1,
         "isPhased": false,
         "phaseCount": 1,
-        "disruptionRisk": true,
-        "disruptionScope": "user-facing"
+        "disruptionRisk": false
       },
-      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"Bing search and YouTube video\"."
+      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"Bing search and YouTube video\".",
+      "tags": [
+        "collaboration",
+        "configuration",
+        "data-classification-handling",
+        "forms"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-003",
@@ -39123,7 +40851,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "EXO-HIDDEN-001",
@@ -39421,7 +41154,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Investigate hidden user mailboxes. Mailboxes hidden from the Global Address List may indicate a compromised account. Review: Get-Mailbox -Filter \"HiddenFromAddressListsEnabled -eq $true -and RecipientTypeDetails -eq UserMailbox\""
+      "remediation": "Investigate hidden user mailboxes. Mailboxes hidden from the Global Address List may indicate a compromised account. Review: Get-Mailbox -Filter \"HiddenFromAddressListsEnabled -eq $true -and RecipientTypeDetails -eq UserMailbox\"",
+      "tags": [
+        "configuration-management",
+        "email",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-002",
@@ -39458,7 +41196,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-024",
@@ -39542,7 +41285,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-025",
@@ -39627,7 +41374,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-006",
@@ -39711,7 +41462,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-010",
@@ -39795,7 +41550,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management",
+        "network"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-006",
@@ -39879,7 +41639,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-012",
@@ -39963,7 +41727,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-013",
@@ -40048,7 +41816,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-003",
@@ -40133,7 +41905,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-007",
@@ -40218,7 +41994,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-008",
@@ -40303,7 +42083,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-009",
@@ -40388,7 +42172,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-016",
@@ -40473,7 +42261,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-028",
@@ -40558,7 +42350,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-029",
@@ -40643,7 +42439,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-030",
@@ -40728,7 +42528,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-037",
@@ -40813,7 +42617,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-045",
@@ -40898,7 +42706,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-046",
@@ -40983,7 +42795,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-053",
@@ -41068,7 +42884,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-062",
@@ -41153,7 +42973,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-063",
@@ -41238,7 +43062,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-070",
@@ -41323,7 +43151,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-VM-008",
@@ -41408,7 +43240,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-VM-012",
@@ -41493,7 +43329,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "AZ-AKS-045",
@@ -41578,7 +43418,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-055",
@@ -41663,7 +43507,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "configuration-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-056",
@@ -41747,7 +43597,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "configuration-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-057",
@@ -41831,7 +43687,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "configuration-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-070",
@@ -41915,7 +43777,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "configuration-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-071",
@@ -41999,7 +43867,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "configuration-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-097",
@@ -42083,7 +43957,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "configuration-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-109",
@@ -42167,7 +44047,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "configuration-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-110",
@@ -42251,7 +44137,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "configuration-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-SERVICES-001",
@@ -42336,7 +44228,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-SERVICES-002",
@@ -42421,7 +44317,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-001",
@@ -42505,7 +44405,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-004",
@@ -42589,7 +44494,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-006",
@@ -42674,7 +44584,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-007",
@@ -42759,7 +44674,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-009",
@@ -42844,7 +44764,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-010",
@@ -42929,7 +44854,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-012",
@@ -43013,7 +44943,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-013",
@@ -43097,7 +45032,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-014",
@@ -43181,7 +45121,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-015",
@@ -43266,7 +45211,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-016",
@@ -43351,7 +45301,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-017",
@@ -43435,7 +45390,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-019",
@@ -43520,7 +45480,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-020",
@@ -43605,7 +45570,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-022",
@@ -43689,7 +45659,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-023",
@@ -43774,7 +45749,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-024",
@@ -43859,7 +45839,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-025",
@@ -43944,7 +45929,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-031",
@@ -44028,7 +46018,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-032",
@@ -44113,7 +46108,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-038",
@@ -44197,7 +46197,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-039",
@@ -44282,7 +46287,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-041",
@@ -44366,7 +46376,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-042",
@@ -44450,7 +46465,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-043",
@@ -44535,7 +46555,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-044",
@@ -44620,7 +46645,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-045",
@@ -44705,7 +46735,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-046",
@@ -44790,7 +46825,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-048",
@@ -44874,7 +46914,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-049",
@@ -44958,7 +47003,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-050",
@@ -45043,7 +47093,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-051",
@@ -45128,7 +47183,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-052",
@@ -45213,7 +47273,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-053",
@@ -45298,7 +47363,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-054",
@@ -45383,7 +47453,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-055",
@@ -45468,7 +47543,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-056",
@@ -45553,7 +47633,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-057",
@@ -45638,7 +47723,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-058",
@@ -45723,7 +47813,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-059",
@@ -45808,7 +47903,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-060",
@@ -45893,7 +47993,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-061",
@@ -45978,7 +48083,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-063",
@@ -46062,7 +48172,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-082",
@@ -46146,7 +48261,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-083",
@@ -46230,7 +48350,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-086",
@@ -46315,7 +48440,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-087",
@@ -46399,7 +48529,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-088",
@@ -46483,7 +48618,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-089",
@@ -46568,7 +48708,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-090",
@@ -46652,7 +48797,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-091",
@@ -46736,7 +48886,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-092",
@@ -46820,7 +48975,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-093",
@@ -46904,7 +49064,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-095",
@@ -46988,7 +49153,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-096",
@@ -47072,7 +49242,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-097",
@@ -47156,7 +49331,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-098",
@@ -47240,7 +49420,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-099",
@@ -47324,7 +49509,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-100",
@@ -47408,7 +49598,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-101",
@@ -47492,7 +49687,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-112",
@@ -47576,7 +49776,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-113",
@@ -47661,7 +49866,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-114",
@@ -47746,7 +49956,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-115",
@@ -47831,7 +50046,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-117",
@@ -47916,7 +50136,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-118",
@@ -48000,7 +50225,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-120",
@@ -48084,7 +50314,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-121",
@@ -48169,7 +50404,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-122",
@@ -48253,7 +50493,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-123",
@@ -48337,7 +50582,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-124",
@@ -48421,7 +50671,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-125",
@@ -48505,7 +50760,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-128",
@@ -48589,7 +50849,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-129",
@@ -48673,7 +50938,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-130",
@@ -48758,7 +51028,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-131",
@@ -48843,7 +51118,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-133",
@@ -48928,7 +51208,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-134",
@@ -49013,7 +51298,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-135",
@@ -49097,7 +51387,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-136",
@@ -49181,7 +51476,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-137",
@@ -49265,7 +51565,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-138",
@@ -49349,7 +51654,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-139",
@@ -49433,7 +51743,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-140",
@@ -49517,7 +51832,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-141",
@@ -49601,7 +51921,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-143",
@@ -49686,7 +52011,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-144",
@@ -49771,7 +52101,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-145",
@@ -49856,7 +52191,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-146",
@@ -49941,7 +52281,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-147",
@@ -50025,7 +52370,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-148",
@@ -50109,7 +52459,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-149",
@@ -50193,7 +52548,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-150",
@@ -50278,7 +52638,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-151",
@@ -50363,7 +52728,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-152",
@@ -50447,7 +52817,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-154",
@@ -50532,7 +52907,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-155",
@@ -50616,7 +52996,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-158",
@@ -50700,7 +53085,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-159",
@@ -50784,7 +53174,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-160",
@@ -50868,7 +53263,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-161",
@@ -50952,7 +53352,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-162",
@@ -51036,7 +53441,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-163",
@@ -51120,7 +53530,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-164",
@@ -51204,7 +53619,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-165",
@@ -51288,7 +53708,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-174",
@@ -51372,7 +53797,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-175",
@@ -51456,7 +53886,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-176",
@@ -51540,7 +53975,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-177",
@@ -51624,7 +54064,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-178",
@@ -51708,7 +54153,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-184",
@@ -51792,7 +54242,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-193",
@@ -51876,7 +54331,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-199",
@@ -51960,7 +54420,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-202",
@@ -52045,7 +54510,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-205",
@@ -52130,7 +54600,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-206",
@@ -52214,7 +54689,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-208",
@@ -52298,7 +54778,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-223",
@@ -52382,7 +54867,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-224",
@@ -52466,7 +54956,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-225",
@@ -52550,7 +55045,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-226",
@@ -52634,7 +55134,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-227",
@@ -52718,7 +55223,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-228",
@@ -52802,7 +55312,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-229",
@@ -52886,7 +55401,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-231",
@@ -52970,7 +55490,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-232",
@@ -53054,7 +55579,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-233",
@@ -53138,7 +55668,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-234",
@@ -53222,7 +55757,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-235",
@@ -53306,7 +55846,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-236",
@@ -53390,7 +55935,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-237",
@@ -53474,7 +56024,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-240",
@@ -53558,7 +56113,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-241",
@@ -53642,7 +56202,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-243",
@@ -53726,7 +56291,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-244",
@@ -53810,7 +56380,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-245",
@@ -53894,7 +56469,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-246",
@@ -53979,7 +56559,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-247",
@@ -54063,7 +56648,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-248",
@@ -54148,7 +56738,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-249",
@@ -54232,7 +56827,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-251",
@@ -54317,7 +56917,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-254",
@@ -54401,7 +57006,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-255",
@@ -54486,7 +57096,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-257",
@@ -54570,7 +57185,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-261",
@@ -54654,7 +57274,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-262",
@@ -54738,7 +57363,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-264",
@@ -54822,7 +57452,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-265",
@@ -54906,7 +57541,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-266",
@@ -54990,7 +57630,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "configuration-management"
+      ]
     },
     {
       "checkId": "DEFENDER-CFGDETECT-001",
@@ -55175,7 +57820,12 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Enable Defender for Endpoint device discovery. security.microsoft.com > Settings > Device discovery. Ensure devices are onboarded and configuration assessment is active."
+      "remediation": "Enable Defender for Endpoint device discovery. security.microsoft.com > Settings > Device discovery. Ensure devices are onboarded and configuration assessment is active.",
+      "tags": [
+        "configuration-management",
+        "defender",
+        "email"
+      ]
     },
     {
       "checkId": "DEFENDER-OUTBOUND-001",
@@ -55373,7 +58023,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-HostedOutboundSpamFilterPolicy -Identity <PolicyName> -AutoForwardingMode Off. Security admin center > Anti-spam > Outbound policy > Auto-forwarding rules > Off."
+      "remediation": "Run: Set-HostedOutboundSpamFilterPolicy -Identity <PolicyName> -AutoForwardingMode Off. Security admin center > Anti-spam > Outbound policy > Auto-forwarding rules > Off.",
+      "tags": [
+        "configuration-management",
+        "defender",
+        "email"
+      ]
     },
     {
       "checkId": "ENTRA-PERUSER-001",
@@ -55591,7 +58246,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Users > Per-user MFA > Ensure all users show Disabled. Use Conditional Access policies for MFA enforcement instead of per-user MFA."
+      "remediation": "Entra admin center > Users > Per-user MFA > Ensure all users show Disabled. Use Conditional Access policies for MFA enforcement instead of per-user MFA.",
+      "tags": [
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-DEVICE-005",
@@ -55791,7 +58451,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Devices > Device settings > Enable Microsoft Entra Local Administrator Password Solution (LAPS) > Yes."
+      "remediation": "Entra admin center > Devices > Device settings > Enable Microsoft Entra Local Administrator Password Solution (LAPS) > Yes.",
+      "tags": [
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "INTUNE-SECURITY-001",
@@ -55984,7 +58649,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration-management",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-001",
@@ -56164,13 +58834,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to document, assess risk and approve or deny deviations to standardized configurations exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 9
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Enterprise applications > review each app with credentials. Remove secrets/certificates from apps that no longer need them."
+      "remediation": "Entra admin center > Enterprise applications > review each app with credentials. Remove secrets/certificates from apps that no longer need them.",
+      "tags": [
+        "app-registration",
+        "configuration-management",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-007",
@@ -56349,13 +59029,23 @@
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to document, assess risk and approve or deny deviations to standardized configurations exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 9
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Applications > App management policies > configure a default policy to lock sensitive properties on multi-tenant apps."
+      "remediation": "Entra admin center > Applications > App management policies > configure a default policy to lock sensitive properties on multi-tenant apps.",
+      "tags": [
+        "app-registration",
+        "configuration-management",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-014",
@@ -56545,7 +59235,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Remove the client secret if a certificate is also configured. Dual credential types widen the attack surface. Entra admin center > App registrations > Certificates & secrets."
+      "remediation": "Remove the client secret if a certificate is also configured. Dual credential types widen the attack surface. Entra admin center > App registrations > Certificates & secrets.",
+      "tags": [
+        "app-registration",
+        "configuration-management",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ORGSETTING-001",
@@ -56759,7 +59454,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Enterprise applications > Consent and permissions > User consent settings > Do not allow user consent."
+      "remediation": "Entra admin center > Enterprise applications > Consent and permissions > User consent settings > Do not allow user consent.",
+      "tags": [
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ORGSETTING-003",
@@ -56976,7 +59676,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "M365 admin center > Settings > Org settings > Microsoft 365 on the web > uncheck all third-party storage services."
+      "remediation": "M365 admin center > Settings > Org settings > Microsoft 365 on the web > uncheck all third-party storage services.",
+      "tags": [
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "INTUNE-ENROLL-001",
@@ -57204,7 +59909,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Intune admin center > Devices > Enrollment > Device platform restrictions > Edit default policy > Block personally owned devices for each platform."
+      "remediation": "Intune admin center > Devices > Enrollment > Device platform restrictions > Edit default policy > Block personally owned devices for each platform.",
+      "tags": [
+        "configuration-management",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "ENTRA-LINKEDIN-001",
@@ -57410,7 +60120,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Users > User settings > LinkedIn account connections > No. Prevents data leakage between LinkedIn and organizational directory."
+      "remediation": "Entra admin center > Users > User settings > LinkedIn account connections > No. Prevents data leakage between LinkedIn and organizational directory.",
+      "tags": [
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-DEVICE-001",
@@ -57641,7 +60356,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Devices > Device settings > Users may join devices to Microsoft Entra > Selected. Restrict to a specific group of authorized users."
+      "remediation": "Entra admin center > Devices > Device settings > Users may join devices to Microsoft Entra > Selected. Restrict to a specific group of authorized users.",
+      "tags": [
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-CA-001",
@@ -57853,7 +60573,13 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "conditional-access",
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-LEGACYAUTH-001",
@@ -58054,6 +60780,11 @@
           "controlId": "V-260338"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": true,
@@ -58061,7 +60792,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Security Defaults blocks legacy authentication protocols. For granular control, disable Security Defaults and create Conditional Access policies."
+      "remediation": "Security Defaults blocks legacy authentication protocols. For granular control, disable Security Defaults and create Conditional Access policies.",
+      "tags": [
+        "conditional-access",
+        "configuration-management",
+        "identity"
+      ]
     },
     {
       "checkId": "CA-DEVICECODE-001",
@@ -58268,7 +61004,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Create a CA policy: Target All users > Conditions > Authentication flows > Device code flow > Grant > Block access. Entra admin center > Protection > Conditional Access."
+      "remediation": "Create a CA policy: Target All users > Conditions > Authentication flows > Device code flow > Grant > Block access. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "configuration-management",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-AUTHMETHOD-001",
@@ -58485,7 +61226,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Protection > Authentication methods > SMS > Disable. SMS is vulnerable to SIM-swapping attacks."
+      "remediation": "Entra admin center > Protection > Authentication methods > SMS > Disable. SMS is vulnerable to SIM-swapping attacks.",
+      "tags": [
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-AUTHMETHOD-002",
@@ -58699,7 +61445,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Protection > Authentication methods > Email OTP > Disable. Email OTP is a weaker authentication factor."
+      "remediation": "Entra admin center > Protection > Authentication methods > Email OTP > Disable. Email OTP is a weaker authentication factor.",
+      "tags": [
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "EXO-ADDINS-001",
@@ -58913,7 +61664,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Exchange admin center > Roles > User roles > Default Role Assignment Policy. Remove MyMarketplaceApps, MyCustomApps, MyReadWriteMailboxApps roles."
+      "remediation": "Exchange admin center > Roles > User roles > Default Role Assignment Policy. Remove MyMarketplaceApps, MyCustomApps, MyReadWriteMailboxApps roles.",
+      "tags": [
+        "configuration-management",
+        "email",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "EXO-AUTH-001",
@@ -59120,7 +61876,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Exchange admin center > Settings > Modern authentication > Enable. Run: Set-OrganizationConfig -OAuth2ClientProfileEnabled $true"
+      "remediation": "Exchange admin center > Settings > Modern authentication > Enable. Run: Set-OrganizationConfig -OAuth2ClientProfileEnabled $true",
+      "tags": [
+        "configuration-management",
+        "email",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "EXO-OWA-001",
@@ -59336,7 +62097,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-OwaMailboxPolicy -Identity OwaMailboxPolicy-Default -AdditionalStorageProvidersAvailable $false"
+      "remediation": "Run: Set-OwaMailboxPolicy -Identity OwaMailboxPolicy-Default -AdditionalStorageProvidersAvailable $false",
+      "tags": [
+        "configuration-management",
+        "email",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "EXO-AUTH-002",
@@ -59546,7 +62312,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Run: Set-TransportConfig -SmtpClientAuthenticationDisabled $true. Disable SMTP AUTH org-wide and enable per-mailbox only where required."
+      "remediation": "Run: Set-TransportConfig -SmtpClientAuthenticationDisabled $true. Disable SMTP AUTH org-wide and enable per-mailbox only where required.",
+      "tags": [
+        "configuration-management",
+        "email",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "SPO-AUTH-001",
@@ -59774,7 +62545,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Run: Set-SPOTenant -LegacyAuthProtocolsEnabled $false. SharePoint admin center > Policies > Access control > Apps that do not use modern authentication > Block access."
+      "remediation": "Run: Set-SPOTenant -LegacyAuthProtocolsEnabled $false. SharePoint admin center > Policies > Access control > Apps that do not use modern authentication > Block access.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-SYNC-001",
@@ -60002,7 +62778,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenantSyncClientRestriction -Enable. SharePoint admin center > Settings > Sync > Allow syncing only on computers joined to specific domains."
+      "remediation": "Run: Set-SPOTenantSyncClientRestriction -Enable. SharePoint admin center > Settings > Sync > Allow syncing only on computers joined to specific domains.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-SCRIPT-001",
@@ -60211,7 +62992,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOSite -Identity <PersonalSiteUrl> -DenyAddAndCustomizePages 1. SharePoint admin center > Settings > Custom Script > prevent users from running custom script on personal sites."
+      "remediation": "Run: Set-SPOSite -Identity <PersonalSiteUrl> -DenyAddAndCustomizePages 1. SharePoint admin center > Settings > Custom Script > prevent users from running custom script on personal sites.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-SCRIPT-002",
@@ -60420,7 +63206,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -DenyAddAndCustomizePagesForSitesCreatedByUser 1. SharePoint admin center > Settings > Custom Script > prevent users from running custom script on self-service created sites."
+      "remediation": "Run: Set-SPOTenant -DenyAddAndCustomizePagesForSitesCreatedByUser 1. SharePoint admin center > Settings > Custom Script > prevent users from running custom script on self-service created sites.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "TEAMS-CLIENT-001",
@@ -60637,7 +63428,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsClientConfiguration -AllowDropBox $false -AllowBox $false -AllowGoogleDrive $false -AllowShareFile $false -AllowEgnyte $false. Teams admin center > Messaging policies > Manage third-party storage."
+      "remediation": "Run: Set-CsTeamsClientConfiguration -AllowDropBox $false -AllowBox $false -AllowGoogleDrive $false -AllowShareFile $false -AllowEgnyte $false. Teams admin center > Messaging policies > Manage third-party storage.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-EXTACCESS-001",
@@ -60853,7 +63649,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTenantFederationConfiguration -AllowTeamsConsumer $false. Teams admin center > Users > External access > Teams accounts not managed by an organization > Off."
+      "remediation": "Run: Set-CsTenantFederationConfiguration -AllowTeamsConsumer $false. Teams admin center > Users > External access > Teams accounts not managed by an organization > Off.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-EXTACCESS-002",
@@ -61063,7 +63864,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTenantFederationConfiguration -AllowTeamsConsumerInbound $false. Teams admin center > Users > External access > External users can initiate conversations > Off."
+      "remediation": "Run: Set-CsTenantFederationConfiguration -AllowTeamsConsumerInbound $false. Teams admin center > Users > External access > External users can initiate conversations > Off.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-EXTACCESS-004",
@@ -61269,7 +64075,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTenantFederationConfiguration -AllowPublicUsers $false. Teams admin center > Users > External access > Skype users > Off."
+      "remediation": "Run: Set-CsTenantFederationConfiguration -AllowPublicUsers $false. Teams admin center > Users > External access > Skype users > Off.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-008",
@@ -61486,7 +64297,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowExternalNonTrustedMeetingChat $false. Teams admin center > Meetings > Meeting policies > Global > External meeting chat > Off."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowExternalNonTrustedMeetingChat $false. Teams admin center > Meetings > Meeting policies > Global > External meeting chat > Off.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-009",
@@ -61693,7 +64509,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowCloudRecording $false. Teams admin center > Meetings > Meeting policies > Global > Cloud recording > Off."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowCloudRecording $false. Teams admin center > Meetings > Meeting policies > Global > Cloud recording > Off.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "teams"
+      ]
     },
     {
       "checkId": "POWERBI-GUEST-001",
@@ -61901,6 +64722,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -61908,7 +64734,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Allow guest users to browse and access Power BI content > Disabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Allow guest users to browse and access Power BI content > Disabled",
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "PBI-GUEST-001",
@@ -62127,7 +64958,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "POWERBI-GUEST-002",
@@ -62335,6 +65171,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -62342,7 +65183,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Invite external users to your organization > Disabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Invite external users to your organization > Disabled",
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "PBI-INVITE-001",
@@ -62561,7 +65407,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "PBI-CONTENT-001",
@@ -62780,7 +65631,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "POWERBI-GUEST-003",
@@ -62988,6 +65844,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -62995,7 +65856,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Allow Azure Active Directory guest users to access Power BI > Disabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Allow Azure Active Directory guest users to access Power BI > Disabled",
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "POWERBI-SHARING-001",
@@ -63200,6 +66066,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -63207,7 +66078,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Publish to web > Disabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Publish to web > Disabled",
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi",
+        "sharing"
+      ]
     },
     {
       "checkId": "PBI-PUBLISH-001",
@@ -63423,7 +66300,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "PBI-SCRIPT-001",
@@ -63671,7 +66553,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "POWERBI-SHARING-002",
@@ -63908,14 +66795,24 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Low",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
+        "complexity": 2,
         "isPhased": false,
         "phaseCount": 1,
-        "disruptionRisk": true,
-        "disruptionScope": "user-facing"
+        "disruptionRisk": false
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > R and Python visuals > Interact with and share R and Python visuals > Disabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > R and Python visuals > Interact with and share R and Python visuals > Disabled",
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi",
+        "sharing"
+      ]
     },
     {
       "checkId": "POWERBI-SHARING-004",
@@ -64120,6 +67017,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -64127,7 +67029,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Allow external data sharing > Disabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Allow external data sharing > Disabled",
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi",
+        "sharing"
+      ]
     },
     {
       "checkId": "PBI-SHARING-001",
@@ -64343,7 +67251,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi",
+        "sharing"
+      ]
     },
     {
       "checkId": "PBI-AUTH-001",
@@ -64556,7 +67470,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration-management",
+        "data",
+        "power-bi"
+      ]
     },
     {
       "checkId": "POWERBI-AUTH-001",
@@ -64758,6 +67677,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -64765,7 +67689,14 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Developer settings > Block ResourceKey Authentication > Enabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Developer settings > Block ResourceKey Authentication > Enabled",
+      "tags": [
+        "conditional-access",
+        "configuration-management",
+        "data",
+        "identity",
+        "power-bi"
+      ]
     },
     {
       "checkId": "ENTRA-APPREG-001",
@@ -64955,6 +67886,11 @@
           "controlId": "MS.AAD.5.3v1"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -64962,7 +67898,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{AllowedToCreateApps = $false}. Entra admin center > Users > User settings."
+      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{AllowedToCreateApps = $false}. Entra admin center > Users > User settings.",
+      "tags": [
+        "app-registration",
+        "configuration-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "SPO-SYNC-002",
@@ -65179,14 +68121,23 @@
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC5.2-POF3;CC6.1-POF1;CC6.1-POF7;CC6.7-POF1"
         }
       },
+      "impactRating": {
+        "severity": "Low",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
+        "complexity": 2,
         "isPhased": false,
         "phaseCount": 1,
-        "disruptionRisk": true,
-        "disruptionScope": "user-facing"
+        "disruptionRisk": false
       },
-      "remediation": "SharePoint admin center > Settings > Sync > disable Mac sync app if not required by organizational policy."
+      "remediation": "SharePoint admin center > Settings > Sync > disable Mac sync app if not required by organizational policy.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-LOOP-001",
@@ -65403,14 +68354,23 @@
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC5.2-POF3;CC6.1-POF1;CC6.1-POF7;CC6.7-POF1"
         }
       },
+      "impactRating": {
+        "severity": "Low",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 3,
+        "complexity": 2,
         "isPhased": false,
         "phaseCount": 1,
-        "disruptionRisk": true,
-        "disruptionScope": "user-facing"
+        "disruptionRisk": false
       },
-      "remediation": "Review Loop components usage policy. Disable via SharePoint admin center > Settings if not required by organizational policy."
+      "remediation": "Review Loop components usage policy. Disable via SharePoint admin center > Settings if not required by organizational policy.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-LOOP-002",
@@ -65627,6 +68587,11 @@
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC5.2-POF3;CC6.1-POF1;CC6.1-POF7;CC6.7-POF1"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -65634,7 +68599,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "SharePoint admin center > Settings > restrict Loop sharing to internal users or existing guests only."
+      "remediation": "SharePoint admin center > Settings > restrict Loop sharing to internal users or existing guests only.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "TEAMS-APPS-001",
@@ -65820,6 +68790,11 @@
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -65827,7 +68802,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsAppPermissionPolicy -DefaultCatalogAppsType AllowedAppList. Teams admin center > Teams apps > Permission policies."
+      "remediation": "Run: Set-CsTeamsAppPermissionPolicy -DefaultCatalogAppsType AllowedAppList. Teams admin center > Teams apps > Permission policies.",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "teams"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-021",
@@ -66062,7 +69042,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Review multi-tenant apps and restrict to AzureADMyOrg if they do not need cross-tenant access. Multi-tenant apps can be accessed by users from any Entra ID tenant. Entra admin center > App registrations > Authentication > Supported account types."
+      "remediation": "Review multi-tenant apps and restrict to AzureADMyOrg if they do not need cross-tenant access. Multi-tenant apps can be accessed by users from any Entra ID tenant. Entra admin center > App registrations > Authentication > Supported account types.",
+      "tags": [
+        "app-registration",
+        "configuration-management",
+        "identity"
+      ]
     },
     {
       "checkId": "INTUNE-APPCONTROL-001",
@@ -66219,7 +69204,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Intune admin center > Devices > Configuration > Create profile > Endpoint protection > Windows Defender Application Control. Alternatively, deploy WDAC via custom OMA-URI."
+      "remediation": "Intune admin center > Devices > Configuration > Create profile > Endpoint protection > Windows Defender Application Control. Alternatively, deploy WDAC via custom OMA-URI.",
+      "tags": [
+        "configuration-management",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "INTUNE-VPNCONFIG-001",
@@ -66351,7 +69341,13 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "configuration",
+        "configuration-management",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "TEAMS-APPS-002",
@@ -66522,7 +69518,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Teams admin center > Teams apps > Permission policies > Org-wide app settings > Third-party apps > Off (or restrict to approved apps)."
+      "remediation": "Teams admin center > Teams apps > Permission policies > Org-wide app settings > Third-party apps > Off (or restrict to approved apps).",
+      "tags": [
+        "collaboration",
+        "configuration-management",
+        "teams"
+      ]
     },
     {
       "checkId": "CA-REPORTONLY-001",
@@ -66713,7 +69714,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Review report-only policies and either enable enforcement or remove if no longer needed. Entra admin center > Protection > Conditional Access."
+      "remediation": "Review report-only policies and either enable enforcement or remove if no longer needed. Entra admin center > Protection > Conditional Access.",
+      "tags": [
+        "conditional-access",
+        "configuration-management",
+        "identity"
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-005",
@@ -66950,13 +69956,25 @@
           "title": "COSO Principle 9: Identifies and Analyzes Changes; Changes to Infrastructure, Data, Software, and Procedures"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to facilitate the implementation of a change management program exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 2,
+        "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Edit each policy in simulation mode and switch it to Enforce once validated."
+      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Edit each policy in simulation mode and switch it to Enforce once validated.",
+      "tags": [
+        "change-management",
+        "configuration",
+        "data-governance",
+        "purview",
+        "retention"
+      ]
     },
     {
       "checkId": "ENTRA-CONSENT-002",
@@ -67132,7 +70150,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Update-MgPolicyAdminConsentRequestPolicy -IsEnabled $true. Entra admin center > Enterprise applications > Admin consent requests."
+      "remediation": "Run: Update-MgPolicyAdminConsentRequestPolicy -IsEnabled $true. Entra admin center > Enterprise applications > Admin consent requests.",
+      "tags": [
+        "change-management",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "INTUNE-MAA-001",
@@ -67298,12 +70321,22 @@
           "controlId": "MS.INTUNE.1.1v1"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to perform after-the-fact reviews of configuration change logs to discover any unauthorized changes exposes the tenant to: Unauthorized access, Loss of integrity through unauthorized changes, Emergent properties and/or unintended consequences.",
+        "scfWeighting": 3
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "change-management",
+        "identity",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-003",
@@ -67341,7 +70374,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-MONITOR-001",
@@ -67379,7 +70416,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "AZ-SQL-002",
@@ -67416,7 +70459,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "COMPLIANCE-COMMS-001",
@@ -67609,7 +70658,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Microsoft Purview > Communication compliance > Create a policy to monitor communications for policy violations and insider risk. Requires E5 Compliance licensing."
+      "remediation": "Microsoft Purview > Communication compliance > Create a policy to monitor communications for policy violations and insider risk. Requires E5 Compliance licensing.",
+      "tags": [
+        "compliance",
+        "continuous-monitoring",
+        "purview"
+      ]
     },
     {
       "checkId": "DEFENDER-ANTIMALWARE-002",
@@ -67828,7 +70882,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-MalwareFilterPolicy -Identity <PolicyName> -EnableInternalSenderAdminNotifications $true -InternalSenderAdminAddress admin@domain.com. Security admin center > Anti-malware > Default policy > Admin notifications > Notify admin about undelivered messages from internal senders."
+      "remediation": "Run: Set-MalwareFilterPolicy -Identity <PolicyName> -EnableInternalSenderAdminNotifications $true -InternalSenderAdminAddress admin@domain.com. Security admin center > Anti-malware > Default policy > Admin notifications > Notify admin about undelivered messages from internal senders.",
+      "tags": [
+        "continuous-monitoring",
+        "defender",
+        "email",
+        "endpoint",
+        "malware"
+      ]
     },
     {
       "checkId": "DNS-DMARC-001",
@@ -68015,7 +71076,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Connect to Exchange Online and verify accepted domains."
+      "remediation": "Connect to Exchange Online and verify accepted domains.",
+      "tags": [
+        "continuous-monitoring",
+        "dns",
+        "email"
+      ]
     },
     {
       "checkId": "DEFENDER-CLOUDAPPS-001",
@@ -68189,7 +71255,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "continuous-monitoring",
+        "defender",
+        "email"
+      ]
     },
     {
       "checkId": "TEAMS-REPORTING-001",
@@ -68370,7 +71441,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Teams admin center > Messaging policies > Global (Org-wide default) > Report a security concern > On."
+      "remediation": "Teams admin center > Messaging policies > Global (Org-wide default) > Report a security concern > On.",
+      "tags": [
+        "collaboration",
+        "continuous-monitoring",
+        "teams"
+      ]
     },
     {
       "checkId": "FORMS-CONFIG-005",
@@ -68575,6 +71651,11 @@
           "title": "Detection and Monitoring of New Vulnerabilities; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Changes to Infrastructure, Data, Software, and Procedures"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to review event logs on an ongoing basis and escalate incidents in accordance with established timelines and procedures exposes the tenant to: Unauthorized access, Lost, damaged or stolen asset(s), Loss of integrity through unauthorized changes.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -68582,7 +71663,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Enable \"Record name by default when new forms are created\"."
+      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Enable \"Record name by default when new forms are created\".",
+      "tags": [
+        "collaboration",
+        "configuration",
+        "continuous-monitoring",
+        "forms"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-007",
@@ -68656,7 +71743,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-007",
@@ -68730,7 +71821,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-012",
@@ -68804,7 +71899,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-014",
@@ -68878,7 +71977,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-015",
@@ -68952,7 +72055,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-017",
@@ -69026,7 +72133,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-018",
@@ -69100,7 +72211,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-021",
@@ -69174,7 +72289,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-022",
@@ -69248,7 +72367,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-025",
@@ -69322,7 +72445,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-026",
@@ -69396,7 +72523,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-027",
@@ -69470,7 +72601,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-018",
@@ -69544,7 +72679,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring",
+        "network"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-020",
@@ -69619,7 +72759,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-022",
@@ -69694,7 +72838,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-024",
@@ -69769,7 +72917,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-025",
@@ -69844,7 +72996,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-026",
@@ -69919,7 +73075,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-018",
@@ -69993,7 +73153,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-055",
@@ -70067,7 +73231,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-COSMOS-007",
@@ -70141,7 +73309,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-005",
@@ -70215,7 +73387,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-006",
@@ -70290,7 +73466,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-007",
@@ -70364,7 +73544,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-007",
@@ -70438,7 +73622,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-008",
@@ -70512,7 +73700,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-009",
@@ -70586,7 +73778,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-SQL-010",
@@ -70661,7 +73857,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-AKS-004",
@@ -70735,7 +73935,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "AZ-AKS-026",
@@ -70809,7 +74013,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-050",
@@ -70883,7 +74091,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-053",
@@ -70957,7 +74171,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-054",
@@ -71031,7 +74251,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-068",
@@ -71105,7 +74331,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-074",
@@ -71179,7 +74411,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-080",
@@ -71253,7 +74491,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-099",
@@ -71327,7 +74571,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-105",
@@ -71401,7 +74651,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-108",
@@ -71475,7 +74731,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-119",
@@ -71549,7 +74811,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-120",
@@ -71623,7 +74891,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-121",
@@ -71697,7 +74971,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-123",
@@ -71771,7 +75051,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-124",
@@ -71845,7 +75131,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-126",
@@ -71919,7 +75211,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-127",
@@ -71993,7 +75291,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-128",
@@ -72067,7 +75371,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-130",
@@ -72141,7 +75451,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-131",
@@ -72215,7 +75531,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-133",
@@ -72289,7 +75611,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-134",
@@ -72363,7 +75691,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-135",
@@ -72437,7 +75771,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-136",
@@ -72511,7 +75851,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-137",
@@ -72585,7 +75931,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-138",
@@ -72659,7 +76011,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-139",
@@ -72733,7 +76091,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-140",
@@ -72807,7 +76171,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-141",
@@ -72881,7 +76251,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-142",
@@ -72955,7 +76331,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-143",
@@ -73029,7 +76411,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-144",
@@ -73103,7 +76491,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-146",
@@ -73177,7 +76571,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-147",
@@ -73251,7 +76651,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-149",
@@ -73325,7 +76731,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-150",
@@ -73399,7 +76811,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-151",
@@ -73473,7 +76891,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-152",
@@ -73547,7 +76971,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-021",
@@ -73621,7 +77051,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-026",
@@ -73695,7 +77130,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-027",
@@ -73769,7 +77209,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-028",
@@ -73843,7 +77288,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-029",
@@ -73917,7 +77367,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-034",
@@ -73991,7 +77446,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-035",
@@ -74065,7 +77525,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-036",
@@ -74139,7 +77604,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-037",
@@ -74213,7 +77683,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-047",
@@ -74287,7 +77762,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-071",
@@ -74361,7 +77841,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-084",
@@ -74435,7 +77920,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-085",
@@ -74509,7 +77999,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-111",
@@ -74583,7 +78078,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-116",
@@ -74657,7 +78157,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-156",
@@ -74731,7 +78236,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-157",
@@ -74805,7 +78315,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-167",
@@ -74879,7 +78394,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-169",
@@ -74953,7 +78473,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-171",
@@ -75027,7 +78552,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-173",
@@ -75101,7 +78631,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-216",
@@ -75175,7 +78710,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-238",
@@ -75249,7 +78789,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-250",
@@ -75323,7 +78868,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "PURVIEW-AUDIT-001",
@@ -75526,7 +79076,14 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "compliance",
+        "continuous-monitoring",
+        "logging",
+        "purview"
+      ]
     },
     {
       "checkId": "COMPLIANCE-ALERTPOLICY-001",
@@ -75730,7 +79287,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Alert policies > Review and enable default alert policies. Ensure high-severity policies for suspicious activity, malware, and privilege escalation are active."
+      "remediation": "Microsoft Purview > Alert policies > Review and enable default alert policies. Ensure high-severity policies for suspicious activity, malware, and privilege escalation are active.",
+      "tags": [
+        "compliance",
+        "continuous-monitoring",
+        "purview"
+      ]
     },
     {
       "checkId": "ENTRA-PIM-010",
@@ -75916,13 +79478,23 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to adjust the level of audit review, analysis and reporting based on evolving threat information from law enforcement, industry associations or other credible sources of threat intelligence exposes the tenant to: Unauthorized access, Lost, damaged or stolen asset(s).",
+        "scfWeighting": 5
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "continuous-monitoring",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "INTUNE-WIPEAUDIT-001",
@@ -76123,12 +79695,25 @@
           "controlId": "MS.INTUNE.1.3v1"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to adjust the level of audit review, analysis and reporting based on evolving threat information from law enforcement, industry associations or other credible sources of threat intelligence exposes the tenant to: Unauthorized access, Lost, damaged or stolen asset(s).",
+        "scfWeighting": 5
+      },
       "effort": {
-        "complexity": 2,
+        "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
-        "disruptionRisk": false
-      }
+        "disruptionRisk": true,
+        "disruptionScope": "admin-only"
+      },
+      "tags": [
+        "audit",
+        "continuous-monitoring",
+        "identity",
+        "logging",
+        "privileged-access"
+      ]
     },
     {
       "checkId": "AZ-MONITOR-002",
@@ -76165,7 +79750,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "continuous-monitoring",
+        "logging"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-021",
@@ -76241,7 +79832,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "continuous-monitoring"
+      ]
     },
     {
       "checkId": "COMPLIANCE-AUDIT-001",
@@ -76425,7 +80020,14 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Run: Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true. Microsoft Purview > Audit > Start recording user and admin activity."
+      "remediation": "Run: Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true. Microsoft Purview > Audit > Start recording user and admin activity.",
+      "tags": [
+        "audit",
+        "compliance",
+        "continuous-monitoring",
+        "logging",
+        "purview"
+      ]
     },
     {
       "checkId": "EXO-AUDIT-001",
@@ -76608,7 +80210,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-OrganizationConfig -AuditDisabled $false. Note: this is the Exchange org-level audit flag and is a pre-condition for UAL, but does not guarantee UAL ingestion is active. Verify UAL separately (COMPLIANCE-AUDIT-001)."
+      "remediation": "Run: Set-OrganizationConfig -AuditDisabled $false. Note: this is the Exchange org-level audit flag and is a pre-condition for UAL, but does not guarantee UAL ingestion is active. Verify UAL separately (COMPLIANCE-AUDIT-001).",
+      "tags": [
+        "audit",
+        "continuous-monitoring",
+        "email",
+        "exchange-online",
+        "logging"
+      ]
     },
     {
       "checkId": "EXO-AUDIT-003",
@@ -76794,7 +80403,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "No user mailboxes found to sample."
+      "remediation": "No user mailboxes found to sample.",
+      "tags": [
+        "audit",
+        "continuous-monitoring",
+        "email",
+        "exchange-online",
+        "logging"
+      ]
     },
     {
       "checkId": "EXO-AUDIT-002",
@@ -76980,7 +80596,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-MailboxAuditBypassAssociation -Identity <user> -AuditBypassEnabled $false for each bypassed mailbox."
+      "remediation": "Run: Set-MailboxAuditBypassAssociation -Identity <user> -AuditBypassEnabled $false for each bypassed mailbox.",
+      "tags": [
+        "audit",
+        "continuous-monitoring",
+        "email",
+        "exchange-online",
+        "logging"
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-001",
@@ -77161,7 +80784,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create a retention policy to preserve or delete content per your requirements."
+      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create a retention policy to preserve or delete content per your requirements.",
+      "tags": [
+        "compliance",
+        "continuous-monitoring",
+        "data-governance",
+        "purview",
+        "retention"
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-003",
@@ -77328,13 +80958,25 @@
           "controlId": "C1.1-POF3;C1.2;C1.2-POF1;C1.2-POF2;CC6.5;CC6.5-POF2;P4.0;P4.2;P4.2-POF1;P4.3;P4.3-POF2;P4.3-POF3;PI1.5"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 2,
+        "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Teams channel messages and chats."
+      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Teams channel messages and chats.",
+      "tags": [
+        "configuration",
+        "continuous-monitoring",
+        "data-governance",
+        "purview",
+        "retention"
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-002",
@@ -77501,13 +81143,25 @@
           "controlId": "C1.1-POF3;C1.2;C1.2-POF1;C1.2-POF2;CC6.5;CC6.5-POF2;P4.0;P4.2;P4.2-POF1;P4.3;P4.3-POF2;P4.3-POF3;PI1.5"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 2,
+        "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Exchange email and mailboxes."
+      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Exchange email and mailboxes.",
+      "tags": [
+        "configuration",
+        "continuous-monitoring",
+        "data-governance",
+        "purview",
+        "retention"
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-004",
@@ -77674,13 +81328,25 @@
           "controlId": "C1.1-POF3;C1.2;C1.2-POF1;C1.2-POF2;CC6.5;CC6.5-POF2;P4.0;P4.2;P4.2-POF1;P4.3;P4.3-POF2;P4.3-POF3;PI1.5"
         }
       },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
+        "scfWeighting": 10
+      },
       "effort": {
-        "complexity": 2,
+        "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include SharePoint sites and OneDrive accounts."
+      "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include SharePoint sites and OneDrive accounts.",
+      "tags": [
+        "configuration",
+        "continuous-monitoring",
+        "data-governance",
+        "purview",
+        "retention"
+      ]
     },
     {
       "checkId": "ENTRA-TOU-001",
@@ -77847,7 +81513,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Identity Governance > Terms of use. Verify agreements have \"Require users to expand the terms of use\" enabled and are assigned via Conditional Access policies."
+      "remediation": "Entra admin center > Identity Governance > Terms of use. Verify agreements have \"Require users to expand the terms of use\" enabled and are assigned via Conditional Access policies.",
+      "tags": [
+        "entra-id",
+        "identity",
+        "secure-engineering-architecture"
+      ]
     },
     {
       "checkId": "ENTRA-APPREG-002",
@@ -78009,7 +81680,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Remove localhost redirect URIs from production app registrations. In shared environments, tokens redirected to localhost can be intercepted. Entra admin center > App registrations > Authentication."
+      "remediation": "Remove localhost redirect URIs from production app registrations. In shared environments, tokens redirected to localhost can be intercepted. Entra admin center > App registrations > Authentication.",
+      "tags": [
+        "app-registration",
+        "identity",
+        "technology-development-acquisition"
+      ]
     },
     {
       "checkId": "ENTRA-CONSENT-003",
@@ -78222,7 +81898,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Enterprise applications > Consent and permissions > User consent settings > Allow consent only from verified publishers or block user consent entirely."
+      "remediation": "Entra admin center > Enterprise applications > Consent and permissions > User consent settings > Allow consent only from verified publishers or block user consent entirely.",
+      "tags": [
+        "entra-id",
+        "identity",
+        "third-party-management"
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-011",
@@ -78433,7 +82114,12 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Entra admin center > Enterprise applications > review foreign apps with broad data access (Mail.ReadWrite, Files.ReadWrite.All, etc.). Scope to least-privilege or remove."
+      "remediation": "Entra admin center > Enterprise applications > review foreign apps with broad data access (Mail.ReadWrite, Files.ReadWrite.All, etc.). Scope to least-privilege or remove.",
+      "tags": [
+        "app-registration",
+        "identity",
+        "third-party-management"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-003",
@@ -78471,7 +82157,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-001",
@@ -78548,7 +82239,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-009",
@@ -78626,7 +82321,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-007",
@@ -78704,7 +82403,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-008",
@@ -78782,7 +82485,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-033",
@@ -78860,7 +82567,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-035",
@@ -78938,7 +82649,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-036",
@@ -79016,7 +82731,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-039",
@@ -79093,7 +82812,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "CA-NAMEDLOC-001",
@@ -79276,7 +82999,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "IP-based trusted locations can be spoofed via VPN or proxy. Consider Global Secure Access compliant network checks or country-based locations for stronger assurance. Entra admin center > Protection > Conditional Access > Named locations."
+      "remediation": "IP-based trusted locations can be spoofed via VPN or proxy. Consider Global Secure Access compliant network checks or country-based locations for stronger assurance. Entra admin center > Protection > Conditional Access > Named locations.",
+      "tags": [
+        "conditional-access",
+        "identity",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-001",
@@ -79314,7 +83042,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-002",
@@ -79352,7 +83085,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-SQL-003",
@@ -79389,7 +83127,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-002",
@@ -79426,7 +83169,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "EXO-SHARING-001",
@@ -79613,7 +83361,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Exchange admin center > Organization > Sharing > Default sharing policy. Remove wildcard (*) domains or restrict to CalendarSharingFreeBusySimple."
+      "remediation": "Exchange admin center > Organization > Sharing > Default sharing policy. Remove wildcard (*) domains or restrict to CalendarSharingFreeBusySimple.",
+      "tags": [
+        "data",
+        "email",
+        "exchange-online",
+        "network-security",
+        "sharing"
+      ]
     },
     {
       "checkId": "SPO-SWAY-001",
@@ -79800,7 +83555,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "collaboration",
+        "network-security",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "COMPLIANCE-DLP-001",
@@ -79909,14 +83669,14 @@
           "controlId": "3.13.1"
         },
         "nist-800-53": {
-          "controlId": "AU-11;CM-12;SI-12;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
+          "controlId": "SC-7(10);AU-11;CM-12;SI-12;SC-07;SC-07(09);SC-07(10);SC-07(11);SI-04(18)",
           "profiles": [
             "Low",
             "Moderate",
             "High",
             "Privacy"
           ],
-          "title": "Audit Record Retention; Information Location; Information Management and Retention"
+          "title": "Prevent Exfiltration; Audit Record Retention; Information Location; Information Management and Retention"
         },
         "pci-dss": {
           "controlId": "1.3.2;1.3.3;1.4;1.4.1;1.4.2;11.5.1;A3.2.6"
@@ -79952,7 +83712,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Data loss prevention > Policies > Create a DLP policy covering sensitive information types relevant to your organization."
+      "remediation": "Microsoft Purview > Data loss prevention > Policies > Create a DLP policy covering sensitive information types relevant to your organization.",
+      "tags": [
+        "compliance",
+        "data-governance",
+        "dlp",
+        "network-security",
+        "purview"
+      ]
     },
     {
       "checkId": "COMPLIANCE-DLP-002",
@@ -80100,7 +83867,14 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Data loss prevention > Policies > Edit an existing policy or create new > Include Teams chat and channel messages location."
+      "remediation": "Microsoft Purview > Data loss prevention > Policies > Edit an existing policy or create new > Include Teams chat and channel messages location.",
+      "tags": [
+        "compliance",
+        "data-governance",
+        "dlp",
+        "network-security",
+        "purview"
+      ]
     },
     {
       "checkId": "COMPLIANCE-LABELS-001",
@@ -80287,7 +84061,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Information protection > Labels > Create and publish sensitivity labels. Then create a label policy to deploy them to users."
+      "remediation": "Microsoft Purview > Information protection > Labels > Create and publish sensitivity labels. Then create a label policy to deploy them to users.",
+      "tags": [
+        "compliance",
+        "network-security",
+        "purview"
+      ]
     },
     {
       "checkId": "TEAMS-CLIENT-002",
@@ -80461,7 +84240,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-CsTeamsClientConfiguration -AllowEmailIntoChannel $false. Teams admin center > Teams settings > Email integration > Users can send emails to a channel email address > Off."
+      "remediation": "Run: Set-CsTeamsClientConfiguration -AllowEmailIntoChannel $false. Teams admin center > Teams settings > Email integration > Users can send emails to a channel email address > Off.",
+      "tags": [
+        "collaboration",
+        "network-security",
+        "teams"
+      ]
     },
     {
       "checkId": "POWERBI-INFOPROT-001",
@@ -80637,6 +84421,11 @@
           "title": "The confidentiality, integrity, and availability of data-at-rest are protected"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to use automated mechanisms to prevent the unauthorized exfiltration of sensitive/regulated data across managed interfaces exposes the tenant to: Emergent properties and/or unintended consequences, Data loss / corruption, Information loss / corruption or system.",
+        "scfWeighting": 5
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -80644,7 +84433,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Information protection > Allow users to apply sensitivity labels for content > Enabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Information protection > Allow users to apply sensitivity labels for content > Enabled",
+      "tags": [
+        "data",
+        "network-security",
+        "power-bi"
+      ]
     },
     {
       "checkId": "PBI-LABELS-001",
@@ -80831,7 +84625,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "data",
+        "network-security",
+        "power-bi"
+      ]
     },
     {
       "checkId": "POWERBI-SHARING-003",
@@ -81006,6 +84805,11 @@
           "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties; The confidentiality, integrity, and availability of data-at-rest are protected"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to use automated mechanisms to prevent the unauthorized exfiltration of sensitive/regulated data across managed interfaces exposes the tenant to: Emergent properties and/or unintended consequences, Data loss / corruption, Information loss / corruption or system.",
+        "scfWeighting": 5
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -81013,7 +84817,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Allow shareable links to grant access to everyone in your organization > Disabled"
+      "remediation": "Power BI Admin Portal > Tenant settings > Export and sharing > Allow shareable links to grant access to everyone in your organization > Disabled",
+      "tags": [
+        "data",
+        "network-security",
+        "power-bi",
+        "sharing"
+      ]
     },
     {
       "checkId": "PBI-LINK-001",
@@ -81199,7 +85009,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "data",
+        "network-security",
+        "power-bi"
+      ]
     },
     {
       "checkId": "COMPLIANCE-DLP-003",
@@ -81348,7 +85163,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Microsoft Purview > Data loss prevention > Policies > Edit existing policies to include Exchange email and SharePoint/OneDrive locations for comprehensive data protection."
+      "remediation": "Microsoft Purview > Data loss prevention > Policies > Edit existing policies to include Exchange email and SharePoint/OneDrive locations for comprehensive data protection.",
+      "tags": [
+        "compliance",
+        "data-governance",
+        "dlp",
+        "network-security",
+        "purview"
+      ]
     },
     {
       "checkId": "EXO-CONNFILTER-001",
@@ -81552,7 +85374,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Run: Set-HostedConnectionFilterPolicy -Identity <Policy> -IPAllowList @{}. Exchange admin center > Protection > Connection filter > Edit the policy and remove all IP allow list entries."
+      "remediation": "Run: Set-HostedConnectionFilterPolicy -Identity <Policy> -IPAllowList @{}. Exchange admin center > Protection > Connection filter > Edit the policy and remove all IP allow list entries.",
+      "tags": [
+        "email",
+        "exchange-online",
+        "network-security"
+      ]
     },
     {
       "checkId": "EXO-CONNFILTER-002",
@@ -81755,7 +85582,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-HostedConnectionFilterPolicy -Identity <Policy> -EnableSafeList $false. Exchange admin center > Protection > Connection filter > Edit the policy and uncheck \"Turn on safe list\"."
+      "remediation": "Run: Set-HostedConnectionFilterPolicy -Identity <Policy> -EnableSafeList $false. Exchange admin center > Protection > Connection filter > Edit the policy and uncheck \"Turn on safe list\".",
+      "tags": [
+        "email",
+        "exchange-online",
+        "network-security"
+      ]
     },
     {
       "checkId": "EXO-TRANSPORT-002",
@@ -81966,7 +85798,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "email",
+        "exchange-online",
+        "network-security"
+      ]
     },
     {
       "checkId": "EXO-FORWARD-001",
@@ -82170,7 +86007,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Run: Set-RemoteDomain -Identity Default -AutoForwardEnabled $false. Also consider transport rules to block client-side forwarding."
+      "remediation": "Run: Set-RemoteDomain -Identity Default -AutoForwardEnabled $false. Also consider transport rules to block client-side forwarding.",
+      "tags": [
+        "email",
+        "exchange-online",
+        "network-security"
+      ]
     },
     {
       "checkId": "PBI-TENANT-001",
@@ -82384,7 +86226,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "data",
+        "network-security",
+        "power-bi"
+      ]
     },
     {
       "checkId": "PBI-TENANT-002",
@@ -82598,7 +86445,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "data",
+        "network-security",
+        "power-bi"
+      ]
     },
     {
       "checkId": "ENTRA-GROUP-006",
@@ -82798,13 +86650,23 @@
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to implement and govern Access Control Lists (ACLs) to provide data flow enforcement that explicitly restrict network traffic to only what is authorized exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 3,
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "entra-id",
+        "identity",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-002",
@@ -82875,7 +86737,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-010",
@@ -82946,7 +86812,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-005",
@@ -83017,7 +86887,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-011",
@@ -83088,7 +86962,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-019",
@@ -83159,7 +87037,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-020",
@@ -83230,7 +87112,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-023",
@@ -83301,7 +87187,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-024",
@@ -83372,7 +87262,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-004",
@@ -83443,7 +87337,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-005",
@@ -83514,7 +87413,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-006",
@@ -83585,7 +87489,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-007",
@@ -83656,7 +87565,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-008",
@@ -83727,7 +87641,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-013",
@@ -83798,7 +87717,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-014",
@@ -83869,7 +87793,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-017",
@@ -83940,7 +87869,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-019",
@@ -84011,7 +87945,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-011",
@@ -84082,7 +88021,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-014",
@@ -84153,7 +88096,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-023",
@@ -84224,7 +88171,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-027",
@@ -84295,7 +88246,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-044",
@@ -84366,7 +88321,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-061",
@@ -84437,7 +88396,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-077",
@@ -84508,7 +88471,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-CONTAINER-001",
@@ -84579,7 +88546,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-VM-006",
@@ -84650,7 +88621,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-COSMOS-001",
@@ -84721,7 +88696,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-COSMOS-004",
@@ -84792,7 +88771,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-COSMOS-006",
@@ -84863,7 +88846,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-003",
@@ -84934,7 +88921,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-003",
@@ -85005,7 +88996,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-SQL-005",
@@ -85076,7 +89071,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-SQL-006",
@@ -85147,7 +89146,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-012",
@@ -85218,7 +89221,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-014",
@@ -85289,7 +89296,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-048",
@@ -85360,7 +89371,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-050",
@@ -85431,7 +89446,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-001",
@@ -85502,7 +89521,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-002",
@@ -85573,7 +89596,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-003",
@@ -85644,7 +89671,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-004",
@@ -85715,7 +89746,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-005",
@@ -85786,7 +89821,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-006",
@@ -85857,7 +89896,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-007",
@@ -85928,7 +89971,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-008",
@@ -85999,7 +90046,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-009",
@@ -86070,7 +90121,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-010",
@@ -86141,7 +90196,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-011",
@@ -86212,7 +90271,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-012",
@@ -86283,7 +90346,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-013",
@@ -86354,7 +90421,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-014",
@@ -86425,7 +90496,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-015",
@@ -86496,7 +90571,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-016",
@@ -86567,7 +90646,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-017",
@@ -86638,7 +90721,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-018",
@@ -86709,7 +90796,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-019",
@@ -86780,7 +90871,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-020",
@@ -86851,7 +90946,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-021",
@@ -86922,7 +91021,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-022",
@@ -86993,7 +91096,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-FIREWALL-023",
@@ -87064,7 +91171,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-145",
@@ -87135,7 +91246,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "logging",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-011",
@@ -87205,7 +91322,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-036",
@@ -87275,7 +91396,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-037",
@@ -87345,7 +91470,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-021",
@@ -87415,7 +91544,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-022",
@@ -87485,7 +91618,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-020",
@@ -87555,7 +91692,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-021",
@@ -87625,7 +91766,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-022",
@@ -87695,7 +91840,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-023",
@@ -87765,7 +91914,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-024",
@@ -87835,7 +91988,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-025",
@@ -87905,7 +92062,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-026",
@@ -87975,7 +92136,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-040",
@@ -88045,7 +92210,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-041",
@@ -88115,7 +92284,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-042",
@@ -88185,7 +92358,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-043",
@@ -88255,7 +92432,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-057",
@@ -88325,7 +92506,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-058",
@@ -88395,7 +92580,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-059",
@@ -88465,7 +92654,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-060",
@@ -88535,7 +92728,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-073",
@@ -88605,7 +92802,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-074",
@@ -88675,7 +92876,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-075",
@@ -88745,7 +92950,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-076",
@@ -88815,7 +93024,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-COSMOS-002",
@@ -88885,7 +93098,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-004",
@@ -88955,7 +93172,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-004",
@@ -89025,7 +93246,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-049",
@@ -89095,7 +93320,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "ENTRA-CA-SESSIONFREQ-001",
@@ -89236,7 +93465,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "conditional-access",
+        "identity",
+        "network-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-004",
@@ -89292,7 +93526,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "network-security"
+      ]
     },
     {
       "checkId": "ENTRA-SESSIONAUTH-001",
@@ -89422,7 +93660,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "conditional-access",
+        "identity",
+        "network-security"
+      ]
     },
     {
       "checkId": "EXO-DIRECTSEND-001",
@@ -89636,7 +93879,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Connect to Exchange Online PowerShell to check inbound connector configuration."
+      "remediation": "Connect to Exchange Online PowerShell to check inbound connector configuration.",
+      "tags": [
+        "email",
+        "exchange-online",
+        "network-security"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-005",
@@ -89839,7 +94087,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowExternalParticipantGiveRequestControl $false. Teams admin center > Meetings > Meeting policies > Global > External participants can give or request control > Off."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowExternalParticipantGiveRequestControl $false. Teams admin center > Meetings > Meeting policies > Global > External participants can give or request control > Off.",
+      "tags": [
+        "collaboration",
+        "network-security",
+        "teams"
+      ]
     },
     {
       "checkId": "CA-REMOTEDEVICE-001",
@@ -89972,7 +94225,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "conditional-access",
+        "identity",
+        "network-security"
+      ]
     },
     {
       "checkId": "INTUNE-REMOTEVPN-001",
@@ -90121,7 +94379,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "endpoint",
+        "intune",
+        "network-security"
+      ]
     },
     {
       "checkId": "ENTRA-PRIVREMOTE-001",
@@ -90275,7 +94538,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Enable Entra ID PIM. Convert permanent role assignments to eligible. Configure activation to require justification and MFA. Entra admin center > Identity Governance > Privileged Identity Management > Entra ID roles."
+      "remediation": "Enable Entra ID PIM. Convert permanent role assignments to eligible. Configure activation to require justification and MFA. Entra admin center > Identity Governance > Privileged Identity Management > Entra ID roles.",
+      "tags": [
+        "entra-id",
+        "identity",
+        "network-security"
+      ]
     },
     {
       "checkId": "INTUNE-WIFI-001",
@@ -90442,7 +94710,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "endpoint",
+        "intune",
+        "network-security"
+      ]
     },
     {
       "checkId": "INTUNE-ENCRYPTION-001",
@@ -90620,7 +94893,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "endpoint",
+        "endpoint-security",
+        "intune"
+      ]
     },
     {
       "checkId": "ENTRA-GROUP-003",
@@ -90809,7 +95087,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Assign owners to ownerless public M365 groups. Entra admin center > Groups > All groups > select group > Owners > Add owners."
+      "remediation": "Assign owners to ownerless public M365 groups. Entra admin center > Groups > All groups > select group > Owners > Add owners.",
+      "tags": [
+        "endpoint-security",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-APPS-001",
@@ -91001,7 +95284,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Users > User settings > Users can register applications > No. Also review Enterprise applications > User settings > Users can consent to apps."
+      "remediation": "Entra admin center > Users > User settings > Users can register applications > No. Also review Enterprise applications > User settings > Users can consent to apps.",
+      "tags": [
+        "endpoint-security",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-TENANT-001",
@@ -91189,7 +95477,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{AllowedToCreateTenants = $false}. Entra admin center > Users > User settings."
+      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{AllowedToCreateTenants = $false}. Entra admin center > Users > User settings.",
+      "tags": [
+        "endpoint-security",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-GROUP-001",
@@ -91377,7 +95670,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{AllowedToCreateSecurityGroups = $false}. Entra admin center > Groups > General."
+      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{AllowedToCreateSecurityGroups = $false}. Entra admin center > Groups > General.",
+      "tags": [
+        "endpoint-security",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-CONSENT-001",
@@ -91568,7 +95866,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{PermissionGrantPoliciesAssigned = @()}. Entra admin center > Enterprise applications > Consent and permissions."
+      "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{PermissionGrantPoliciesAssigned = @()}. Entra admin center > Enterprise applications > Consent and permissions.",
+      "tags": [
+        "endpoint-security",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "DEFENDER-SAFELINKS-001",
@@ -91837,7 +96140,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: New-SafeLinksPolicy -Name \"Safe Links\" -IsEnabled $true; New-SafeLinksRule -Name \"Safe Links\" -SafeLinksPolicy \"Safe Links\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Links > Create a policy covering all users."
+      "remediation": "Run: New-SafeLinksPolicy -Name \"Safe Links\" -IsEnabled $true; New-SafeLinksRule -Name \"Safe Links\" -SafeLinksPolicy \"Safe Links\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Links > Create a policy covering all users.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "DEFENDER-ANTIMALWARE-001",
@@ -92064,8 +96372,8 @@
           "controlId": "3.14.1;3.14.2;3.14.4;3.3.3;3.4.1;3.4.2"
         },
         "nist-800-53": {
-          "controlId": "SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
-          "title": "Malicious Code Protection; Spam Protection; Baseline Selection",
+          "controlId": "CM-6;SI-3;SI-8;CM-02;CM-06;PL-10;SA-08;SA-15(05);SI-02;SI-03;SI-08",
+          "title": "Configuration Settings; Malicious Code Protection; Spam Protection; Baseline Selection",
           "profiles": [
             "Low",
             "Moderate",
@@ -92107,7 +96415,14 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-MalwareFilterPolicy -Identity <PolicyName> -EnableFileFilter $true. Security admin center > Anti-malware > Default policy > Common attachments filter > Enable."
+      "remediation": "Run: Set-MalwareFilterPolicy -Identity <PolicyName> -EnableFileFilter $true. Security admin center > Anti-malware > Default policy > Common attachments filter > Enable.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint",
+        "endpoint-security",
+        "malware"
+      ]
     },
     {
       "checkId": "DEFENDER-SAFEATTACH-001",
@@ -92376,7 +96691,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: New-SafeAttachmentPolicy -Name \"Safe Attachments\" -Enable $true -Action Block; New-SafeAttachmentRule -Name \"Safe Attachments\" -SafeAttachmentPolicy \"Safe Attachments\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Attachments > Create a policy covering all users."
+      "remediation": "Run: New-SafeAttachmentPolicy -Name \"Safe Attachments\" -Enable $true -Action Block; New-SafeAttachmentRule -Name \"Safe Attachments\" -SafeAttachmentPolicy \"Safe Attachments\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Attachments > Create a policy covering all users.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "DEFENDER-SAFEATTACH-002",
@@ -92640,7 +96960,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Run: Set-AtpPolicyForO365 -EnableATPForSPOTeamsODB $true. Security admin center > Safe Attachments > Global settings > Turn on Defender for Office 365 for SharePoint, OneDrive, and Microsoft Teams."
+      "remediation": "Run: Set-AtpPolicyForO365 -EnableATPForSPOTeamsODB $true. Security admin center > Safe Attachments > Global settings > Turn on Defender for Office 365 for SharePoint, OneDrive, and Microsoft Teams.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "DEFENDER-ANTISPAM-001",
@@ -92907,7 +97232,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "No action needed -- settings enforced by preset security policy."
+      "remediation": "No action needed -- settings enforced by preset security policy.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "DEFENDER-MALWARE-002",
@@ -93173,7 +97503,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "DEFENDER-PRIORITY-001",
@@ -93440,7 +97775,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Configure preset security policies in Security admin center > Preset security policies > Strict or Standard protection > Assign users/groups."
+      "remediation": "Configure preset security policies in Security admin center > Preset security policies > Strict or Standard protection > Assign users/groups.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "DEFENDER-PRIORITY-002",
@@ -93707,7 +98047,12 @@
         "disruptionRisk": true,
         "disruptionScope": "admin-only"
       },
-      "remediation": "Assign priority account users to the Strict preset policy. Security admin center > Preset security policies > Strict protection > Manage protection settings > Add users or groups."
+      "remediation": "Assign priority account users to the Strict preset policy. Security admin center > Preset security policies > Strict protection > Manage protection settings > Add users or groups.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "DEFENDER-ZAP-001",
@@ -93971,7 +98316,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Enable ZAP for Teams in Security admin center > Settings > Zero-hour auto purge > Teams."
+      "remediation": "Enable ZAP for Teams in Security admin center > Settings > Zero-hour auto purge > Teams.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "FORMS-CONFIG-004",
@@ -94222,6 +98572,11 @@
           ]
         }
       },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to utilize antimalware technologies to detect and eradicate malicious code exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
+        "scfWeighting": 10
+      },
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -94229,7 +98584,13 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Enable \"Internal phishing protection\"."
+      "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Enable \"Internal phishing protection\".",
+      "tags": [
+        "collaboration",
+        "configuration",
+        "endpoint-security",
+        "forms"
+      ]
     },
     {
       "checkId": "EXO-ANTIPHISH-001",
@@ -94489,7 +98850,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "email",
+        "endpoint-security",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "EXO-DKIM-001",
@@ -94749,7 +99115,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "email",
+        "endpoint-security",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "EXO-MALWARE-001",
@@ -95008,7 +99379,12 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "email",
+        "endpoint-security",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "SPO-MALWARE-002",
@@ -95272,7 +99648,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenant -DisallowInfectedFileDownload $true. SharePoint admin center > Policies > Malware protection."
+      "remediation": "Run: Set-SPOTenant -DisallowInfectedFileDownload $true. SharePoint admin center > Policies > Malware protection.",
+      "tags": [
+        "collaboration",
+        "endpoint-security",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "SPO-ACCESS-002",
@@ -95513,7 +99894,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-SPOTenantSyncClientRestriction -Enable. Also consider Conditional Access policies with device compliance conditions for defense in depth. SharePoint admin center > Settings > Sync."
+      "remediation": "Run: Set-SPOTenantSyncClientRestriction -Enable. Also consider Conditional Access policies with device compliance conditions for defense in depth. SharePoint admin center > Settings > Sync.",
+      "tags": [
+        "collaboration",
+        "endpoint-security",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "AZ-VM-002",
@@ -95551,7 +99937,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-005",
@@ -95626,7 +100016,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-013",
@@ -95701,7 +100095,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-014",
@@ -95776,7 +100174,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-015",
@@ -95851,7 +100253,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-016",
@@ -95926,7 +100332,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-017",
@@ -96001,7 +100411,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-019",
@@ -96076,7 +100490,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-023",
@@ -96151,7 +100569,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-028",
@@ -96226,7 +100648,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-029",
@@ -96301,7 +100727,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-VM-009",
@@ -96376,7 +100806,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "AZ-AKS-042",
@@ -96451,7 +100885,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-182",
@@ -96526,7 +100964,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-183",
@@ -96601,7 +101044,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-186",
@@ -96676,7 +101124,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-188",
@@ -96751,7 +101204,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-189",
@@ -96826,7 +101284,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-190",
@@ -96901,7 +101364,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-191",
@@ -96976,7 +101444,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-192",
@@ -97051,7 +101524,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-194",
@@ -97126,7 +101604,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-195",
@@ -97201,7 +101684,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-196",
@@ -97276,7 +101764,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-197",
@@ -97351,7 +101844,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-198",
@@ -97426,7 +101924,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-200",
@@ -97501,7 +102004,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-201",
@@ -97576,7 +102084,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-203",
@@ -97651,7 +102164,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-204",
@@ -97726,7 +102244,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-230",
@@ -97801,7 +102324,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-259",
@@ -97876,7 +102404,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "INTUNE-UPDATE-001",
@@ -98071,7 +102604,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "endpoint",
+        "endpoint-security",
+        "intune"
+      ]
     },
     {
       "checkId": "DEFENDER-REALTIMESCAN-001",
@@ -98235,7 +102773,14 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Intune admin center > Endpoint security > Antivirus > Create policy > Microsoft Defender Antivirus > Enable real-time protection."
+      "remediation": "Intune admin center > Endpoint security > Antivirus > Create policy > Microsoft Defender Antivirus > Enable real-time protection.",
+      "tags": [
+        "conditional-access",
+        "defender",
+        "email",
+        "endpoint-security",
+        "identity"
+      ]
     },
     {
       "checkId": "ENTRA-ORGSETTING-002",
@@ -98386,7 +102931,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "M365 admin center > Settings > Org settings > Microsoft Forms > ensure internal phishing protection is enabled."
+      "remediation": "M365 admin center > Settings > Org settings > Microsoft Forms > ensure internal phishing protection is enabled.",
+      "tags": [
+        "endpoint-security",
+        "entra-id",
+        "identity"
+      ]
     },
     {
       "checkId": "DEFENDER-ANTIPHISH-001",
@@ -98499,12 +103049,12 @@
           "controlId": "T1137;T1137.001;T1137.002;T1137.003;T1137.004;T1137.005;T1137.006;T1204;T1204.001;T1204.002;T1204.003;T1221;T1566;T1566.001;T1566.002;T1566.003;T1598;T1598.001;T1598.002;T1598.003"
         },
         "nist-800-53": {
-          "controlId": "SI-3;SI-8;SI-08",
+          "controlId": "SI-8;SI-3;SI-08",
           "profiles": [
             "Moderate",
             "High"
           ],
-          "title": "Malicious Code Protection; Spam Protection"
+          "title": "Spam Protection; Malicious Code Protection"
         },
         "pci-dss": {
           "controlId": "5.4;5.4.1"
@@ -98539,7 +103089,12 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "No action needed -- settings enforced by preset security policy."
+      "remediation": "No action needed -- settings enforced by preset security policy.",
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "DEFENDER-ANTISPAM-002",
@@ -98689,7 +103244,12 @@
         "isPhased": true,
         "phaseCount": 3,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "defender",
+        "email",
+        "endpoint-security"
+      ]
     },
     {
       "checkId": "EXO-ANTISPAM-001",
@@ -98829,7 +103389,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "email",
+        "endpoint-security",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "EXO-TRANSPORT-001",
@@ -98980,7 +103545,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Exchange admin center > Mail flow > Rules. Remove or disable any transport rules that set SCL to -1 for specific sender domains, as this bypasses spam filtering."
+      "remediation": "Exchange admin center > Mail flow > Rules. Remove or disable any transport rules that set SCL to -1 for specific sender domains, as this bypasses spam filtering.",
+      "tags": [
+        "email",
+        "endpoint-security",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "EXO-EXTTAG-001",
@@ -99134,7 +103704,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Run: Set-ExternalInOutlook -Enabled $true. Tags external emails with a visual indicator in Outlook."
+      "remediation": "Run: Set-ExternalInOutlook -Enabled $true. Tags external emails with a visual indicator in Outlook.",
+      "tags": [
+        "email",
+        "endpoint-security",
+        "exchange-online"
+      ]
     },
     {
       "checkId": "INTUNE-MOBILECODE-001",
@@ -99346,7 +103921,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
-      }
+      },
+      "tags": [
+        "endpoint",
+        "endpoint-security",
+        "intune"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-001",
@@ -99554,7 +104134,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowAnonymousUsersToJoinMeeting $false. Teams admin center > Meetings > Meeting policies > Global > Anonymous users can join a meeting > Off."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowAnonymousUsersToJoinMeeting $false. Teams admin center > Meetings > Meeting policies > Global > Anonymous users can join a meeting > Off.",
+      "tags": [
+        "collaboration",
+        "endpoint-security",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-002",
@@ -99728,7 +104313,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowAnonymousUsersToStartMeeting $false. Teams admin center > Meetings > Meeting policies > Global > Anonymous users can start a meeting > Off."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowAnonymousUsersToStartMeeting $false. Teams admin center > Meetings > Meeting policies > Global > Anonymous users can start a meeting > Off.",
+      "tags": [
+        "collaboration",
+        "endpoint-security",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-004",
@@ -99902,7 +104492,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowPSTNUsersToBypassLobby $false. Teams admin center > Meetings > Meeting policies > Global > Dial-in users can bypass the lobby > Off."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowPSTNUsersToBypassLobby $false. Teams admin center > Meetings > Meeting policies > Global > Dial-in users can bypass the lobby > Off.",
+      "tags": [
+        "collaboration",
+        "endpoint-security",
+        "teams"
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-006",
@@ -100110,7 +104705,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -MeetingChatEnabledType EnabledExceptAnonymous. Teams admin center > Meetings > Meeting policies > Global > Meeting chat > On for everyone except anonymous users."
+      "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -MeetingChatEnabledType EnabledExceptAnonymous. Teams admin center > Meetings > Meeting policies > Global > Meeting chat > On for everyone except anonymous users.",
+      "tags": [
+        "collaboration",
+        "endpoint-security",
+        "teams"
+      ]
     },
     {
       "checkId": "ENTRA-DEVICE-002",
@@ -100317,7 +104917,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Entra admin center > Devices > Device settings > Maximum number of devices per user. Set to 15 or lower."
+      "remediation": "Entra admin center > Devices > Device settings > Maximum number of devices per user. Set to 15 or lower.",
+      "tags": [
+        "entra-id",
+        "identity",
+        "mobile-device-management"
+      ]
     },
     {
       "checkId": "INTUNE-MOBILEENCRYPT-001",
@@ -100440,7 +105045,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Intune admin center > Devices > Compliance > Create/edit iOS and Android compliance policies > Require device encryption."
+      "remediation": "Intune admin center > Devices > Compliance > Create/edit iOS and Android compliance policies > Require device encryption.",
+      "tags": [
+        "endpoint",
+        "intune",
+        "mobile-device-management"
+      ]
     },
     {
       "checkId": "ENTRA-APPREG-004",
@@ -100583,7 +105193,12 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Replace wildcard redirect URIs with explicit URIs. Wildcards enable open redirect attacks for token theft. Entra admin center > App registrations > Authentication."
+      "remediation": "Replace wildcard redirect URIs with explicit URIs. Wildcards enable open redirect attacks for token theft. Entra admin center > App registrations > Authentication.",
+      "tags": [
+        "app-registration",
+        "identity",
+        "web-security"
+      ]
     },
     {
       "checkId": "INTUNE-FIPS-001",
@@ -100809,7 +105424,12 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Intune admin center > Devices > Configuration > Create profile > Custom OMA-URI > Add setting: ./Device/Vendor/MSFT/Policy/Config/Cryptography/AllowFipsAlgorithmPolicy = 1."
+      "remediation": "Intune admin center > Devices > Configuration > Create profile > Custom OMA-URI > Add setting: ./Device/Vendor/MSFT/Policy/Config/Cryptography/AllowFipsAlgorithmPolicy = 1.",
+      "tags": [
+        "cryptographic-protections",
+        "endpoint",
+        "intune"
+      ]
     },
     {
       "checkId": "AZ-KEYVAULT-001",
@@ -100846,7 +105466,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-KEYVAULT-002",
@@ -100884,7 +105508,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-KEYVAULT-003",
@@ -100921,7 +105549,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "DNS-DKIM-001",
@@ -101089,7 +105721,12 @@
         "disruptionRisk": true,
         "disruptionScope": "service"
       },
-      "remediation": "Connect to Exchange Online and verify accepted domains."
+      "remediation": "Connect to Exchange Online and verify accepted domains.",
+      "tags": [
+        "cryptographic-protections",
+        "dns",
+        "email"
+      ]
     },
     {
       "checkId": "ENTRA-APPREG-003",
@@ -101263,7 +105900,12 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Update HTTP redirect URIs to HTTPS. Non-HTTPS URIs allow token interception via MITM attacks. Entra admin center > App registrations > Authentication."
+      "remediation": "Update HTTP redirect URIs to HTTPS. Non-HTTPS URIs allow token interception via MITM attacks. Entra admin center > App registrations > Authentication.",
+      "tags": [
+        "app-registration",
+        "cryptographic-protections",
+        "identity"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-002",
@@ -101301,7 +105943,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections",
+        "encryption",
+        "tls"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-003",
@@ -101338,7 +105986,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections",
+        "encryption",
+        "tls"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-001",
@@ -101376,7 +106030,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-VM-001",
@@ -101414,7 +106072,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections",
+        "encryption"
+      ]
     },
     {
       "checkId": "AZ-SQL-001",
@@ -101452,7 +106115,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections",
+        "encryption"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-003",
@@ -101528,7 +106196,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-015",
@@ -101604,7 +106276,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-016",
@@ -101680,7 +106356,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-VM-003",
@@ -101756,7 +106436,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-VM-013",
@@ -101832,7 +106516,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-SQL-009",
@@ -101908,7 +106596,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-AKS-038",
@@ -101984,7 +106676,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-AKS-047",
@@ -102060,7 +106756,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-015",
@@ -102136,7 +106836,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections",
+        "network"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-011",
@@ -102212,7 +106917,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-041",
@@ -102288,7 +106997,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-005",
@@ -102364,7 +107077,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-006",
@@ -102440,7 +107157,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-010",
@@ -102516,7 +107237,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-012",
@@ -102592,7 +107317,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-005",
@@ -102668,7 +107397,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-006",
@@ -102744,7 +107477,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-013",
@@ -102820,7 +107557,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-014",
@@ -102896,7 +107637,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-015",
@@ -102972,7 +107717,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-034",
@@ -103048,7 +107797,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-035",
@@ -103124,7 +107877,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-036",
@@ -103200,7 +107957,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-050",
@@ -103276,7 +108037,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-051",
@@ -103352,7 +108117,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-052",
@@ -103428,7 +108197,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-067",
@@ -103504,7 +108277,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-068",
@@ -103580,7 +108357,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-069",
@@ -103656,7 +108437,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-009",
@@ -103732,7 +108517,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-011",
@@ -103808,7 +108597,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-SQL-011",
@@ -103884,7 +108677,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-AKS-052",
@@ -103960,7 +108757,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-058",
@@ -104036,7 +108837,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptographic-protections",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-059",
@@ -104112,7 +108919,13 @@
         "phaseCount": 3,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptographic-protections",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-081",
@@ -104188,7 +109001,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptographic-protections",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-092",
@@ -104264,7 +109083,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptographic-protections",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-101",
@@ -104340,7 +109165,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptographic-protections",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-102",
@@ -104416,7 +109247,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptographic-protections",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-129",
@@ -104492,7 +109329,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptographic-protections",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-148",
@@ -104568,7 +109411,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptographic-protections",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-008",
@@ -104644,7 +109493,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-011",
@@ -104720,7 +109574,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-018",
@@ -104796,7 +109655,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-062",
@@ -104872,7 +109736,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-064",
@@ -104948,7 +109817,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-065",
@@ -105024,7 +109898,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-066",
@@ -105100,7 +109979,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-067",
@@ -105176,7 +110060,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-068",
@@ -105252,7 +110141,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-069",
@@ -105328,7 +110222,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-070",
@@ -105404,7 +110303,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-072",
@@ -105480,7 +110384,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-074",
@@ -105556,7 +110465,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-075",
@@ -105632,7 +110546,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-076",
@@ -105708,7 +110627,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-077",
@@ -105784,7 +110708,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-078",
@@ -105860,7 +110789,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-079",
@@ -105936,7 +110870,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-080",
@@ -106012,7 +110951,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-081",
@@ -106088,7 +111032,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-094",
@@ -106164,7 +111113,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-103",
@@ -106240,7 +111194,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-153",
@@ -106316,7 +111275,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-181",
@@ -106392,7 +111356,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-185",
@@ -106468,7 +111437,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-187",
@@ -106544,7 +111518,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-218",
@@ -106620,7 +111599,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-220",
@@ -106696,7 +111680,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-252",
@@ -106772,7 +111761,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-253",
@@ -106848,7 +111842,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-258",
@@ -106924,7 +111923,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-260",
@@ -107000,7 +112004,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-263",
@@ -107076,7 +112085,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-008",
@@ -107135,7 +112149,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-009",
@@ -107194,7 +112212,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-010",
@@ -107253,7 +112275,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-027",
@@ -107312,7 +112338,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-038",
@@ -107371,7 +112401,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-039",
@@ -107430,7 +112464,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-040",
@@ -107489,7 +112527,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-VM-004",
@@ -107548,7 +112590,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-VM-005",
@@ -107607,7 +112653,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-VM-010",
@@ -107666,7 +112716,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-COSMOS-005",
@@ -107725,7 +112779,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-001",
@@ -107784,7 +112842,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-001",
@@ -107843,7 +112905,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-SQL-007",
@@ -107902,7 +112968,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "AZ-AKS-019",
@@ -107961,7 +113031,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptographic-protections"
+      ]
     },
     {
       "checkId": "SPO-VERSIONING-001",
@@ -108132,7 +113206,12 @@
         "phaseCount": 1,
         "disruptionRisk": false
       },
-      "remediation": "Set version history limits at the library level in SharePoint admin center. Ensure at least 100 major versions are retained for ransomware recovery."
+      "remediation": "Set version history limits at the library level in SharePoint admin center. Ensure at least 100 major versions are retained for ransomware recovery.",
+      "tags": [
+        "business-continuity-disaster-recovery",
+        "collaboration",
+        "sharepoint"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-004",
@@ -108186,7 +113265,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-007",
@@ -108240,7 +113323,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-008",
@@ -108294,7 +113381,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-009",
@@ -108348,7 +113439,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-017",
@@ -108402,7 +113497,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-001",
@@ -108456,7 +113555,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "business-continuity-disaster-recovery",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-007",
@@ -108510,7 +113615,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "business-continuity-disaster-recovery",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-008",
@@ -108564,7 +113675,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "business-continuity-disaster-recovery",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-011",
@@ -108618,7 +113735,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "business-continuity-disaster-recovery",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-045",
@@ -108672,7 +113795,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "business-continuity-disaster-recovery",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-060",
@@ -108726,7 +113855,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "business-continuity-disaster-recovery",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-104",
@@ -108780,7 +113915,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery",
+        "configuration"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-166",
@@ -108834,7 +113974,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery",
+        "configuration"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-168",
@@ -108888,7 +114033,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery",
+        "configuration"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-170",
@@ -108942,7 +114092,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery",
+        "configuration"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-172",
@@ -108996,7 +114151,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery",
+        "configuration"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-179",
@@ -109050,7 +114210,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "business-continuity-disaster-recovery",
+        "configuration"
+      ]
     },
     {
       "checkId": "BACKUP-ENABLED-001",
@@ -109218,7 +114383,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "business-continuity-disaster-recovery",
+        "compliance",
+        "purview"
+      ]
     },
     {
       "checkId": "DEFENDER-VULNSCAN-001",
@@ -109455,7 +114625,14 @@
         "phaseCount": 3,
         "disruptionRisk": false
       },
-      "remediation": "Enable Microsoft Defender for Endpoint. Navigate to security.microsoft.com > Vulnerability management to review coverage. Ensure devices are onboarded to MDE."
+      "remediation": "Enable Microsoft Defender for Endpoint. Navigate to security.microsoft.com > Vulnerability management to review coverage. Ensure devices are onboarded to MDE.",
+      "tags": [
+        "conditional-access",
+        "defender",
+        "email",
+        "identity",
+        "vulnerability-patch-management"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-001",
@@ -109493,7 +114670,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "vulnerability-patch-management"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-002",
@@ -109531,7 +114712,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "vulnerability-patch-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-004",
@@ -109607,7 +114792,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-016",
@@ -109682,7 +114871,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography",
+        "network"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-002",
@@ -109758,7 +114952,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-011",
@@ -109834,7 +115032,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-012",
@@ -109909,7 +115111,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-032",
@@ -109985,7 +115191,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-033",
@@ -110060,7 +115270,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-048",
@@ -110136,7 +115350,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-049",
@@ -110211,7 +115429,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-065",
@@ -110287,7 +115509,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-066",
@@ -110362,7 +115588,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-008",
@@ -110438,7 +115668,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-010",
@@ -110514,7 +115748,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-061",
@@ -110590,7 +115828,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptography",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-062",
@@ -110666,7 +115910,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptography",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-063",
@@ -110742,7 +115992,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptography",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-066",
@@ -110818,7 +116074,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptography",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-076",
@@ -110894,7 +116156,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptography",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-079",
@@ -110970,7 +116238,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "cryptography",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-040",
@@ -111046,7 +116320,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptography"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-073",
@@ -111122,7 +116401,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptography"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-242",
@@ -111198,7 +116482,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-STORAGE-019",
@@ -111257,7 +116546,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-AKS-016",
@@ -111316,7 +116609,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-AKS-017",
@@ -111375,7 +116672,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-AKS-037",
@@ -111434,7 +116735,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "cryptography"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-132",
@@ -111493,7 +116798,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "cryptography"
+      ]
     },
     {
       "checkId": "AZ-ANALYTICS-005",
@@ -111544,7 +116854,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "security,-compliance-resilience-governance"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-028",
@@ -111611,7 +116925,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-012",
@@ -111678,7 +116996,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management",
+        "network"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-017",
@@ -111745,7 +117068,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-038",
@@ -111812,7 +117139,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-054",
@@ -111879,7 +117210,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-071",
@@ -111946,7 +117281,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-VM-007",
@@ -112013,7 +117352,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-MYSQL-002",
@@ -112080,7 +117423,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-002",
@@ -112147,7 +117494,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-SQL-008",
@@ -112214,7 +117565,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-AKS-009",
@@ -112281,7 +117636,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-AKS-011",
@@ -112348,7 +117707,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-102",
@@ -112415,7 +117778,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-095",
@@ -112482,7 +117850,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-098",
@@ -112549,7 +117923,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-100",
@@ -112616,7 +117996,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-103",
@@ -112683,7 +118069,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-104",
@@ -112750,7 +118142,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-106",
@@ -112817,7 +118215,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-107",
@@ -112884,7 +118288,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-001",
@@ -112955,7 +118365,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-010",
@@ -113026,7 +118440,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-031",
@@ -113097,7 +118515,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-047",
@@ -113168,7 +118590,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-APPSVC-064",
@@ -113239,7 +118665,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-073",
@@ -113309,7 +118739,13 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-105",
@@ -113380,7 +118816,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-106",
@@ -113451,7 +118892,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-109",
@@ -113522,7 +118968,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-110",
@@ -113593,7 +119044,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-005",
@@ -113664,7 +119120,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-030",
@@ -113735,7 +119195,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-033",
@@ -113806,7 +119271,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-AKS-013",
@@ -113865,7 +119335,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-072",
@@ -113924,7 +119398,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-075",
@@ -113983,7 +119463,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-126",
@@ -114042,7 +119528,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-127",
@@ -114101,7 +119592,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-207",
@@ -114160,7 +119656,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-209",
@@ -114219,7 +119720,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-210",
@@ -114278,7 +119784,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-211",
@@ -114337,7 +119848,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-212",
@@ -114396,7 +119912,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-213",
@@ -114455,7 +119976,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-214",
@@ -114514,7 +120040,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-215",
@@ -114573,7 +120104,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-217",
@@ -114632,7 +120168,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-219",
@@ -114691,7 +120232,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-221",
@@ -114750,7 +120296,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-222",
@@ -114809,7 +120360,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-016",
@@ -114889,7 +120445,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-027",
@@ -114969,7 +120529,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "AZ-IDENTITY-040",
@@ -115049,7 +120613,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "identity-access-management"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-027",
@@ -115129,7 +120697,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-028",
@@ -115209,7 +120783,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-051",
@@ -115289,7 +120869,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "identity-access-management",
+        "logging"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-008",
@@ -115364,7 +120950,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-013",
@@ -115438,7 +121028,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-016",
@@ -115512,7 +121106,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-GOVERNANCE-028",
@@ -115586,7 +121184,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-009",
@@ -115661,7 +121263,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring",
+        "network"
+      ]
     },
     {
       "checkId": "AZ-NETWORK-011",
@@ -115735,7 +121342,12 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring",
+        "network"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-007",
@@ -115809,7 +121421,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-008",
@@ -115883,7 +121499,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-009",
@@ -115957,7 +121577,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-010",
@@ -116032,7 +121656,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-DEFENDER-018",
@@ -116107,7 +121735,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-POSTGRES-006",
@@ -116181,7 +121813,11 @@
         "isPhased": false,
         "phaseCount": 1,
         "disruptionRisk": false
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-SQL-004",
@@ -116256,7 +121892,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "AZ-AKS-015",
@@ -116331,7 +121971,11 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "monitoring"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-030",
@@ -116406,7 +122050,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "logging",
+        "monitoring"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-037",
@@ -116481,7 +122131,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "logging",
+        "monitoring"
+      ]
     },
     {
       "checkId": "WIN-AUDIT-038",
@@ -116556,7 +122212,13 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "audit",
+        "azure",
+        "logging",
+        "monitoring"
+      ]
     },
     {
       "checkId": "WIN-CONFIG-239",
@@ -116631,7 +122293,12 @@
         "phaseCount": 1,
         "disruptionRisk": true,
         "disruptionScope": "service"
-      }
+      },
+      "tags": [
+        "azure",
+        "configuration",
+        "monitoring"
+      ]
     }
   ]
 }

--- a/data/registry.schema.json
+++ b/data/registry.schema.json
@@ -178,6 +178,41 @@
         "remediation": {
           "type": "string",
           "description": "Actionable guidance for resolving a failing check \u2014 UI navigation path or PowerShell command."
+        },
+        "impact": {
+          "type": "string",
+          "description": "What an attacker or auditor observes when this check fails. Distinct from remediation (fix) and rationale (why it matters)."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "The security principle behind this control \u2014 why it exists, written for a practitioner audience."
+        },
+        "references": {
+          "type": "array",
+          "description": "Links to official documentation supporting this check.",
+          "items": {
+            "type": "object",
+            "required": ["url", "title"],
+            "additionalProperties": false,
+            "properties": {
+              "url": {
+                "type": "string",
+                "format": "uri"
+              },
+              "title": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "tags": {
+          "type": "array",
+          "description": "Functional/topical tags for search and filtering.",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       },
       "if": {

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -43,7 +43,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "cisM365ControlId": "1.1.1",
       "cisM365Profiles": [
@@ -108,7 +108,7 @@
         "BCD-06",
         "BCD-01"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to use automated mechanisms to disable or remove temporary and emergency accounts after an organization-defined time period for each type of account exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "1.1.4",
       "cisM365Profiles": [
@@ -880,7 +880,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to control publicly-accessible content exposes the tenant to: Inability to maintain individual accountability, Unauthorized access, Lost, damaged or stolen asset(s).",
       "cisM365ControlId": "3.6.1",
       "cisM365Profiles": [
@@ -902,7 +902,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to control publicly-accessible content exposes the tenant to: Inability to maintain individual accountability, Unauthorized access, Lost, damaged or stolen asset(s).",
       "cisM365ControlId": "3.6.1",
       "cisM365Profiles": [
@@ -926,7 +926,7 @@
         "VPM-01",
         "VPM-05"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to utilize antimalware technologies to detect and eradicate malicious code exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "cisM365ControlId": "3.6.2",
       "cisM365Profiles": [
@@ -1088,7 +1088,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to utilize the concept of least privilege, allowing only authorized access to processes necessary to accomplish assigned tasks in accordance with organizational business functions exposes the tenant to: Inability to maintain individual accountability, Improper assignment.",
       "cisM365ControlId": "5.1.2.1",
       "cisM365Profiles": [
@@ -1595,7 +1595,7 @@
       "licensing": "E3",
       "scfPrimary": "CFG-03",
       "scfAdditional": [],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "5.2.2.3",
       "cisM365Profiles": [
@@ -3201,7 +3201,7 @@
         "IAC-21",
         "IAC-20"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "9.1.1",
       "cisM365Profiles": [
@@ -3242,7 +3242,7 @@
         "IAC-21",
         "IAC-20"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "9.1.2",
       "cisM365Profiles": [
@@ -3303,7 +3303,7 @@
         "IAC-21",
         "IAC-20"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "9.1.3",
       "cisM365Profiles": [
@@ -3324,7 +3324,7 @@
         "NET-03.5",
         "NET-17"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "9.1.4",
       "cisM365Profiles": [
@@ -3391,7 +3391,7 @@
         "VPM-01",
         "VPM-05"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Low",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "9.1.5",
       "cisM365Profiles": [
@@ -3414,7 +3414,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to use automated mechanisms to prevent the unauthorized exfiltration of sensitive/regulated data across managed interfaces exposes the tenant to: Emergent properties and/or unintended consequences, Data loss / corruption, Information loss / corruption or system.",
       "cisM365ControlId": "9.1.6",
       "cisM365Profiles": [
@@ -3458,7 +3458,7 @@
         "PRI-07",
         "NET-17"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to use automated mechanisms to prevent the unauthorized exfiltration of sensitive/regulated data across managed interfaces exposes the tenant to: Emergent properties and/or unintended consequences, Data loss / corruption, Information loss / corruption or system.",
       "cisM365ControlId": "9.1.7",
       "cisM365Profiles": [
@@ -3500,7 +3500,7 @@
         "NET-03.5",
         "NET-17"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "9.1.8",
       "cisM365Profiles": [
@@ -3561,7 +3561,7 @@
         "IAC-10.8",
         "IAC-10"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "9.1.9",
       "cisM365Profiles": [
@@ -3600,7 +3600,7 @@
       "scfAdditional": [
         "NET-04"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "cisM365ControlId": "9.1.10",
       "cisM365Profiles": [
@@ -3620,7 +3620,7 @@
       "scfAdditional": [
         "NET-04"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "cisM365ControlId": "9.1.11",
       "cisM365Profiles": [
@@ -3660,7 +3660,7 @@
         "IAC-10.8",
         "IAC-10"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation."
     },
     {
@@ -3674,7 +3674,7 @@
       "scfAdditional": [
         "IAC-17"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to enforce Role-Based Access Control (RBAC) for Technology Assets, Applications, Services and/or Data (TAASD) to restrict access to individuals assigned specific roles with legitimate business needs exposes the tenant to: Inability to maintain individual accountability.",
       "cisaScubaControlId": "MS.AAD.7.2v1"
     },
@@ -3690,7 +3690,7 @@
         "IRO-09",
         "MON-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to adjust the level of audit review, analysis and reporting based on evolving threat information from law enforcement, industry associations or other credible sources of threat intelligence exposes the tenant to: Unauthorized access, Lost, damaged or stolen asset(s).",
       "cisM365ControlId": "5.3.9",
       "cisM365Profiles": [
@@ -3711,7 +3711,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to proactively govern account management of individual, group, system, service, application, guest and temporary accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "cisaScubaControlId": "MS.AAD.7.4v1"
     },
@@ -3728,7 +3728,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to control publicly-accessible content exposes the tenant to: Inability to maintain individual accountability, Unauthorized access, Lost, damaged or stolen asset(s).",
       "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"People outside your organization can see results summary and individual responses\"."
     },
@@ -3743,7 +3743,7 @@
       "scfAdditional": [
         "IAC-21.2"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Low",
       "impactRationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "cisaScubaControlId": "MS.INTUNE.1.2v1"
     },
@@ -3761,7 +3761,7 @@
         "MON-02",
         "CFG-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to review event logs on an ongoing basis and escalate incidents in accordance with established timelines and procedures exposes the tenant to: Unauthorized access, Lost, damaged or stolen asset(s), Loss of integrity through unauthorized changes.",
       "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Enable \"Record name by default when new forms are created\"."
     },
@@ -3776,7 +3776,7 @@
       "scfAdditional": [
         "NET-03"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Low",
       "impactRationale": "Failure to control publicly-accessible content exposes the tenant to: Inability to maintain individual accountability, Unauthorized access, Lost, damaged or stolen asset(s).",
       "remediation": "Microsoft 365 admin center > Settings > Org settings > Microsoft Forms > Uncheck \"Bing search and YouTube video\"."
     },
@@ -3792,7 +3792,7 @@
         "IAC-20.5",
         "HRS-12.1"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to perform after-the-fact reviews of configuration change logs to discover any unauthorized changes exposes the tenant to: Unauthorized access, Loss of integrity through unauthorized changes, Emergent properties and/or unintended consequences.",
       "cisaScubaControlId": "MS.INTUNE.1.1v1"
     },
@@ -3811,7 +3811,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to adjust the level of audit review, analysis and reporting based on evolving threat information from law enforcement, industry associations or other credible sources of threat intelligence exposes the tenant to: Unauthorized access, Lost, damaged or stolen asset(s).",
       "cisaScubaControlId": "MS.INTUNE.1.3v1"
     },
@@ -3827,7 +3827,7 @@
         "DCH-18",
         "PRI-05"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Teams channel messages and chats."
     },
@@ -3843,7 +3843,7 @@
         "DCH-18",
         "PRI-05"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Exchange email and mailboxes."
     },
@@ -3858,7 +3858,7 @@
       "scfAdditional": [
         "IAC-15.3"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to use automated mechanisms to disable or remove temporary and emergency accounts after an organization-defined time period for each type of account exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": ""
     },
@@ -3874,7 +3874,7 @@
         "DCH-18",
         "PRI-05"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include SharePoint sites and OneDrive accounts."
     },
@@ -3893,7 +3893,7 @@
         "IAC-06",
         "IAC-06.1"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to utilize Multi-Factor Authentication (MFA) to authenticate local access for privileged accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "cisM365ControlId": "5.3.7",
       "cisM365Profiles": [
@@ -3912,7 +3912,7 @@
         "IAC-10.8",
         "IAC-10"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to use automated mechanisms to disable inactive accounts after an organization-defined time period exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Review the following inactive apps and remove their credentials or disable them: Entra admin center > Enterprise applications > filter by last sign-in > remove secrets/certificates."
     },
@@ -3927,7 +3927,7 @@
       "scfAdditional": [
         "IAC-21.1"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to use automated mechanisms to disable or remove temporary and emergency accounts after an organization-defined time period for each type of account exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisM365ControlId": "5.3.8",
       "cisM365Profiles": [
@@ -3948,7 +3948,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to uniquely identify and centrally Authenticate, Authorize and Audit (AAA) organizational users and processes acting on behalf of organizational users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisaScubaControlId": "MS.AAD.1.1v1",
       "remediation": "Run: Update-MgPolicyIdentitySecurityDefaultsEnforcementPolicy -IsEnabled $true. Entra admin center > Properties > Manage security defaults."
@@ -3962,7 +3962,7 @@
       "licensing": "E3",
       "scfPrimary": "CFG-03",
       "scfAdditional": [],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "cisaScubaControlId": "MS.AAD.5.3v1",
       "remediation": "Run: Update-MgPolicyAuthorizationPolicy -DefaultUserRolePermissions @{AllowedToCreateApps = $false}. Entra admin center > Users > User settings."
@@ -3980,7 +3980,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to revoke user access rights in a timely manner, upon termination of employment or contract exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Informational — review and remove stale guest accounts periodically. Entra admin center > Users > Guest users."
     },
@@ -3996,7 +3996,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to enforce Logical Access Control (LAC) permissions that conform to the principle of \"least privilege?\" exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Informational — review Conditional Access policy coverage for your organization."
     },
@@ -4012,7 +4012,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to enforce Logical Access Control (LAC) permissions that conform to the principle of \"least privilege?\" exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Run: Get-MgIdentityConditionalAccessPolicy | Where-Object {$_.State -eq ''enabled''}. Ensure policies are set to On, not Report-only."
     },
@@ -4025,7 +4025,7 @@
       "licensing": "E3",
       "scfPrimary": "IAC-22",
       "scfAdditional": [],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to enforce a limit for consecutive invalid login attempts by a user during an organization-defined time period and automatically locks the account when the maximum number of unsuccessful attempts is exceeded exposes the tenant to: Inability to maintain individual.",
       "remediation": "Run: Update-MgBetaDirectorySetting for Password Rule Settings with LockoutThreshold. Entra admin center > Protection > Password protection."
     },
@@ -4040,7 +4040,7 @@
       "scfAdditional": [
         "IAC-10"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to ensure default authenticators are changed as part of account creation or system installation exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Run: Update-MgBetaDirectorySetting for Password Rule Settings to add organization-specific terms. Entra admin center > Protection > Password protection."
     },
@@ -4056,7 +4056,7 @@
         "AST-02.3",
         "AST-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Low",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "remediation": "SharePoint admin center > Settings > Sync > disable Mac sync app if not required by organizational policy."
     },
@@ -4072,7 +4072,7 @@
         "AST-02.3",
         "AST-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Low",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "remediation": "Review Loop components usage policy. Disable via SharePoint admin center > Settings if not required by organizational policy."
     },
@@ -4088,7 +4088,7 @@
         "AST-02.3",
         "AST-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "remediation": "SharePoint admin center > Settings > restrict Loop sharing to internal users or existing guests only."
     },
@@ -4101,7 +4101,7 @@
       "licensing": "E3",
       "scfPrimary": "CFG-03",
       "scfAdditional": [],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to configure systems to provide only essential capabilities by specifically prohibiting or restricting the use of ports, protocols, and/or services exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions.",
       "remediation": "Run: Set-CsTeamsAppPermissionPolicy -DefaultCatalogAppsType AllowedAppList. Teams admin center > Teams apps > Permission policies."
     },
@@ -4116,7 +4116,7 @@
       "scfAdditional": [
         "AST-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Informational",
       "impactRationale": "Failure to establish and maintain an authoritative source and repository to provide a trusted source and accountability for approved and implemented system components that prevents assets from being duplicated in other asset inventories exposes the tenant to: Emergent properties.",
       "remediation": "Informational — confirms Teams service connectivity."
     },
@@ -4134,7 +4134,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to enforce a limit for consecutive invalid login attempts by a user during an organization-defined time period and automatically locks the account when the maximum number of unsuccessful attempts is exceeded exposes the tenant to: Inability to maintain individual.",
       "remediation": "Combining sign-in risk and user risk in one CA policy creates an AND condition -- both must be true to trigger. Microsoft recommends separate policies for each risk type. Entra admin center > Protection > Conditional Access."
     },
@@ -4153,7 +4153,7 @@
         "MON-02",
         "CFG-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to use automated mechanisms to audit account creation, modification, enabling, disabling and removal actions and notify organization-defined personnel or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged."
     },
     {
@@ -4169,7 +4169,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Consider creating CA policies that specifically target privileged directory roles with stricter controls (phishing-resistant MFA, compliant devices)."
     },
@@ -4186,7 +4186,7 @@
         "IAC-10",
         "CFG-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to document, assess risk and approve or deny deviations to standardized configurations exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Entra admin center > Enterprise applications > review each app with credentials. Remove secrets/certificates from apps that no longer need them."
     },
@@ -4202,7 +4202,7 @@
         "IAC-21.3",
         "TPM-04"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Entra admin center > Enterprise applications > review foreign apps with Tier 0 permissions. These permissions have documented attack paths to Global Administrator. Remove or replace with least-privilege alternatives."
     },
@@ -4217,7 +4217,7 @@
       "scfAdditional": [
         "TPM-04"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Entra admin center > Enterprise applications > review foreign apps with high-privilege delegated permissions. Revoke admin consent or remove the app."
     },
@@ -4236,7 +4236,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Entra admin center > Roles and administrators > review roles assigned to foreign service principals. Remove role assignments from untrusted external apps."
     },
@@ -4252,7 +4252,7 @@
         "IAC-21",
         "IAC-20"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Review apps with > 10 application permissions. Remove unnecessary permissions to follow least-privilege. Entra admin center > App registrations > [app] > API permissions."
     },
@@ -4268,7 +4268,7 @@
         "CFG-03",
         "CFG-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to document, assess risk and approve or deny deviations to standardized configurations exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Entra admin center > Applications > App management policies > configure a default policy to lock sensitive properties on multi-tenant apps."
     },
@@ -4284,7 +4284,7 @@
         "IAC-21",
         "IAC-20"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Review managed identity permissions. Use narrower permissions (e.g., Mail.Read instead of Mail.ReadWrite). Azure portal > Managed Identity > API permissions."
     },
@@ -4302,7 +4302,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Review managed identities with directory roles. Use Graph API permissions instead of directory roles where possible. Entra admin center > Roles and administrators."
     },
@@ -4321,7 +4321,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to proactively govern account management of individual, group, system, service, application, guest and temporary accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation."
     },
     {
@@ -4337,7 +4337,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation."
     },
     {
@@ -4353,7 +4353,7 @@
         "TDA-18",
         "NET-12"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "Medium",
       "impactRationale": "Failure to implement and govern Access Control Lists (ACLs) to provide data flow enforcement that explicitly restrict network traffic to only what is authorized exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions."
     },
     {
@@ -4370,7 +4370,7 @@
         "NET-12",
         "TDA-18"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation."
     },
     {
@@ -4388,7 +4388,7 @@
         "IAC-06.1",
         "IAC-06.4"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to utilize Multi-Factor Authentication (MFA) to authenticate local access for privileged accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation."
     },
     {
@@ -4402,7 +4402,7 @@
       "scfAdditional": [
         "CFG-03.3"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to prevent non-privileged users from executing privileged functions to include disabling, circumventing or altering implemented security safeguards / countermeasures exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged.",
       "cisaScubaControlId": "MS.AAD.6.1v1"
     },
@@ -4418,7 +4418,7 @@
         "MON-10",
         "CHG-02"
       ],
-      "impactSeverity": "",
+      "impactSeverity": "High",
       "impactRationale": "Failure to facilitate the implementation of a change management program exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Edit each policy in simulation mode and switch it to Enforce once validated."
     },

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -40,7 +40,7 @@ if sys.stdout.encoding != "utf-8":
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 
-SCHEMA_VERSION = "2.1.0"
+SCHEMA_VERSION = "2.2.0"
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +480,69 @@ def derive_effort(check_obj: dict, effort_overrides: dict) -> dict:
     return effort
 
 
+_COLLECTOR_TAGS: dict[str, list[str]] = {
+    "Entra": ["entra-id", "identity"],
+    "CAEvaluator": ["conditional-access", "identity"],
+    "ExchangeOnline": ["exchange-online", "email"],
+    "DNS": ["dns", "email"],
+    "Defender": ["defender", "email"],
+    "Compliance": ["compliance", "purview"],
+    "Intune": ["intune", "endpoint"],
+    "SharePoint": ["sharepoint", "collaboration"],
+    "Teams": ["teams", "collaboration"],
+    "PowerBI": ["power-bi", "data"],
+    "Purview": ["purview", "data-governance"],
+    "StrykerReadiness": ["identity", "privileged-access"],
+    "Forms": ["forms", "collaboration"],
+    "PurviewRetention": ["purview", "data-governance", "retention"],
+    "EntApp": ["app-registration", "identity"],
+    "AzAssess": ["azure"],
+}
+
+_CATEGORY_TAGS: dict[str, list[str]] = {
+    "MFA": ["mfa", "authentication"],
+    "ENCRYPTION_AT_REST": ["encryption"],
+    "ENCRYPTION_IN_TRANSIT": ["encryption", "tls"],
+    "AUDIT": ["logging", "audit"],
+    "LOGGING": ["logging", "audit"],
+    "CLOUDADMIN": ["privileged-access", "admin"],
+    "PRIVACCESS": ["privileged-access"],
+    "ROLES": ["rbac", "privileged-access"],
+    "GUESTACCESS": ["guest-access", "identity"],
+    "SHARING": ["sharing", "data"],
+    "RETENTION": ["retention", "data-governance"],
+    "DLP": ["dlp", "data-governance"],
+    "ANTIPHISHING": ["phishing", "email-security"],
+    "ANTIMALWARE": ["malware", "endpoint"],
+    "CA": ["conditional-access", "identity"],
+    "APPREG": ["app-registration"],
+    "NETWORK": ["network"],
+    "CONFIG": ["configuration"],
+}
+
+
+def derive_tags(check_obj: dict) -> list[str]:
+    """Derive functional tags from collector, category, and SCF domain."""
+    collector = check_obj.get("collector", "")
+    category = check_obj.get("category", "")
+    domain = check_obj.get("scf", {}).get("domain", "")
+
+    tags: list[str] = []
+    tags.extend(_COLLECTOR_TAGS.get(collector, []))
+
+    for cat_key, cat_tags in _CATEGORY_TAGS.items():
+        if cat_key in category.upper():
+            for t in cat_tags:
+                if t not in tags:
+                    tags.append(t)
+
+    domain_lower = domain.lower().replace(" & ", "-").replace(" ", "-")
+    if domain_lower and domain_lower not in tags:
+        tags.append(domain_lower)
+
+    return sorted(set(tags))
+
+
 def scf_sort_key(check: dict) -> tuple:
     """Sort key: SCF domain order → SCF ID (numeric sort)."""
     scf = check.get("scf", {})
@@ -858,6 +921,10 @@ def main():
         if remediation:
             check_obj["remediation"] = remediation
 
+        tags = derive_tags(check_obj)
+        if tags:
+            check_obj["tags"] = tags
+
         checks.append(check_obj)
 
     # Merge AZ-Assess checks (Azure ARM surface — not SCF-database-derived)
@@ -875,6 +942,9 @@ def main():
                 )
                 fw_derived += 1
         az["effort"] = derive_effort(az, effort_overrides)
+        az_tags = derive_tags(az)
+        if az_tags:
+            az["tags"] = az_tags
     checks.extend(az_checks)
     checks.sort(key=scf_sort_key)
 

--- a/scripts/Test-RegistryData.ps1
+++ b/scripts/Test-RegistryData.ps1
@@ -17,7 +17,7 @@
 .EXAMPLE
     ./scripts/Test-RegistryData.ps1
 .NOTES
-    Version: 2.1.0
+    Version: 2.2.0
 #>
 [CmdletBinding()]
 param(
@@ -94,9 +94,9 @@ Test-Check "registry.json is valid JSON" {
 
 if (-not $reg) { Write-Host "`nRegistry JSON invalid — cannot continue." -ForegroundColor Red; exit 1 }
 
-Test-Check "registry.json has schemaVersion 2.1.0" {
+Test-Check "registry.json has schemaVersion 2.2.0" {
     if (-not $reg.schemaVersion) { return "Missing schemaVersion field" }
-    if ($reg.schemaVersion -ne '2.1.0') { return "Expected schemaVersion 2.1.0, got '$($reg.schemaVersion)'" }
+    if ($reg.schemaVersion -ne '2.2.0') { return "Expected schemaVersion 2.2.0, got '$($reg.schemaVersion)'" }
 }
 
 Test-Check "registry.json has dataVersion" {

--- a/tests/registry-integrity.Tests.ps1
+++ b/tests/registry-integrity.Tests.ps1
@@ -7,9 +7,9 @@ Describe 'Control Registry Integrity' {
 
     # --- Schema-level tests ---
 
-    It 'Has schemaVersion 2.1.0' {
-        $raw.schemaVersion | Should -Be '2.1.0' `
-            -Because "registry must be schema version 2.1.0 (SCF-based, includes effort field)"
+    It 'Has schemaVersion 2.2.0' {
+        $raw.schemaVersion | Should -Be '2.2.0' `
+            -Because "registry must be schema version 2.2.0 (adds impact, rationale, references, tags fields)"
     }
 
     It 'Has dataVersion field with valid date format' {


### PR DESCRIPTION
## Summary

- Adds four new optional fields to registry schema v2.2.0: `impact`, `rationale`, `references`, `tags`
- `tags` are auto-derived for all 1,092 checks from collector, category, and SCF domain (no manual work needed)
- Populates `impactRating.severity` for 65 M365 checks that had empty values in `scf-check-mapping.json`
- Pester tests updated to expect schema v2.2.0

## Fields added

| Field | Type | Notes |
|---|---|---|
| `impact` | string | What fails when check is not met — populated in later phases |
| `rationale` | string | Security principle behind the control — populated in later phases |
| `references` | array of `{url, title}` | Official docs — populated in later phases |
| `tags` | array of strings | Auto-derived on every build from collector/category/SCF domain |

## Test plan

- [x] `Invoke-Pester -Path tests/` — all 281 tests pass (was 280/281 before schema version fix)
- [x] All 1,092 checks have tags in registry.json
- [x] Zero checks with null severity (was 65)
- [x] schema v2.2.0 in registry.json

Closes #212 Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)