### PR TITLE
feat(data): add reference URLs for all 110 Critical/High M365 checks (Phase 4)

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -739,6 +739,12 @@
       "remediation": "Investigate foreign apps using Microsoft product names -- they may be social engineering attempts. Verify the publisher and appId against known Microsoft first-party apps. Remove if suspicious.",
       "impact": "Users who grant consent to impersonating apps give external parties persistent delegated access to their data. The Microsoft-branded name increases consent rates and reduces user suspicion.",
       "rationale": "Applications that impersonate Microsoft product names in their display names are a social engineering vector. Users who see 'Microsoft Teams Meeting Add-in' or 'Office 365 Security' in a consent prompt are more likely to approve the consent without scrutiny.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/application-sign-in-unexpected-user-consent-error",
+          "title": "Microsoft Learn — Unexpected error when performing consent to an application"
+        }
+      ],
       "tags": [
         "app-registration",
         "identity",
@@ -952,6 +958,12 @@
       "remediation": "Run: Update-MgPolicyIdentitySecurityDefaultsEnforcementPolicy -IsEnabled $true. Entra admin center > Properties > Manage security defaults.",
       "impact": "Tenants without Security Defaults and without equivalent CA policies have no enforced MFA, no legacy auth blocking, and no baseline protection. All users authenticate with passwords only unless individually configured.",
       "rationale": "Security Defaults enforce a baseline of MFA for all users and block legacy authentication — but they are incompatible with Conditional Access and are typically disabled when CA policies are in place. A tenant with Security Defaults disabled and insufficient CA policies has no enforced authentication baseline.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults",
+          "title": "Microsoft Learn — Security defaults in Microsoft Entra ID"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -1165,6 +1177,16 @@
       "remediation": "No action needed. Conditional Access policies provide equivalent coverage to Security Defaults.",
       "impact": "Users or actions not covered by Conditional Access policies are subject to password-only authentication. A CA configuration that appears comprehensive but misses specific roles or legacy auth endpoints provides false assurance of MFA coverage.",
       "rationale": "When Security Defaults are disabled, the assumption is that Conditional Access policies provide equivalent coverage. Gaps in CA policy coverage — roles not targeted, users excluded, legacy auth not blocked — create security regressions compared to the Security Defaults baseline.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults",
+          "title": "Microsoft Learn — Security defaults in Microsoft Entra ID"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/plan-conditional-access",
+          "title": "Microsoft Learn — Plan a Conditional Access deployment"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -1392,6 +1414,16 @@
       "remediation": "Create a CA policy: Target admin roles > Grant > Require authentication strength > Phishing-resistant MFA. Entra admin center > Protection > Conditional Access.",
       "impact": "Privileged accounts protected only by TOTP or push MFA are vulnerable to real-time AiTM session hijacking. Attackers capture the post-MFA session token and have full authenticated access without the MFA device.",
       "rationale": "Standard MFA (TOTP, push notification, SMS) is bypassed by AiTM phishing toolkits (e.g., Evilginx, Modlishka) that relay authentication in real time and capture session cookies. Phishing-resistant MFA (FIDO2, Windows Hello, certificate-based) is cryptographically bound to the origin and cannot be relayed by an attacker-controlled proxy.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths",
+          "title": "Microsoft Learn — Authentication strengths overview"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-passwordless-security-key",
+          "title": "Microsoft Learn — Enable FIDO2 security key sign-in"
+        }
+      ],
       "tags": [
         "conditional-access",
         "identification-authentication",
@@ -1978,6 +2010,12 @@
       "remediation": "Run: Set-SPOTenant -SharingCapability ExistingExternalUserSharingOnly. SharePoint admin center > Policies > Sharing.",
       "impact": "Sensitive documents including financial data, PII, and IP can be shared externally without audit or approval. Anonymous sharing links persist indefinitely and are discoverable by search engines if not restricted.",
       "rationale": "SharePoint is a primary repository for sensitive organizational documents. Unrestricted external sharing allows any user to share any document with any email address, bypassing data classification controls and creating permanent unauthenticated access links.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        }
+      ],
       "tags": [
         "collaboration",
         "data",
@@ -2171,6 +2209,12 @@
       "remediation": "SharePoint admin center > Policies > Sharing > OneDrive > set to \"Existing guests\" or more restrictive.",
       "impact": "Sensitive files stored in OneDrive can be shared externally via unauthenticated anonymous links. A user can exfiltrate any file they have access to — including synchronized SharePoint content — without DLP inspection.",
       "rationale": "Unrestricted OneDrive sharing allows users to share any file with anyone externally via anonymous links. OneDrive is connected to SharePoint and subject to the same data exfiltration risks as corporate file servers.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        }
+      ],
       "tags": [
         "collaboration",
         "identification-authentication",
@@ -2370,6 +2414,12 @@
       "remediation": "Ensure Policy.Read.All permission is consented. Create a CA policy targeting SharePoint Online (00000003-0000-0ff1-ce00-000000000000) or All Cloud Apps.",
       "impact": "Unmanaged or compromised devices can access SharePoint and OneDrive content. Files downloaded to an unmanaged device bypass DLP, endpoint security, and data classification controls.",
       "rationale": "SharePoint contains sensitive documents that require the same access controls as other sensitive resources. Without Conditional Access coverage for SharePoint, unmanaged devices or non-compliant endpoints can access SharePoint content even when other resources are protected by CA policies.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/control-access-from-unmanaged-devices",
+          "title": "Microsoft Learn — Control access from unmanaged devices"
+        }
+      ],
       "tags": [
         "collaboration",
         "identification-authentication",
@@ -3723,6 +3773,12 @@
       "remediation": "Security Defaults enforces MFA for all admin roles. For granular control, disable Security Defaults and create Conditional Access policies.",
       "impact": "A phished or sprayed admin password gives full administrative access. Attackers can create backdoor accounts, disable security policies, and exfiltrate data before the incident is detected.",
       "rationale": "Administrator accounts have access to sensitive configuration, user management, and data across the tenant. Without MFA, a stolen password provides immediate, unrestricted administrative access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-admin-mfa",
+          "title": "Microsoft Learn — Require MFA for administrators"
+        }
+      ],
       "tags": [
         "authentication",
         "conditional-access",
@@ -3928,6 +3984,16 @@
       "remediation": "Security Defaults enforces MFA for all users. For granular control, disable Security Defaults and create Conditional Access policies.",
       "impact": "Compromised user credentials give full access to email, Teams, SharePoint, and any app the user accesses. Business email compromise (BEC) attacks exploit standard user accounts to intercept payments and exfiltrate data.",
       "rationale": "MFA is the single most effective control against account takeover from phished or stolen credentials. Without MFA, any user with a compromised password is a lateral movement pivot point into the tenant.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-all-users-mfa",
+          "title": "Microsoft Learn — Require MFA for all users"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/tutorial-enable-azure-mfa",
+          "title": "Microsoft Learn — Enable Microsoft Entra multifactor authentication"
+        }
+      ],
       "tags": [
         "authentication",
         "conditional-access",
@@ -4327,6 +4393,16 @@
       "remediation": "Run: Update-MgBetaPolicyAuthenticationMethodPolicy with RegistrationEnforcement settings. Entra admin center > Protection > Authentication methods > Registration campaign.",
       "impact": "Users without registered MFA methods bypass MFA enforcement in Conditional Access policies. Their accounts are vulnerable to password-only attacks despite MFA policies appearing to be in place.",
       "rationale": "MFA capability means the user has registered at least one MFA method. Without a registered method, MFA policies cannot be enforced for the user even if Conditional Access requires it — they fall back to password-only authentication.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-userdevicesettings",
+          "title": "Microsoft Learn — Manage user authentication methods"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-mfa-licensing",
+          "title": "Microsoft Learn — Features and licenses for Microsoft Entra multifactor authentication"
+        }
+      ],
       "tags": [
         "authentication",
         "entra-id",
@@ -4723,6 +4799,12 @@
       "remediation": "Require MFA on Tier-0 role activation. Entra admin center > Identity Governance > PIM > Microsoft Entra roles > select role > Settings > Edit > Activation tab > Require Azure MFA on activation.",
       "impact": "An attacker with a stolen session token or password for an eligible user can activate Tier-0 roles without any additional authentication factor, converting account access to full administrative access silently.",
       "rationale": "PIM role activation without MFA requirement means a compromised account can activate Tier-0 roles using only the account's existing session — no MFA challenge at activation. This defeats the purpose of JIT access as a security control.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings",
+          "title": "Microsoft Learn — Configure Microsoft Entra role settings in PIM"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -4911,6 +4993,12 @@
       "remediation": "Enable the registration campaign to prompt unregistered users. Entra admin center > Protection > Authentication methods > Registration campaign > Enable. Follow up with users shown in the authentication methods activity report.",
       "impact": "Users without MFA method registration can authenticate with only a password in any CA policy that requires MFA, because there is no registered method to satisfy the MFA requirement. These accounts are the weakest link for credential-based attacks.",
       "rationale": "Even a small percentage of users without MFA methods provides meaningful attack surface. Attackers performing credential spray attacks will find and prioritize accounts where MFA cannot be enforced.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-methods-activity",
+          "title": "Microsoft Learn — Authentication methods activity reports"
+        }
+      ],
       "tags": [
         "authentication",
         "entra-id",
@@ -5103,6 +5191,16 @@
       "remediation": "Enroll all Global Administrators in phishing-resistant MFA (FIDO2, Windows Hello for Business, or certificate-based). Entra admin center > Protection > Authentication methods > Policies.",
       "impact": "Global Administrators protected by standard MFA are still vulnerable to AiTM token theft. An attacker who intercepts the session token gains persistent Global Admin access without needing the user's password or MFA device.",
       "rationale": "Global Administrators control every aspect of the tenant. Standard MFA can be bypassed via adversary-in-the-middle (AiTM) phishing attacks that relay the authentication session. Phishing-resistant MFA (FIDO2, Windows Hello, certificate) eliminates this attack class for the highest-privilege accounts.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths",
+          "title": "Microsoft Learn — Authentication strengths overview"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-passwordless-security-key",
+          "title": "Microsoft Learn — Enable FIDO2 security key sign-in"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -5697,6 +5795,12 @@
       "remediation": "Replace unprotected groups in privileged role assignments with role-assignable groups. Entra admin center > Groups > New group > enable 'Azure AD roles can be assigned to the group'. Recreate the group and migrate the role assignment.",
       "impact": "An attacker who compromises a group owner account can add any user to a group that holds a privileged role, effectively granting that role without a direct role assignment or PIM activation.",
       "rationale": "Groups used in privileged role assignments that lack the role-assignable property can have their membership modified by group owners or administrators who do not hold the role themselves. This creates an indirect privilege escalation path through group ownership.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/groups-create-eligible",
+          "title": "Microsoft Learn — Create a role-assignable group in Microsoft Entra ID"
+        }
+      ],
       "tags": [
         "identification-authentication",
         "identity",
@@ -8637,6 +8741,16 @@
       "remediation": "Verify Password Hash Sync status in Azure AD Connect. Entra admin center > Identity > Hybrid management > Azure AD Connect.",
       "impact": "On-premises credential compromises are invisible to Entra ID Identity Protection when password hashes are not synced. Stolen on-premises credentials used in cloud authentication generate no risk signal and are not blocked by risk-based CA policies.",
       "rationale": "Password hash sync ensures that Entra ID has a copy of password hashes from on-premises AD. Without it, leaked on-premises credentials cannot be detected by Entra ID's Identity Protection and compromised on-premises accounts can authenticate to cloud services with no cloud-side risk signal.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/whatis-phs",
+          "title": "Microsoft Learn — What is password hash synchronization with Microsoft Entra ID?"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-risks",
+          "title": "Microsoft Learn — Risk detections in Microsoft Entra ID Protection"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -10218,6 +10332,16 @@
       "remediation": "Connect to Exchange Online and verify accepted domains.",
       "impact": "Attackers can send email appearing to come from your domain without SPF, DKIM, or DMARC to block them. Phishing campaigns impersonating your organization are more effective when the sending domain has no authentication.",
       "rationale": "SPF (Sender Policy Framework) authorizes which mail servers may send email on behalf of your domain. Without an SPF record, receiving servers cannot verify that email from your domain is legitimate, enabling spoofing and reducing deliverability of legitimate email.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/email-authentication-spf-configure",
+          "title": "Microsoft Learn — Set up SPF to help prevent spoofing"
+        },
+        {
+          "url": "https://www.rfc-editor.org/rfc/rfc7208",
+          "title": "RFC 7208 — Sender Policy Framework (SPF) for Authorizing Use of Domains in Email"
+        }
+      ],
       "tags": [
         "dns",
         "email",
@@ -11023,6 +11147,12 @@
       "remediation": "Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles > Global Administrator > Remove permanent active assignments. Use eligible assignments with time-bound activation.",
       "impact": "Permanently active admin accounts are available for abuse at any time. Credential compromise provides persistent, immediately usable admin access with no activation step to trigger alerts.",
       "rationale": "Permanently active privileged roles maintain standing admin access with no time limit or justification requirement. JIT access via PIM limits the window of exposure: even if admin credentials are compromised, the attacker can only act during the brief activation window.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure",
+          "title": "Microsoft Learn — What is Microsoft Entra Privileged Identity Management?"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -11419,6 +11549,12 @@
       "remediation": "Disable or delete admin accounts inactive for 90+ days. Entra admin center > Users > sign-in activity column. Review active PIM eligible assignments (Identity Governance > PIM > Assignments) and remove stale principals.",
       "impact": "Credentials for stale admin accounts — whether from phishing, password reuse, or data breaches — provide persistent privileged access. Inactive accounts are rarely monitored, so sign-in activity from a stale account may go undetected for extended periods.",
       "rationale": "Admin accounts that are no longer in use are dormant attack surfaces with standing privileged access. Stale accounts are often overlooked in security reviews and may retain credentials that were never rotated.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/access-reviews-overview",
+          "title": "Microsoft Learn — What are access reviews in Microsoft Entra ID?"
+        }
+      ],
       "tags": [
         "identification-authentication",
         "identity",
@@ -12979,6 +13115,12 @@
       "remediation": "Entra admin center > Identity Governance > Access reviews > New access review > Review type: Members of a group or Users assigned to a privileged role.",
       "impact": "Stale privileged role assignments accumulate over time. Former employees, moved employees, or compromised accounts that retain role assignments provide persistent attack vectors that are never automatically detected or removed.",
       "rationale": "Access reviews for privileged roles detect and remove stale, unnecessary, or unauthorized role assignments. Without periodic reviews, accumulation of privileged role assignments creates lateral movement opportunities and violates least-privilege principles.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-create-roles-and-resource-roles-review",
+          "title": "Microsoft Learn — Create an access review of Azure resource and Microsoft Entra roles in PIM"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -13176,6 +13318,16 @@
       "remediation": "Maintain at least two cloud-only emergency access accounts excluded from all Conditional Access policies.",
       "impact": "A misconfigured Conditional Access policy or MFA outage can permanently lock all administrators out of the tenant, requiring a time-consuming Microsoft Support escalation to recover.",
       "rationale": "Emergency access accounts provide a recovery path when primary admin access is unavailable — for example, if MFA is unavailable or a Conditional Access misconfiguration locks out all admins. Without them, a single configuration error can make the tenant unmanageable.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access",
+          "title": "Microsoft Learn — Manage emergency access accounts in Microsoft Entra ID"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -13385,6 +13537,12 @@
       "remediation": "Create two cloud-only emergency access accounts with permanent Global Administrator roles. Exclude from all Conditional Access policies. Store credentials offline. Entra admin center > Users > New user. Alert on any sign-in via Azure Monitor or Microsoft Sentinel.",
       "impact": "Without break-glass accounts, a misconfigured Conditional Access policy that blocks all admin sign-ins makes the tenant unmanageable. Recovery requires a Microsoft Support escalation that can take hours or days.",
       "rationale": "Break-glass accounts are the recovery mechanism when normal admin access paths fail — MFA outages, misconfigured CA policies, or locked-out credentials. Without them, a configuration error can result in complete loss of tenant management capability.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access",
+          "title": "Microsoft Learn — Manage emergency access accounts in Microsoft Entra ID"
+        }
+      ],
       "tags": [
         "identification-authentication",
         "identity",
@@ -13552,6 +13710,16 @@
       "remediation": "Set a time-bound expiry on eligible assignments for Tier-0 roles. Entra admin center > Identity Governance > PIM > Microsoft Entra roles > select role > Settings > Edit > Assignment tab > Expire eligible assignments after (e.g., 12 months). Remove existing permanent eligible assignments and reissue as time-bound.",
       "impact": "A compromised account with a permanent eligible assignment can activate privileged roles indefinitely. Time-bound assignments would limit the attack window, but permanent assignments remove this defense.",
       "rationale": "Permanent eligible assignments allow role activation at any time without expiry. Time-bound eligible assignments limit the window during which a compromised account can activate a privileged role — after expiry, the assignment must be renewed through a governed process.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings",
+          "title": "Microsoft Learn — Configure Microsoft Entra role settings in PIM"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-add-role-to-user",
+          "title": "Microsoft Learn — Assign Microsoft Entra roles in PIM"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -14091,6 +14259,12 @@
       "remediation": "Review apps with Tier 0 permissions that show no sign-in activity. These permissions may have been granted but never used -- remove them to reduce attack surface. Entra admin center > Enterprise applications > Sign-in logs.",
       "impact": "A compromised client secret for an inactive Tier 0 app allows an attacker to use the app's permissions without generating user-facing anomalies. Inactivity signals may mask the compromise in log reviews.",
       "rationale": "Apps with Tier 0 permissions that have not signed in recently are unmonitored attack surfaces. Their credentials may still be valid but their activity is not tracked. Credential theft for an inactive app may go undetected for an extended period.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -15332,6 +15506,16 @@
       "remediation": "Review tenant-wide admin consent grants. These grants apply to all users in the tenant. Remove overly broad grants that are no longer needed. Entra admin center > Enterprise applications > filter by Admin consent.",
       "impact": "A malicious application that obtained tenant-wide admin consent can access all users' mail, files, and calendar data. These grants persist and are rarely reviewed, providing long-term silent data access.",
       "rationale": "Tenant-wide admin consent grants an application permissions for every user in the tenant. An application with admin consent and broad permissions (e.g., Mail.ReadWrite, Files.ReadWrite.All) can read and modify all user data without individual user interaction.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent",
+          "title": "Microsoft Learn — Grant tenant-wide admin consent to an application"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-consent-requests",
+          "title": "Microsoft Learn — Manage consent requests"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -15775,6 +15959,12 @@
       "remediation": "Disable or restrict guest access. Teams Admin Center > Org-wide settings > Guest access > Allow guest access in Teams: Off, or restrict calling, meeting, and messaging settings to the minimum required for external collaboration.",
       "impact": "External guest users added to Teams channels can access all historical messages and files in those channels. Sensitive business discussions, shared documents, and strategic information are visible to unvetted external parties.",
       "rationale": "Guest access to Teams allows external users to participate in channels, chats, and meetings, and by default access the files and conversations in those channels. Without restrictions, any external user invited as a guest can see sensitive internal conversations and documents.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoftteams/set-up-guests",
+          "title": "Microsoft Learn — Turn guest access on or off in Microsoft Teams"
+        }
+      ],
       "tags": [
         "collaboration",
         "identification-authentication",
@@ -17514,6 +17704,16 @@
       "remediation": "Remove privileged admin accounts from Conditional Access policy exclusions. Entra admin center > Security > Conditional Access > review each policy's exclusions. Use PIM just-in-time activation instead of permanent CA exclusions. Retain only break-glass accounts as exclusions.",
       "impact": "Admins in CA exclusion lists authenticate with only a username and password. Credential phishing or spray attacks against these accounts bypass all Conditional Access controls and gain unmediated admin access.",
       "rationale": "Conditional Access exclusions are necessary for break-glass scenarios but dangerous when applied to privileged admin accounts: an excluded admin bypasses every MFA and compliance requirement, making their credentials a high-value target with no authentication safeguards.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/troubleshoot-conditional-access",
+          "title": "Microsoft Learn — Troubleshoot Conditional Access policies"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access",
+          "title": "Microsoft Learn — Manage emergency access accounts in Microsoft Entra ID"
+        }
+      ],
       "tags": [
         "conditional-access",
         "identification-authentication",
@@ -18140,6 +18340,16 @@
       "remediation": "Run: Set-SPOTenant -DefaultSharingLinkType Direct. SharePoint admin center > Policies > Sharing > File and folder links > Default link type > Specific people.",
       "impact": "Documents shared via Anyone links are accessible without authentication. Links shared in emails, chats, or indexed by search engines expose content permanently, with no audit trail of who accessed it.",
       "rationale": "Shareable links that grant access to 'anyone with the link' bypass all identity and device controls. A single leaked link is sufficient to expose the target content to any person, device, or automated system worldwide.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/change-default-sharing-link",
+          "title": "Microsoft Learn — Change the default link type for SharePoint and OneDrive"
+        }
+      ],
       "tags": [
         "collaboration",
         "data",
@@ -28833,6 +29043,12 @@
       "remediation": "Entra admin center > Identity Governance > PIM > Azure AD roles > Settings > Global Administrator > Require approval to activate > Yes.",
       "impact": "Without approval requirements, a compromised account with eligible Global Administrator assignment can self-activate the role immediately, granting full tenant control with no human verification required.",
       "rationale": "The Global Administrator role provides complete control over the tenant. Requiring approval for activation means that even a compromised account cannot self-activate the role — an approver must confirm the activation request before access is granted.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings",
+          "title": "Microsoft Learn — Configure Microsoft Entra role settings in PIM"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -29036,6 +29252,12 @@
       "remediation": "Entra admin center > Identity Governance > PIM > Azure AD roles > Settings > Privileged Role Administrator > Require approval to activate > Yes.",
       "impact": "A compromised account with eligible Privileged Role Administrator assignment can activate the role, then assign Global Administrator to any account, bypassing all access controls in a single step.",
       "rationale": "The Privileged Role Administrator role controls who has access to other privileged roles. Without approval requirements, a compromised account eligible for this role can assign itself or others to any directory role, including Global Administrator.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings",
+          "title": "Microsoft Learn — Configure Microsoft Entra role settings in PIM"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -29456,6 +29678,16 @@
       "remediation": "Entra admin center > Enterprise applications > review foreign apps with Tier 0 permissions. These permissions have documented attack paths to Global Administrator. Remove or replace with least-privilege alternatives.",
       "impact": "A compromised foreign app with application-level permissions can access all user data in the tenant without a user session, without triggering user-based risk signals, and from infrastructure controlled by the publisher.",
       "rationale": "Applications with dangerous application permissions (not delegated) act as autonomous service accounts that can read, write, and delete data for all users without any user sign-in. Foreign (multi-tenant) apps with these permissions operate from outside the tenant's control plane.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/graph/permissions-reference",
+          "title": "Microsoft Learn — Microsoft Graph permissions reference"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -29680,6 +29912,12 @@
       "remediation": "Entra admin center > Enterprise applications > review foreign apps with high-privilege delegated permissions. Revoke admin consent or remove the app.",
       "impact": "A foreign app with delegated permissions for Mail.ReadWrite or Files.ReadWrite.All can read, send, or delete email and files on behalf of any user who granted consent, enabling persistent exfiltration or impersonation.",
       "rationale": "Dangerous delegated permissions grant an app the ability to act as any user who consented to the app. For foreign (multi-tenant) apps, this means the app publisher can trigger API actions using the delegated grant without the user's direct involvement after initial consent.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -30072,6 +30310,16 @@
       "remediation": "Review managed identity permissions. Use narrower permissions (e.g., Mail.Read instead of Mail.ReadWrite). Azure portal > Managed Identity > API permissions.",
       "impact": "A compromised Azure resource whose managed identity holds application-level Graph API permissions can be used to exfiltrate all user mail, read all files, or manipulate directory objects without any credential artifact to detect or rotate.",
       "rationale": "Managed identities are designed to eliminate secrets, but when assigned dangerous application permissions, they become powerful unmonitored agents: no credentials to steal, no MFA to bypass, and API access that scales across all tenant data.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview",
+          "title": "Microsoft Learn — What are managed identities for Azure resources?"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -30268,6 +30516,16 @@
       "remediation": "Entra admin center > App registrations > review internal apps with Tier 0 permissions. Each has a documented path to Global Administrator. Replace with narrower permissions or use managed identities where possible.",
       "impact": "Credential theft for any app holding Tier 0 permissions grants the attacker full tenant control: ability to create admin accounts, disable CA policies, read all user data, and persist indefinitely without triggering user-facing alerts.",
       "rationale": "Applications with Tier 0 permissions (e.g., Directory.ReadWrite.All, RoleManagement.ReadWrite.Directory) can read and modify the entire Entra ID directory, including assigning admin roles to other principals. A compromised app credential is equivalent to a compromised Global Administrator.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent",
+          "title": "Microsoft Learn — Grant tenant-wide admin consent"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/security/privileged-access-workstations/privileged-access-access-model",
+          "title": "Microsoft Learn — Privileged access: enterprise access model (Tier 0)"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -30465,6 +30723,12 @@
       "remediation": "Remove owners from apps with Tier 0 permissions. An owner of a Tier 0 app can add credentials and impersonate it to escalate to Global Admin. Entra admin center > App registrations > Owners.",
       "impact": "Any user listed as an owner of a Tier 0 permission app can add client secrets and use the app's full permissions. This creates an indirect path to tenant compromise via accounts that may not themselves hold privileged roles.",
       "rationale": "Application owners can modify app credentials and permissions without additional approval. An app with Tier 0 permissions and an owner who can add credentials creates a privilege escalation path: an attacker who compromises the owner account can immediately add a secret and gain Tier 0 access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/overview-assign-app-owners",
+          "title": "Microsoft Learn — Manage app registration owners"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -30661,6 +30925,12 @@
       "remediation": "Remove owners from apps holding Entra directory roles. Owners can add credentials and impersonate the SP to exercise those roles. Entra admin center > App registrations > Owners.",
       "impact": "Any user listed as an owner of an app with directory roles can add a client secret, authenticate as the app, and exercise the app's role permissions — without holding the role themselves and without the action appearing in standard privileged role assignment reports.",
       "rationale": "Application owners can add credentials to the app, allowing them to authenticate as the app and exercise its full permissions. When an app holds privileged directory roles, its owners have an indirect path to those privileges without being directly assigned the role.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/overview-assign-app-owners",
+          "title": "Microsoft Learn — Manage app registration owners"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -30832,6 +31102,16 @@
       "remediation": "Create dedicated cloud-only admin accounts separate from daily-use accounts. Admin accounts should hold no Exchange mailbox or E3/E5 licenses. Entra admin center > Users > New user (cloud identity). Assign admin roles only to the dedicated accounts.",
       "impact": "A phished or malware-infected daily-use account that also holds admin roles gives the attacker immediate administrative access to the tenant with no additional steps required.",
       "rationale": "Daily-use accounts are higher-risk targets — they access email, browse the web, and are more exposed to phishing. Using the same account for admin tasks means a successful phishing attack against a daily-use activity immediately compromises a privileged account.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/security/privileged-access-workstations/privileged-access-accounts",
+          "title": "Microsoft Learn — Privileged access: accounts"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -31035,6 +31315,16 @@
       "remediation": "Create cloud-only admin accounts instead of using on-premises synced accounts. Entra admin center > Users > New user > Create user (cloud identity).",
       "impact": "A compromised on-premises domain controller provides NTLM or Kerberos credentials for any synced admin account. The attacker converts on-premises domain dominance into cloud tenant administrator access without any additional steps.",
       "rationale": "On-premises Active Directory is the primary target in hybrid identity compromise scenarios. Admin accounts synced from on-premises AD inherit the risk of the on-premises environment: an on-premises compromise (ransomware, domain controller breach) immediately provides cloud admin credentials.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/plan-hybrid-identity-design-considerations-overview",
+          "title": "Microsoft Learn — Hybrid identity design considerations"
+        }
+      ],
       "tags": [
         "admin",
         "entra-id",
@@ -31237,6 +31527,16 @@
       "remediation": "Replace on-premises synced admin accounts with cloud-only accounts for all Tier-0/1 roles. Entra admin center > Users > identify synced accounts holding directory roles > create cloud-only replacements > migrate role assignments > remove roles from synced accounts.",
       "impact": "An attacker who compromises on-premises AD and extracts NTLM hashes for synced admin accounts can pass-the-hash or use harvested credentials to authenticate to Entra ID, directly translating an on-premises breach into cloud administrative access.",
       "rationale": "On-premises AD is a frequent initial compromise target. Admin accounts synced from on-premises AD carry the credential risk of the on-premises environment into the cloud: NTLM hash extraction from a domain controller provides working cloud credentials.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/whatis-phs",
+          "title": "Microsoft Learn — What is password hash synchronization?"
+        }
+      ],
       "tags": [
         "conditional-access",
         "identification-authentication",
@@ -33039,6 +33339,16 @@
       "remediation": "Disable SSPR for administrator accounts. Entra admin center > Protection > Password reset > Properties > set scope to Selected and exclude accounts holding directory roles. Admin password resets should follow a governed helpdesk or PIM workflow.",
       "impact": "A successful SSPR social engineering attack against an admin account provides a new password, effectively revoking any existing session and granting fresh access that does not trigger re-authentication requirements.",
       "rationale": "Self-service password reset for administrator accounts is a social engineering risk. If an attacker can trick the SSPR verification process (security questions, registered phone), they can reset the admin password and bypass MFA entirely.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-sspr-howitworks",
+          "title": "Microsoft Learn — How Microsoft Entra self-service password reset works"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-sspr-deployment",
+          "title": "Microsoft Learn — Plan a Microsoft Entra self-service password reset deployment"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -33227,6 +33537,12 @@
       "remediation": "Consider creating CA policies that specifically target privileged directory roles with stricter controls (phishing-resistant MFA, compliant devices).",
       "impact": "A Tier-0 role (e.g., Exchange Administrator, Security Administrator) not covered by CA policies has no enforced MFA, device compliance, or risk signal evaluation. Credential theft for these roles grants unmediated administrative access.",
       "rationale": "Conditional Access policies that target directory roles by name only protect role members at policy evaluation time. Active role assignments added after policy creation are not covered until the policy explicitly includes them. Tier-0 roles without CA coverage are high-privilege accounts with no authentication requirements enforced by CA.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-users-groups",
+          "title": "Microsoft Learn — Users and groups in Conditional Access policy"
+        }
+      ],
       "tags": [
         "conditional-access",
         "identification-authentication",
@@ -33428,6 +33744,16 @@
       "remediation": "Entra admin center > Roles and administrators > review roles assigned to foreign service principals. Remove role assignments from untrusted external apps.",
       "impact": "A foreign app with a directory role assignment (e.g., User Administrator, Exchange Administrator) can be used by the external publisher to manage your tenant. If the publisher is compromised, the attacker inherits your directory admin privileges.",
       "rationale": "Entra ID directory roles assigned to foreign (multi-tenant) applications give the external publisher's service control-plane access to the tenant — the same access as a human administrator. These assignments persist across app updates and are not visible in standard role management views.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/overview-assign-app-owners",
+          "title": "Microsoft Learn — Manage app owners"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -33616,6 +33942,12 @@
       "remediation": "Review managed identities with directory roles. Use Graph API permissions instead of directory roles where possible. Entra admin center > Roles and administrators.",
       "impact": "A compromised Azure resource with a managed identity holding a privileged Entra directory role provides administrative access to the tenant from within the Azure compute environment, which may have weaker security controls than the corporate network.",
       "rationale": "Managed identities assigned Entra directory roles operate as privileged administrative agents. Unlike service principals with secrets, managed identities cannot have their credentials rotated — the only remediation for a compromised managed identity is to remove its role assignments.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview",
+          "title": "Microsoft Learn — What are managed identities for Azure resources?"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -33804,6 +34136,12 @@
       "remediation": "Convert sensitive security groups to role-assignable to prevent unauthorized membership changes. Entra admin center > Groups > New group > enable 'Azure AD roles can be assigned to the group'. Recreate affected groups and update any app role or CA policy assignments.",
       "impact": "An attacker who compromises a group owner account can add themselves or other accounts to a sensitive group, gaining the access rights associated with that group — potentially including app role permissions or CA policy exclusions.",
       "rationale": "Security groups without the role-assignable property can have their membership modified by group owners and certain administrative roles without Global Administrator or Privileged Role Administrator approval. Groups used in Conditional Access policy or app role assignments are high-value targets for membership manipulation.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/groups-create-eligible",
+          "title": "Microsoft Learn — Create a role-assignable group in Microsoft Entra ID"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -33993,6 +34331,12 @@
       "remediation": "Remove Tier-0/1 Entra directory roles from on-premises synced user accounts. Entra admin center > Users > filter synced accounts > review role assignments. Create cloud-only replacement accounts and migrate role assignments; on-premises compromise must not reach cloud privilege.",
       "impact": "An attacker who compromises on-premises AD can extract credentials for synced admin accounts and use them immediately for cloud administrative access — no additional steps are needed to pivot from on-premises to cloud.",
       "rationale": "On-premises synced accounts are controlled by on-premises Active Directory. When these accounts hold Tier-0 or Tier-1 Entra directory roles, an on-premises domain compromise (ransomware, DC compromise) directly translates to cloud admin access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        }
+      ],
       "tags": [
         "entra-id",
         "identification-authentication",
@@ -34162,6 +34506,16 @@
       "remediation": "Migrate privileged service principals from client secrets to certificates or managed identities. A secret on a permanently privileged SP is a persistent backdoor risk.",
       "impact": "A leaked or brute-forced client secret grants the attacker persistent, silent access at Global Admin or equivalent privilege with no user interaction, no MFA challenge, and no sign-in behavior visible in user-based risk signals.",
       "rationale": "Service principals with client secrets and permanent privileged role assignments combine the two highest risk factors in app identity: a long-lived credential that never expires and a standing privilege that never rotates. This combination is a primary target in cloud supply-chain attacks.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/architecture/service-accounts-principal",
+          "title": "Microsoft Learn — Securing service principals in Microsoft Entra ID"
+        }
+      ],
       "tags": [
         "app-registration",
         "identification-authentication",
@@ -35142,6 +35496,16 @@
       "remediation": "Remove Intune write permissions from app registrations that do not require them. Entra admin center > App registrations > select app > API permissions. Remove DeviceManagementConfiguration.ReadWrite.All and equivalent permissions. Only approved, monitored service principals should hold Intune write access.",
       "impact": "A compromised service principal with Intune write permissions can mass-wipe managed devices, remove compliance policies, or push malicious configuration profiles to all enrolled endpoints.",
       "rationale": "App registrations with Intune write permissions (DeviceManagementManagedDevices.ReadWrite.All) can wipe, retire, or reconfigure managed devices at scale. If such an app's credentials are compromised, the attacker can destroy device data across the entire tenant in seconds.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/role-based-access-control",
+          "title": "Microsoft Learn — Role-based access control with Microsoft Intune"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/graph/permissions-reference#intune-device-management-permissions",
+          "title": "Microsoft Learn — Microsoft Graph Intune device management permissions"
+        }
+      ],
       "tags": [
         "identification-authentication",
         "identity",
@@ -36342,6 +36706,16 @@
       "remediation": "Create a CA policy: Target All users > Conditions > User risk > High > Grant > Require password change + MFA. Entra admin center > Protection > Conditional Access.",
       "impact": "Users whose credentials are detected in breach databases or flagged by threat intelligence can continue authenticating normally. Attackers with purchased or leaked credentials encounter no additional friction.",
       "rationale": "User risk reflects cumulative signals of account compromise — leaked credentials, unusual behavior patterns, and threat intelligence. Without user-risk policies, compromised accounts identified by Identity Protection remain active and accessible until manually reviewed.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies",
+          "title": "Microsoft Learn — Configure and enable risk policies"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-risks",
+          "title": "Microsoft Learn — What are risk detections?"
+        }
+      ],
       "tags": [
         "conditional-access",
         "human-resources-security",
@@ -36557,6 +36931,12 @@
       "remediation": "Create a CA policy: Target All users > Conditions > Sign-in risk > High, Medium > Grant > Require MFA. Entra admin center > Protection > Conditional Access.",
       "impact": "High-risk sign-in events (indicating probable account compromise) proceed without any remediation challenge. Attackers operating from anomalous locations or with stolen tokens can authenticate successfully.",
       "rationale": "Entra ID Identity Protection generates real-time risk scores for sign-in events based on behavioral signals such as impossible travel, atypical locations, and token anomalies. Without risk-based CA policies, these signals are generated but never acted upon — the sign-in succeeds regardless of risk level.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies",
+          "title": "Microsoft Learn — Configure and enable risk policies"
+        }
+      ],
       "tags": [
         "conditional-access",
         "human-resources-security",
@@ -36772,6 +37152,12 @@
       "remediation": "Security Defaults blocks high-risk sign-ins but does not provide granular medium-risk controls. For full coverage, disable Security Defaults and create Conditional Access policies with Entra ID P2.",
       "impact": "Sign-ins flagged at medium or high risk are allowed to complete MFA and gain access. An attacker performing AiTM phishing can relay the MFA challenge in real time and capture the authenticated session.",
       "rationale": "Medium and high sign-in risk signals indicate a strong likelihood of account compromise. Blocking rather than challenging these sign-ins eliminates the possibility that an attacker could intercept the MFA challenge in a real-time relay attack.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-conditions#sign-in-risk",
+          "title": "Microsoft Learn — Sign-in risk condition in Conditional Access"
+        }
+      ],
       "tags": [
         "conditional-access",
         "human-resources-security",
@@ -36945,6 +37331,16 @@
       "remediation": "Ensure Global Administrator and Privileged Role Administrator roles are assigned to separate accounts. Entra admin center > Identity > Roles & admins. Enable PIM approval workflows for role activation.",
       "impact": "An account with conflicting admin roles can self-authorize sensitive operations without a second approver. This eliminates the detection and prevention benefit of requiring multiple parties for sensitive actions.",
       "rationale": "Separation of duties prevents a single account from holding roles that, in combination, allow self-authorization of sensitive actions — for example, both User Administrator and Billing Administrator. Without SoD, a compromised account with incompatible role combinations can self-escalate or approve its own privileged actions.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure",
+          "title": "Microsoft Learn — What is Microsoft Entra Privileged Identity Management?"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        }
+      ],
       "tags": [
         "entra-id",
         "human-resources-security",
@@ -37394,6 +37790,12 @@
       "remediation": "Intune admin center > Devices > Compliance > Compliance policy settings > Mark devices with no compliance policy assigned as > Not compliant.",
       "impact": "Unassigned devices bypass device compliance requirements in Conditional Access. An unmanaged or misconfigured device that reaches a 'compliant' CA policy without a compliance policy may be granted access based on an unchecked compliance state.",
       "rationale": "Devices without a compliance policy assignment are never evaluated against compliance requirements. These devices report as 'unknown' compliance state, and Conditional Access policies that require 'compliant' devices will not block them if the CA policy also allows the unknown state.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/device-compliance-get-started",
+          "title": "Microsoft Learn — Use compliance policies to set rules for devices managed with Intune"
+        }
+      ],
       "tags": [
         "asset-management",
         "endpoint",
@@ -38352,6 +38754,12 @@
       "remediation": "Ensure SharePointTenantSettings.Read.All permission is consented. Review site sharing levels in SharePoint admin center > Active sites.",
       "impact": "Sites created without explicit sharing restrictions default to the tenant maximum — potentially allowing anonymous link sharing for all new sites. Sensitive data in default-configured sites is exposed without intentional site-level controls.",
       "rationale": "Site-level sharing settings cannot exceed the tenant-wide sharing policy. If the tenant policy allows sharing with anyone, individual sites must restrict sharing themselves. Without a restrictive tenant policy, every new site defaults to maximum sharing permissions.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        }
+      ],
       "tags": [
         "collaboration",
         "data-classification-handling",
@@ -38554,6 +38962,16 @@
       "remediation": "Restrict SharePoint external sharing to prevent CUI exposure. SharePoint Admin Center > Policies > Sharing > set external sharing to 'Existing guests only' or 'Only people in your organization'. Apply sensitivity labels and CA policies to CUI-classified sites.",
       "impact": "CUI stored in SharePoint can be shared with external parties who are not authorized to access it, creating regulatory compliance violations and potentially triggering mandatory breach reporting.",
       "rationale": "CUI (Controlled Unclassified Information) has specific access and handling requirements under NIST 800-171 and CMMC. External sharing of SharePoint sites containing CUI without controls may expose regulated data to unauthorized parties.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        },
+        {
+          "url": "https://csrc.nist.gov/publications/detail/sp/800-171/rev-2/final",
+          "title": "NIST SP 800-171 Rev. 2 — Protecting CUI in Non-Federal Systems"
+        }
+      ],
       "tags": [
         "collaboration",
         "data-classification-handling",
@@ -38705,6 +39123,12 @@
       "remediation": "Microsoft Purview > Information protection > Auto-labeling > Create a policy to automatically classify sensitive content. Requires Azure Information Protection P2 (E5 or E5 Compliance).",
       "impact": "Sensitive documents that users fail to manually label are stored and shared without classification-based protections. DLP policies that rely on label conditions will not fire on unclassified content.",
       "rationale": "Auto-labeling policies classify sensitive content without requiring user action, ensuring that documents containing PII, financial data, or health information are consistently classified and subject to appropriate access and retention controls.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/apply-sensitivity-label-automatically",
+          "title": "Microsoft Learn — Apply a sensitivity label automatically"
+        }
+      ],
       "tags": [
         "compliance",
         "data-classification-handling",
@@ -38933,6 +39357,12 @@
       "remediation": "Review site sharing manually in SharePoint admin center > Active sites.",
       "impact": "Sensitive SharePoint sites with default or tenant-maximum sharing settings allow authorized users to share sensitive content with external parties. Data classification controls have no effect if sharing policies do not reflect data sensitivity.",
       "rationale": "Sites containing sensitive data require tighter sharing controls than general-purpose collaboration sites. Without site-level sharing restrictions, sensitive data sites are subject to the same sharing rules as non-sensitive sites, potentially allowing external sharing of regulated content.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        }
+      ],
       "tags": [
         "collaboration",
         "data-classification-handling",
@@ -39095,6 +39525,12 @@
       "remediation": "Block removable storage on managed devices. Intune > Devices > Configuration profiles > New profile > Windows > Device restrictions > General > Removable storage: Block. Assign to all managed device groups.",
       "impact": "Without removable media restrictions, an insider can copy any accessible data to a USB drive. Dropped USB attacks (maliciously placed drives) can also auto-execute or be manually opened by employees.",
       "rationale": "Removable media is a common vector for both data theft and malware introduction. Blocking removable storage prevents exfiltration of data to personal devices and eliminates the attack surface for dropped-USB and supply-chain media attacks.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/device-restrictions-windows-10",
+          "title": "Microsoft Learn — Windows 10/11 device restriction settings in Intune"
+        }
+      ],
       "tags": [
         "data-classification-handling",
         "endpoint",
@@ -39341,6 +39777,16 @@
       "remediation": "Create a CA policy: Target All users > All cloud apps > Grant > Require device to be marked as compliant (or Hybrid Azure AD joined). Entra admin center > Protection > Conditional Access.",
       "impact": "Session tokens stolen from unmanaged or compromised devices provide full access to corporate resources. Malware running on the device can exfiltrate tokens and replay them from attacker-controlled infrastructure.",
       "rationale": "Device compliance is a key pillar of Zero Trust: verify explicitly that the device is managed, patched, and meets security requirements before granting access. Without device trust as a signal, corporate credentials on a compromised personal device are sufficient for full access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-grant",
+          "title": "Microsoft Learn — Conditional Access grant controls (require compliant device)"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-compliant-device",
+          "title": "Microsoft Learn — Require compliant or hybrid joined device"
+        }
+      ],
       "tags": [
         "conditional-access",
         "data-classification-handling",
@@ -39758,6 +40204,12 @@
       "remediation": "Intune admin center > Devices > Configuration > Create profile > Windows 10 and later > Device restrictions > General > Removable storage: Block.",
       "impact": "Sensitive data can be copied to uncontrolled removable media and exfiltrated. Conversely, malware dropped via USB (including BadUSB attacks) can execute on endpoints with unrestricted port access.",
       "rationale": "Portable storage devices (USB drives) are a primary vector for data exfiltration and malware introduction. An employee can copy sensitive data to a USB drive undetected if portable storage is not restricted.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/device-restrictions-windows-10",
+          "title": "Microsoft Learn — Windows 10/11 device restriction settings in Intune"
+        }
+      ],
       "tags": [
         "data-classification-handling",
         "endpoint",
@@ -58073,6 +58525,12 @@
       "remediation": "Enable Defender for Endpoint device discovery. security.microsoft.com > Settings > Device discovery. Ensure devices are onboarded and configuration assessment is active.",
       "impact": "Devices with exploitable misconfigurations — open firewall rules, disabled AV, missing patches — are not surfaced for remediation and remain available as attack targets.",
       "rationale": "Automated detection of misconfigured or vulnerable devices identifies gaps in device security posture before attackers exploit them. Without this capability, misconfigured devices remain undetected until they are compromised.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-vulnerability-management/tvm-security-recommendation",
+          "title": "Microsoft Learn — Security recommendations in Defender Vulnerability Management"
+        }
+      ],
       "tags": [
         "configuration-management",
         "defender",
@@ -58911,6 +59369,12 @@
       "remediation": "Create a device compliance policy requiring BitLocker, secure boot, and minimum OS version. Intune > Devices > Compliance policies > Create policy > Windows 10 and later. Combine with a Conditional Access policy blocking non-compliant devices from accessing corporate resources.",
       "impact": "Devices with critical security gaps — disabled BitLocker, no secure boot, outdated OS — are treated as compliant by Conditional Access and receive full resource access, despite being at high risk of compromise.",
       "rationale": "A device compliance policy baseline establishes the minimum security posture required for a managed device. Without it, devices with disabled AV, missing encryption, or outdated OS are evaluated as compliant and receive full access to corporate resources.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/device-compliance-get-started",
+          "title": "Microsoft Learn — Use compliance policies to set rules for devices managed with Intune"
+        }
+      ],
       "tags": [
         "configuration-management",
         "endpoint",
@@ -60852,6 +61316,12 @@
       "remediation": "Create a Conditional Access policy blocking legacy authentication protocols. Entra admin center > Security > Conditional Access > New policy > Condition: Client apps = Other clients + Exchange ActiveSync clients > Grant: Block access. Monitor legacy auth sign-ins in the sign-in log before enforcing.",
       "impact": "Attackers who identify and spray legacy auth endpoints can authenticate with only a username and password, bypassing all Conditional Access MFA requirements and gaining full account access.",
       "rationale": "Legacy authentication protocols (Basic Auth, NTLM via IMAP/POP3/SMTP) do not support MFA. Any enabled legacy auth endpoint is a password-spray target that bypasses every MFA policy.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication",
+          "title": "Microsoft Learn — Block legacy authentication with Conditional Access"
+        }
+      ],
       "tags": [
         "conditional-access",
         "configuration-management",
@@ -61073,6 +61543,16 @@
       "remediation": "Security Defaults blocks legacy authentication protocols. For granular control, disable Security Defaults and create Conditional Access policies.",
       "impact": "Attackers can spray passwords against legacy protocol endpoints and authenticate successfully even when CA MFA policies are in place. A single compromised account via legacy auth gives full mailbox and Graph API access.",
       "rationale": "Legacy authentication protocols (Basic Auth, NTLM over SMTP/IMAP/POP3) do not support MFA and cannot be evaluated by Conditional Access policies. Any user with legacy auth enabled is a viable target for password spray attacks that MFA cannot stop.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication",
+          "title": "Microsoft Learn — Block legacy authentication with Conditional Access"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/disable-basic-authentication-in-exchange-online",
+          "title": "Microsoft Learn — Disable Basic authentication in Exchange Online"
+        }
+      ],
       "tags": [
         "conditional-access",
         "configuration-management",
@@ -61287,6 +61767,16 @@
       "remediation": "Create a CA policy: Target All users > Conditions > Authentication flows > Device code flow > Grant > Block access. Entra admin center > Protection > Conditional Access.",
       "impact": "A user who enters a device code presented by an attacker hands over a session token with full user permissions. The attack is invisible in sign-in logs because the authentication appears to originate from the user's location.",
       "rationale": "The device code flow is designed for devices without browsers (e.g., TV apps). Attackers abuse it in device code phishing: they generate a code, convince a user to enter it, and receive a fully authenticated session token without any MFA interaction from the attacker's machine.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-authentication-flows#device-code-flow",
+          "title": "Microsoft Learn — Authentication flows in Conditional Access (device code flow)"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/plan-conditional-access",
+          "title": "Microsoft Learn — Plan a Conditional Access deployment"
+        }
+      ],
       "tags": [
         "conditional-access",
         "configuration-management",
@@ -62607,6 +63097,12 @@
       "remediation": "Run: Set-TransportConfig -SmtpClientAuthenticationDisabled $true. Disable SMTP AUTH org-wide and enable per-mailbox only where required.",
       "impact": "Attackers can spray passwords against the SMTP AUTH endpoint to compromise mailboxes and use them as relay points for spam, phishing, or internal reconnaissance — all with only a valid username and password.",
       "rationale": "SMTP AUTH is a legacy protocol that supports Basic Authentication and is used for sending email from devices and applications. If enabled globally, any client can attempt to authenticate to Exchange using only a username and password, bypassing all modern authentication controls.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/authenticated-client-smtp-submission",
+          "title": "Microsoft Learn — Enable or disable authenticated client SMTP submission (SMTP AUTH)"
+        }
+      ],
       "tags": [
         "configuration-management",
         "email",
@@ -62842,6 +63338,16 @@
       "remediation": "Run: Set-SPOTenant -LegacyAuthProtocolsEnabled $false. SharePoint admin center > Policies > Access control > Apps that do not use modern authentication > Block access.",
       "impact": "Applications or scripts using legacy SharePoint authentication authenticate with only a username and password, bypassing MFA and CA policies. Compromised credentials provide full SharePoint access without any additional control.",
       "rationale": "Legacy SharePoint authentication (pre-modern) does not support MFA, Conditional Access, or token-based controls. Applications using legacy SharePoint auth bypass all modern authentication security controls enforced via CA.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/control-access-from-unmanaged-devices",
+          "title": "Microsoft Learn — Control access from unmanaged devices"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoft-365/admin/security-and-compliance/set-up-multi-factor-authentication",
+          "title": "Microsoft Learn — Set up multifactor authentication for Microsoft 365"
+        }
+      ],
       "tags": [
         "collaboration",
         "configuration-management",
@@ -63293,6 +63799,12 @@
       "remediation": "Run: Set-SPOSite -Identity <PersonalSiteUrl> -DenyAddAndCustomizePages 1. SharePoint admin center > Settings > Custom Script > prevent users from running custom script on personal sites.",
       "impact": "An attacker or insider who adds a malicious custom script to a SharePoint personal site can steal session cookies, exfiltrate documents, or perform actions in the SharePoint context on behalf of any user who visits the site.",
       "rationale": "Custom scripts on personal sites can execute arbitrary JavaScript in the SharePoint context, enabling attacks that capture user credentials, exfiltrate content, or manipulate SharePoint data using the victim user's session.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/allow-or-prevent-custom-script",
+          "title": "Microsoft Learn — Allow or prevent custom script"
+        }
+      ],
       "tags": [
         "collaboration",
         "configuration-management",
@@ -63509,6 +64021,12 @@
       "remediation": "Run: Set-SPOTenant -DenyAddAndCustomizePagesForSitesCreatedByUser 1. SharePoint admin center > Settings > Custom Script > prevent users from running custom script on self-service created sites.",
       "impact": "A compromised site collection administrator can inject persistent malicious JavaScript into a SharePoint site, affecting all users who access it — enabling credential theft, data exfiltration, and session hijacking at scale.",
       "rationale": "Custom scripts on site collections allow arbitrary JavaScript execution in the SharePoint context. Without restriction, any site collection administrator can inject code that affects all users of that site.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/allow-or-prevent-custom-script",
+          "title": "Microsoft Learn — Allow or prevent custom script"
+        }
+      ],
       "tags": [
         "collaboration",
         "configuration-management",
@@ -69562,6 +70080,16 @@
       "remediation": "Intune admin center > Devices > Configuration > Create profile > Endpoint protection > Windows Defender Application Control. Alternatively, deploy WDAC via custom OMA-URI.",
       "impact": "Any downloaded or dropped executable, script, or living-off-the-land binary (LOLBin) can run unobstructed. Attackers can execute ransomware, remote access tools, or credential dumpers without application control restrictions.",
       "rationale": "Application control (AppLocker / WDAC) prevents unauthorized software from executing on managed endpoints. Without it, attackers who gain initial access can run any executable, script, or payload without triggering application-based controls.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/endpoint-security-asr-policy",
+          "title": "Microsoft Learn — Manage Attack surface reduction policies in Intune"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/appcontrol-and-applocker-overview",
+          "title": "Microsoft Learn — App Control for Business and AppLocker overview"
+        }
+      ],
       "tags": [
         "configuration-management",
         "endpoint",
@@ -69702,6 +70230,12 @@
       "remediation": "Disable VPN split tunneling on managed devices. Intune > Devices > Configuration profiles > New profile > Windows > VPN > disable split tunneling (route all traffic through VPN). Assign to all devices used for remote access.",
       "impact": "A device using split tunneling can have its non-corporate traffic intercepted or manipulated by a network-positioned attacker. Malware using direct internet connectivity bypasses corporate network security controls entirely.",
       "rationale": "Split tunneling routes only corporate traffic through the VPN while allowing direct internet access for other traffic. This allows DNS and web traffic from the device to bypass corporate security controls (proxy, DNS filtering) and enables attackers who compromise web traffic to intercept sessions.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/vpn-settings-configure",
+          "title": "Microsoft Learn — Add VPN settings on devices using Intune"
+        }
+      ],
       "tags": [
         "configuration",
         "configuration-management",
@@ -70334,6 +70868,16 @@
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Edit each policy in simulation mode and switch it to Enforce once validated.",
       "impact": "A retention policy in simulation mode has no effect on actual data retention. Content that should be preserved can still be deleted, and data that should be automatically disposed of is retained indefinitely — creating both compliance gaps and unintended data accumulation.",
       "rationale": "Retention policies in simulation mode do not enforce retention — they only predict what would be retained. Policies must be in Enforce mode to actually preserve or delete content according to the configured rules.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/create-retention-policies",
+          "title": "Microsoft Learn — Create and configure retention policies"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/retention",
+          "title": "Microsoft Learn — Learn about retention policies and retention labels"
+        }
+      ],
       "tags": [
         "change-management",
         "configuration",
@@ -71452,6 +71996,16 @@
       "remediation": "Connect to Exchange Online and verify accepted domains.",
       "impact": "External attackers can send phishing emails appearing to originate from your organization's domain. Employees, customers, and partners receive convincing impersonation emails with no visual indicator of spoofing.",
       "rationale": "DMARC (Domain-based Message Authentication, Reporting, and Conformance) instructs receiving mail servers to reject or quarantine emails that fail SPF and DKIM alignment checks, preventing domain impersonation. Without DMARC, any server can send emails that appear to come from your domain.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/email-authentication-dmarc-configure",
+          "title": "Microsoft Learn — Use DMARC to validate email"
+        },
+        {
+          "url": "https://www.rfc-editor.org/rfc/rfc7489",
+          "title": "RFC 7489 — Domain-based Message Authentication, Reporting, and Conformance (DMARC)"
+        }
+      ],
       "tags": [
         "continuous-monitoring",
         "dns",
@@ -79462,6 +80016,16 @@
       "remediation": "Enable unified audit logging. Purview compliance portal > Audit > Search > Start recording user and admin activity. PowerShell: Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true",
       "impact": "Security incidents cannot be investigated, breaches cannot be scoped, and compliance audits cannot be satisfied. Attackers can operate for extended periods without any log trail to detect or reconstruct their activities.",
       "rationale": "Unified audit logging is the foundation of incident response and forensic investigation in Microsoft 365. Without it, there is no record of who accessed what, when, or what configuration changes were made.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/audit-log-enable-disable",
+          "title": "Microsoft Learn — Turn auditing on or off"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/audit-solutions-overview",
+          "title": "Microsoft Learn — Microsoft Purview Audit overview"
+        }
+      ],
       "tags": [
         "audit",
         "compliance",
@@ -79675,6 +80239,12 @@
       "remediation": "Microsoft Purview > Alert policies > Review and enable default alert policies. Ensure high-severity policies for suspicious activity, malware, and privilege escalation are active.",
       "impact": "Anomalous activity such as a user downloading thousands of files or a new admin being created goes undetected until a manual audit or external report. Incident response is delayed by hours or days.",
       "rationale": "Alert policies detect anomalous tenant activity — mass data downloads, unusual external sharing, admin permission changes — and notify security teams in near-real-time. Without them, security events are only discovered during periodic log reviews.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/alert-policies",
+          "title": "Microsoft Learn — Alert policies in Microsoft Purview"
+        }
+      ],
       "tags": [
         "compliance",
         "continuous-monitoring",
@@ -80100,6 +80670,16 @@
       "remediation": "Investigate: review Intune audit logs for the device wipe events immediately. Intune > Tenant administration > Audit logs > filter by DeviceAction: Wipe. Verify each wipe was authorized. Rotate credentials and initiate incident response if unauthorized activity is confirmed.",
       "impact": "An attacker or malicious insider with Intune write access can wipe all managed devices simultaneously, destroying data and disrupting operations across the entire device fleet before any manual detection.",
       "rationale": "Mass device wipe activity is an indicator of either an insider threat action or an attacker who has compromised administrative credentials. Detecting this in real time limits the number of devices affected and enables rapid credential revocation.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/remote-actions/device-management",
+          "title": "Microsoft Learn — Use the full Wipe, Retire, or manually Unenroll devices using Intune"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/fundamentals/monitor-audit-logs",
+          "title": "Microsoft Learn — Use audit logs to track and monitor events in Intune"
+        }
+      ],
       "tags": [
         "audit",
         "continuous-monitoring",
@@ -80416,6 +80996,12 @@
       "remediation": "Run: Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true. Microsoft Purview > Audit > Start recording user and admin activity.",
       "impact": "Security incidents leave no forensic trail. Breach scope cannot be determined, compliance audit requirements cannot be met, and attackers can operate without leaving a detectable record.",
       "rationale": "Audit log search is the investigative capability for Microsoft 365 — every admin action, user sign-in, file access, and configuration change is recorded here. Without it enabled, incidents cannot be investigated.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/audit-log-enable-disable",
+          "title": "Microsoft Learn — Turn auditing on or off"
+        }
+      ],
       "tags": [
         "audit",
         "compliance",
@@ -81371,6 +81957,12 @@
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Teams channel messages and chats.",
       "impact": "Teams conversations, channel messages, and meeting recordings that should be retained for compliance or legal hold purposes may be permanently deleted, creating the same exposure as email data without a retention policy.",
       "rationale": "Teams messages and meeting recordings constitute business records subject to the same retention requirements as email. Without a retention policy, Teams data can be permanently deleted, destroying evidence of conversations, decisions, and security-relevant activity.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/retention-policies-teams",
+          "title": "Microsoft Learn — Learn about retention for Microsoft Teams"
+        }
+      ],
       "tags": [
         "configuration",
         "continuous-monitoring",
@@ -81558,6 +82150,16 @@
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Exchange email and mailboxes.",
       "impact": "Email evidence required for legal holds, regulatory audits, or security investigations may be permanently deleted if no retention policy exists. Data loss creates compliance failures and impedes incident response.",
       "rationale": "Email is the primary record of business communications and the most common target in litigation holds and regulatory audits. Without a retention policy, email data may be deleted before the legally required retention period, creating compliance exposure and destroying forensic evidence.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/retention-policies-exchange",
+          "title": "Microsoft Learn — Learn about retention for Exchange"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/create-retention-policies",
+          "title": "Microsoft Learn — Create and configure retention policies"
+        }
+      ],
       "tags": [
         "configuration",
         "continuous-monitoring",
@@ -81745,6 +82347,12 @@
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include SharePoint sites and OneDrive accounts.",
       "impact": "Documents deleted from SharePoint or OneDrive without a retention policy are permanently purged after the recycle bin period. Records required for compliance attestation or incident investigation may be unrecoverable.",
       "rationale": "SharePoint and OneDrive store documents, collaboration artifacts, and file-based records. Without a retention policy, files can be deleted before their required retention period expires, eliminating records needed for compliance, litigation, and forensic investigations.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/retention-policies-sharepoint",
+          "title": "Microsoft Learn — Learn about retention for SharePoint and OneDrive"
+        }
+      ],
       "tags": [
         "configuration",
         "continuous-monitoring",
@@ -82310,6 +82918,12 @@
       "remediation": "Entra admin center > Enterprise applications > Consent and permissions > User consent settings > Allow consent only from verified publishers or block user consent entirely.",
       "impact": "Malicious OAuth apps displayed in consent phishing campaigns acquire delegated access to user mailboxes, files, and contacts. Access persists until explicitly revoked, surviving password changes and MFA events.",
       "rationale": "User consent to third-party apps grants those apps access to the user's data (email, files, contacts) on behalf of the user. Without restricting consent to verified publishers, any malicious app can acquire persistent delegated access via a single user consent click.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent",
+          "title": "Microsoft Learn — Configure how users consent to applications"
+        }
+      ],
       "tags": [
         "entra-id",
         "identity",
@@ -82528,6 +83142,12 @@
       "remediation": "Entra admin center > Enterprise applications > review foreign apps with broad data access (Mail.ReadWrite, Files.ReadWrite.All, etc.). Scope to least-privilege or remove.",
       "impact": "Foreign apps with Tier 1 data permissions can read all email, files, and calendar data for any user who grants consent. This data leaves your tenant boundary and may be stored, processed, or accessed by the app publisher.",
       "rationale": "Tier 1 data permissions (Mail.ReadWrite, Files.ReadWrite.All, Calendars.ReadWrite) grant access to individual user communication and collaboration data. For foreign apps, this data flows to the publisher's infrastructure and is subject to their security and privacy controls, not yours.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        }
+      ],
       "tags": [
         "app-registration",
         "identity",
@@ -83415,6 +84035,12 @@
       "remediation": "IP-based trusted locations can be spoofed via VPN or proxy. Consider Global Secure Access compliant network checks or country-based locations for stronger assurance. Entra admin center > Protection > Conditional Access > Named locations.",
       "impact": "Attackers with access to a trusted IP range (shared hosting, compromised on-premises network, VPN exit node) authenticate without MFA challenges, bypassing the core CA control.",
       "rationale": "IP-based named locations used in CA 'trusted location' exclusions can be spoofed via VPN or proxy. Relying on IP reputation as a trust signal without combining it with device compliance or MFA creates an authentication bypass for any attacker who can route through a trusted IP range.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/location-condition",
+          "title": "Microsoft Learn — Location condition in Conditional Access"
+        }
+      ],
       "tags": [
         "conditional-access",
         "identity",
@@ -84133,6 +84759,16 @@
       "remediation": "Microsoft Purview > Data loss prevention > Policies > Create a DLP policy covering sensitive information types relevant to your organization.",
       "impact": "Sensitive data can be sent externally via email, Teams, or file sharing without any controls, inspection, or audit trail. A single misdirected email or shared link can expose thousands of records.",
       "rationale": "Data loss prevention policies enforce data handling rules at the point of sharing, preventing users from accidentally or maliciously sending sensitive data (PII, financial, health) to unauthorized recipients.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/dlp-learn-about-dlp",
+          "title": "Microsoft Learn — Learn about Microsoft Purview Data Loss Prevention"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/dlp-create-deploy-policy",
+          "title": "Microsoft Learn — Create and deploy a data loss prevention policy"
+        }
+      ],
       "tags": [
         "compliance",
         "data-governance",
@@ -84290,6 +84926,12 @@
       "remediation": "Microsoft Purview > Data loss prevention > Policies > Edit an existing policy or create new > Include Teams chat and channel messages location.",
       "impact": "Sensitive data shared in Teams chats or channels — including PII, payment card data, and internal credentials — is not detected or blocked, creating uncontrolled data exposure paths.",
       "rationale": "Teams is a primary communication channel where sensitive information is routinely shared in chat. Without DLP coverage for Teams, conversations containing PII, financial data, or credentials are not inspected or blocked.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/dlp-microsoft-teams",
+          "title": "Microsoft Learn — Data loss prevention and Microsoft Teams"
+        }
+      ],
       "tags": [
         "compliance",
         "data-governance",
@@ -85600,6 +86242,12 @@
       "remediation": "Microsoft Purview > Data loss prevention > Policies > Edit existing policies to include Exchange email and SharePoint/OneDrive locations for comprehensive data protection.",
       "impact": "Gaps in DLP coverage between email and collaboration platforms create bypass paths: data blocked via email can be exfiltrated by first uploading to SharePoint and sharing a link externally.",
       "rationale": "Exchange email and SharePoint/OneDrive are the highest-volume channels for sensitive data movement. DLP policies covering both ensure consistent enforcement regardless of whether data is emailed or shared via a link.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/dlp-create-deploy-policy",
+          "title": "Microsoft Learn — Create and deploy a data loss prevention policy"
+        }
+      ],
       "tags": [
         "compliance",
         "data-governance",
@@ -85813,6 +86461,12 @@
       "remediation": "Run: Set-HostedConnectionFilterPolicy -Identity <Policy> -IPAllowList @{}. Exchange admin center > Protection > Connection filter > Edit the policy and remove all IP allow list entries.",
       "impact": "Malicious email originating from or relayed through an allowed IP is delivered without spam, malware, or phishing inspection. A single compromised host on an allowlisted range can be used to deliver unfiltered malware to all users.",
       "rationale": "IP allow lists in the connection filter bypass all spam and malware filtering for connections from listed IPs. Shared hosting IPs, CDN exit nodes, and business partner ranges can be abused to relay malicious email that completely bypasses filtering.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/connection-filter-policies-configure",
+          "title": "Microsoft Learn — Configure connection filter policies in EOP"
+        }
+      ],
       "tags": [
         "email",
         "exchange-online",
@@ -86242,6 +86896,16 @@
       "remediation": "Block automatic external forwarding via transport rule. Exchange Admin Center > Mail flow > Rules > New rule: apply to messages where recipient is outside the org and message type is Auto Forward > Block the message. Also disable auto-forwarding in the outbound anti-spam policy.",
       "impact": "Compromised mailboxes with auto-forwarding rules silently exfiltrate all incoming email to attacker-controlled addresses. The exfiltration persists through password resets and MFA changes because the forwarding rule is not cleared by authentication remediation.",
       "rationale": "Automatic external forwarding allows users (or compromised accounts) to silently redirect email to external addresses. Without a transport rule blocking this, a single compromised mailbox becomes a persistent data exfiltration channel that survives credential rotation.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/outbound-spam-policies-external-email-forwarding",
+          "title": "Microsoft Learn — Control automatic external email forwarding in Microsoft 365"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules",
+          "title": "Microsoft Learn — Mail flow rules in Exchange Online"
+        }
+      ],
       "tags": [
         "email",
         "exchange-online",
@@ -86453,6 +87117,12 @@
       "remediation": "Run: Set-RemoteDomain -Identity Default -AutoForwardEnabled $false. Also consider transport rules to block client-side forwarding.",
       "impact": "All email to a mailbox with an external forwarding rule is exfiltrated silently. The rule survives password changes and MFA re-enrollment, providing persistent mail access long after an account compromise is detected and remediated.",
       "rationale": "External mail forwarding creates persistent data exfiltration paths — every email received is silently copied to an external address. Attackers who compromise mailboxes routinely create forwarding rules as a persistence mechanism that survives password resets.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/outbound-spam-policies-external-email-forwarding",
+          "title": "Microsoft Learn — Control automatic external email forwarding in Microsoft 365"
+        }
+      ],
       "tags": [
         "email",
         "exchange-online",
@@ -86897,6 +87567,12 @@
       "remediation": "Disable or restrict 'Publish to web'. Power BI Admin portal > Tenant settings > Export and sharing settings > Publish to web: Disabled or Apply to specific security groups. Revoke existing public embed codes via Power BI Admin portal > Embed Codes.",
       "impact": "Reports published to web are publicly accessible and may be indexed by search engines. Sensitive operational, financial, or customer data embedded in a published report is exposed to the internet indefinitely.",
       "rationale": "'Publish to web' creates unauthenticated, publicly accessible embed codes for Power BI content. Any report published this way is accessible to anyone with the URL, with no authentication, no access control, and no audit trail.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/power-bi/admin/service-admin-portal-export-sharing",
+          "title": "Microsoft Learn — Power BI export and sharing settings"
+        }
+      ],
       "tags": [
         "data",
         "network-security",
@@ -94121,6 +94797,12 @@
       "remediation": "Block legacy authentication via Conditional Access. Entra admin center > Security > Conditional Access > New policy > target all users > Condition: Client apps = Other clients + Exchange ActiveSync > Grant: Block access. Alternatively, enable the Microsoft-managed legacy auth block policy.",
       "impact": "Attackers targeting legacy auth endpoints (IMAP, POP3, EAS, SMTP AUTH) can authenticate with only a username and password, bypassing MFA policies that apply to modern authentication flows.",
       "rationale": "Legacy authentication protocols cannot be evaluated by Conditional Access policies. Enabling these protocols for any user creates a pathway around every MFA requirement in the tenant.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication",
+          "title": "Microsoft Learn — Block legacy authentication with Conditional Access"
+        }
+      ],
       "tags": [
         "conditional-access",
         "identity",
@@ -94342,6 +95024,12 @@
       "remediation": "Connect to Exchange Online PowerShell to check inbound connector configuration.",
       "impact": "An attacker or compromised device on an allowed IP range can send spoofed email appearing to come from any address in your domain, bypassing DMARC (which does not apply to internal relay), enabling BEC and executive impersonation campaigns.",
       "rationale": "Direct send allows unauthenticated email delivery from internal IP ranges without credentials. Without controls on which systems are authorized to send, any device that can reach Exchange Online can send email appearing to originate from your domain — a spoofing and BEC enabler.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-microsoft-365-or-office-365",
+          "title": "Microsoft Learn — How to set up a multifunction device to send email using Microsoft 365"
+        }
+      ],
       "tags": [
         "email",
         "exchange-online",
@@ -94693,6 +95381,12 @@
       "remediation": "Require device compliance for remote access. Entra admin center > Security > Conditional Access > New policy > target all users > Condition: Device platforms or named locations > Grant: Require device to be marked as compliant. Combine with Intune compliance policies.",
       "impact": "Unmanaged remote devices can be compromised and used to relay authenticated sessions to attacker infrastructure. Without device compliance enforcement, there is no assurance that the device accessing sensitive data is trustworthy.",
       "rationale": "Remote access from unmanaged devices bypasses endpoint detection, patch enforcement, and data loss controls. A corporate credential entered on a personal or public device may be stolen by keyloggers or malware running on that device.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-compliant-device",
+          "title": "Microsoft Learn — Require compliant or hybrid joined device"
+        }
+      ],
       "tags": [
         "conditional-access",
         "identity",
@@ -95011,6 +95705,12 @@
       "remediation": "Enable Entra ID PIM. Convert permanent role assignments to eligible. Configure activation to require justification and MFA. Entra admin center > Identity Governance > Privileged Identity Management > Entra ID roles.",
       "impact": "Privileged commands executed remotely from unmanaged devices bypass endpoint security controls. An attacker who compromises a remote session inherits all standing privileged access of the connected user.",
       "rationale": "Remote access sessions from personal or unmanaged devices have weaker security assurances. Requiring PIM activation for privileged commands during remote sessions adds a time-bound, audited step and ensures privileged actions are explicitly authorized even when performed remotely.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure",
+          "title": "Microsoft Learn — What is Microsoft Entra Privileged Identity Management?"
+        }
+      ],
       "tags": [
         "entra-id",
         "identity",
@@ -95186,6 +95886,12 @@
       "remediation": "Deploy a Wi-Fi configuration profile requiring WPA2/WPA3-Enterprise authentication. Intune > Devices > Configuration profiles > New profile > Windows > Wi-Fi > set Security type: WPA2-Enterprise, Authentication method: Certificates. Assign to managed device groups.",
       "impact": "Devices connecting to open or pre-shared-key Wi-Fi networks can have their traffic captured and decrypted. WPA2-Personal networks are vulnerable to handshake capture and offline brute force of the pre-shared key.",
       "rationale": "Open or WPA2-Personal Wi-Fi networks are vulnerable to passive capture and WPA2 handshake attacks. WPA2/WPA3-Enterprise with certificate-based authentication prevents credential theft and ensures only enrolled devices connect to corporate networks.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/wi-fi-settings-configure",
+          "title": "Microsoft Learn — Configure Wi-Fi settings for devices in Intune"
+        }
+      ],
       "tags": [
         "endpoint",
         "intune",
@@ -95372,6 +96078,12 @@
       "remediation": "Enable BitLocker via Intune endpoint protection policy. Intune > Devices > Configuration profiles > Endpoint protection > BitLocker > require TPM startup, encrypt all drives, back up recovery keys to Entra ID. Assign to all managed Windows device groups.",
       "impact": "A stolen device without disk encryption exposes all locally cached email, documents, credentials, and browser data to anyone with physical access. Data recovery requires no credentials — only attaching the drive to another system.",
       "rationale": "Full-disk encryption (BitLocker) protects data at rest on managed devices. Without it, a lost or stolen device provides physical access to all locally stored corporate data without any password or authentication requirement.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/encrypt-devices",
+          "title": "Microsoft Learn — Use BitLocker encryption for Windows devices"
+        }
+      ],
       "tags": [
         "endpoint",
         "endpoint-security",
@@ -96625,6 +97337,16 @@
       "remediation": "Run: New-SafeLinksPolicy -Name \"Safe Links\" -IsEnabled $true; New-SafeLinksRule -Name \"Safe Links\" -SafeLinksPolicy \"Safe Links\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Links > Create a policy covering all users.",
       "impact": "Users who click malicious URLs are taken directly to phishing pages, credential harvesters, or malware download sites. Time-of-click protection is the only defense against links weaponized after email delivery.",
       "rationale": "Safe Links rewrites URLs in emails and Office documents and checks them at click time against Microsoft's threat intelligence. Without it, URLs pointing to malicious sites — including late-stage weaponized links that appear safe at delivery — are not blocked when the user clicks.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/safe-links-about",
+          "title": "Microsoft Learn — Safe Links in Microsoft Defender for Office 365"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/safe-links-policies-configure",
+          "title": "Microsoft Learn — Set up Safe Links policies"
+        }
+      ],
       "tags": [
         "defender",
         "email",
@@ -97180,6 +97902,16 @@
       "remediation": "Run: New-SafeAttachmentPolicy -Name \"Safe Attachments\" -Enable $true -Action Block; New-SafeAttachmentRule -Name \"Safe Attachments\" -SafeAttachmentPolicy \"Safe Attachments\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Attachments > Create a policy covering all users.",
       "impact": "Zero-day malware and novel attack tools embedded in Office documents, PDFs, and archives are delivered to users. A single opened attachment can compromise an endpoint and provide an initial foothold in the organization.",
       "rationale": "Safe Attachments detonates email attachments in a sandbox before delivery, detecting zero-day malware that signature-based AV would miss. Without it, malicious attachments are only scanned with known signatures and delivered before sandbox analysis completes.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/safe-attachments-about",
+          "title": "Microsoft Learn — Safe Attachments in Microsoft Defender for Office 365"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/safe-attachments-policies-configure",
+          "title": "Microsoft Learn — Set up Safe Attachments policies"
+        }
+      ],
       "tags": [
         "defender",
         "email",
@@ -99357,6 +100089,16 @@
       "remediation": "Harden the anti-phishing policy. Defender portal > Email & Collaboration > Policies & rules > Threat policies > Anti-phishing > edit default policy: enable mailbox intelligence, enable impersonation protection for key users and domains, set action to Quarantine for impersonation and spoof detections.",
       "impact": "Phishing emails impersonating executives, vendors, or trusted contacts are delivered to users. Business email compromise (BEC) attacks that leverage impersonation cause direct financial loss and credential theft.",
       "rationale": "The anti-phishing policy is the primary defense against impersonation attacks, including executive spoofing and lookalike domain phishing. Without hardened settings, impersonation attempts that bypass DMARC — using lookalike domains, display name spoofing, or compromised external accounts — land in user inboxes.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-about",
+          "title": "Microsoft Learn — Anti-phishing policies in Microsoft 365"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-mdo-configure",
+          "title": "Microsoft Learn — Configure anti-phishing policies in Defender for Office 365"
+        }
+      ],
       "tags": [
         "email",
         "endpoint-security",
@@ -99625,6 +100367,16 @@
       "remediation": "Enable DKIM signing for each accepted domain. Defender portal > Email & Collaboration > Policies & rules > Threat policies > DKIM > select domain > Enable. Add the two provided CNAME records to your DNS zone before enabling.",
       "impact": "Email from your domain can be spoofed or tampered with in transit without detection. Without DKIM signatures, DMARC enforcement is weakened and phishing emails may pass alignment checks.",
       "rationale": "DKIM (DomainKeys Identified Mail) signs outbound emails with a private key, allowing receivers to verify that the email content was not modified in transit and genuinely originated from your domain. DKIM is required for effective DMARC enforcement.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/email-authentication-dkim-configure",
+          "title": "Microsoft Learn — Use DKIM to validate outbound email sent from your domain"
+        },
+        {
+          "url": "https://www.rfc-editor.org/rfc/rfc6376",
+          "title": "RFC 6376 — DomainKeys Identified Mail (DKIM) Signatures"
+        }
+      ],
       "tags": [
         "email",
         "endpoint-security",
@@ -99892,6 +100644,12 @@
       "remediation": "Harden the anti-malware policy. Defender portal > Email & Collaboration > Policies & rules > Threat policies > Anti-malware > edit default policy: enable common attachments filter, enable ZAP, configure admin notifications.",
       "impact": "Malicious files (executables, script files, Office macros) are delivered to user inboxes. Infected emails delivered before signature updates are not retroactively quarantined without ZAP enabled.",
       "rationale": "The malware filter policy is the baseline anti-malware control for Exchange Online. Without proper configuration — common attachment filtering, ZAP, admin notifications — known malware file types are delivered, zero-hour threats linger in inboxes, and infections go unnoticed.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-malware-policies-configure",
+          "title": "Microsoft Learn — Configure anti-malware policies in EOP"
+        }
+      ],
       "tags": [
         "email",
         "endpoint-security",
@@ -100163,6 +100921,12 @@
       "remediation": "Run: Set-SPOTenant -DisallowInfectedFileDownload $true. SharePoint admin center > Policies > Malware protection.",
       "impact": "An infected document uploaded to SharePoint is synced to all users via OneDrive sync clients. A single malicious file can reach hundreds or thousands of endpoints before manual detection.",
       "rationale": "SharePoint file storage can be used to host and distribute malware if infected file quarantine is disabled. A malware-infected document uploaded to SharePoint can be synced to all users who have access to the library, spreading the infection across the organization.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/safeguarding-your-data",
+          "title": "Microsoft Learn — How SharePoint safeguards your data"
+        }
+      ],
       "tags": [
         "collaboration",
         "endpoint-security",
@@ -103295,6 +104059,12 @@
       "remediation": "Intune admin center > Endpoint security > Antivirus > Create policy > Microsoft Defender Antivirus > Enable real-time protection.",
       "impact": "Malware can execute, establish persistence, and exfiltrate data before any scheduled scan detects it. Endpoint compromise becomes undetected until symptoms appear or a scan runs.",
       "rationale": "Real-time protection is the primary line of defense against malware executing on endpoints. Without it, malicious files are only caught at scheduled scan intervals, giving attackers a wide window to establish persistence.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/configure-real-time-protection-microsoft-defender-antivirus",
+          "title": "Microsoft Learn — Configure always-on protection in Microsoft Defender Antivirus"
+        }
+      ],
       "tags": [
         "conditional-access",
         "defender",
@@ -103771,6 +104541,16 @@
       "remediation": "Remove all entries from the 'Allowed domains' list in inbound anti-spam policies. Defender portal > Email & Collaboration > Policies & rules > Threat policies > Anti-spam > edit each inbound policy > Allow & block lists > Allowed domains: remove all entries. Allowed domains bypass both spam and malware filtering.",
       "impact": "Phishing and malware emails originating from allowed domains are delivered to inboxes without any filtering. Attackers who control or compromise an allowed domain have an unobstructed channel for malicious emails.",
       "rationale": "Domains on the anti-spam allow list bypass all spam and malware filtering, including Safe Attachments and Safe Links. This is one of the highest-impact configuration errors in Exchange Online security — a single allowlisted domain eliminates all email-based protections for messages from that domain.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-spam-protection-about",
+          "title": "Microsoft Learn — Anti-spam protection in EOP"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-spam-policies-configure",
+          "title": "Microsoft Learn — Configure anti-spam policies in EOP"
+        }
+      ],
       "tags": [
         "defender",
         "email",
@@ -104456,6 +105236,16 @@
       "remediation": "Restrict PowerShell execution policy on managed endpoints. Intune > Devices > Configuration profiles > Settings catalog > search 'Turn on Script Execution' > set to AllSigned or RemoteSigned. Assign to all managed Windows device groups.",
       "impact": "Malicious PowerShell scripts execute without restriction: credential dumpers, reverse shells, ransomware droppers, and exfiltration tools all commonly use PowerShell and are blocked only when execution policy is enforced.",
       "rationale": "Unrestricted PowerShell execution on managed endpoints allows any script — downloaded, embedded in documents, or dropped by malware — to run without signature verification. PowerShell is the most commonly abused living-off-the-land technique in modern attacks.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/settings-catalog",
+          "title": "Microsoft Learn — Use the settings catalog to configure settings on Windows devices"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy",
+          "title": "Microsoft Learn — Set-ExecutionPolicy"
+        }
+      ],
       "tags": [
         "endpoint",
         "endpoint-security",
@@ -104671,6 +105461,12 @@
       "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowAnonymousUsersToJoinMeeting $false. Teams admin center > Meetings > Meeting policies > Global > Anonymous users can join a meeting > Off.",
       "impact": "Meeting links forwarded or accidentally shared publicly allow unauthorized parties to join internal meetings. Sensitive business discussions, strategy sessions, and confidential presentations can be observed by anonymous attendees.",
       "rationale": "Anonymous meeting join allows any user with the meeting link — including those without an account — to join Teams meetings. Meeting links shared accidentally expose internal business discussions to uninvited external parties.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoftteams/meeting-settings-in-teams",
+          "title": "Microsoft Learn — Manage meeting settings in Microsoft Teams"
+        }
+      ],
       "tags": [
         "collaboration",
         "endpoint-security",
@@ -105592,6 +106388,12 @@
       "remediation": "Intune admin center > Devices > Compliance > Create/edit iOS and Android compliance policies > Require device encryption.",
       "impact": "A lost or stolen unencrypted mobile device exposes all locally cached corporate data including email, contacts, Teams messages, and app credentials to anyone with physical access.",
       "rationale": "Unencrypted mobile devices expose corporate email, contacts, documents, and app data if lost or stolen. Mobile devices are higher-risk endpoints due to portability and greater likelihood of physical loss.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/device-compliance-get-started",
+          "title": "Microsoft Learn — Device compliance policies in Intune"
+        }
+      ],
       "tags": [
         "endpoint",
         "intune",
@@ -105742,6 +106544,12 @@
       "remediation": "Replace wildcard redirect URIs with explicit URIs. Wildcards enable open redirect attacks for token theft. Entra admin center > App registrations > Authentication.",
       "impact": "An attacker can craft an authorization request using the legitimate app's client ID but pointing to an attacker-controlled path within the wildcard URI, capturing OAuth tokens without compromising the app itself.",
       "rationale": "Wildcard redirect URIs (e.g., https://example.com/*) allow OAuth tokens to be delivered to any path under that domain. If any subdirectory of the registered domain is compromised or supports open redirects, an attacker can craft a URL that sends tokens to an attacker-controlled endpoint.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity-platform/reply-url",
+          "title": "Microsoft Learn — Redirect URI (reply URL) restrictions"
+        }
+      ],
       "tags": [
         "app-registration",
         "identity",
@@ -105975,6 +106783,16 @@
       "remediation": "Intune admin center > Devices > Configuration > Create profile > Custom OMA-URI > Add setting: ./Device/Vendor/MSFT/Policy/Config/Cryptography/AllowFipsAlgorithmPolicy = 1.",
       "impact": "Data encrypted with non-FIPS-validated algorithms may be vulnerable to cryptanalytic attacks or algorithmic weaknesses. For FedRAMP and CMMC environments, non-FIPS devices fail compliance attestation.",
       "rationale": "FIPS-validated cryptography ensures that encryption and cryptographic operations on managed devices meet federal security requirements. Non-FIPS algorithms may have known weaknesses or implementation flaws that weaken data protection.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/windows/security/security-foundations/certification/fips-140-validation",
+          "title": "Microsoft Learn — FIPS 140 validation"
+        },
+        {
+          "url": "https://csrc.nist.gov/publications/detail/fips/140/3/final",
+          "title": "NIST FIPS 140-3 — Security Requirements for Cryptographic Modules"
+        }
+      ],
       "tags": [
         "cryptographic-protections",
         "endpoint",
@@ -106453,6 +107271,12 @@
       "remediation": "Update HTTP redirect URIs to HTTPS. Non-HTTPS URIs allow token interception via MITM attacks. Entra admin center > App registrations > Authentication.",
       "impact": "OAuth tokens or authorization codes sent to HTTP endpoints can be intercepted via man-in-the-middle attacks on the same network. An intercepted token grants the attacker the same access as the legitimate application.",
       "rationale": "HTTP redirect URIs in app registrations allow OAuth tokens to be sent to non-HTTPS endpoints, exposing them to interception in transit. OAuth authorization codes delivered over HTTP can be captured by a network-positioned attacker.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity-platform/reply-url",
+          "title": "Microsoft Learn — Redirect URI (reply URL) restrictions"
+        }
+      ],
       "tags": [
         "app-registration",
         "cryptographic-protections",
@@ -114941,6 +115765,12 @@
       "remediation": "Enable Microsoft 365 Backup in the admin center. Microsoft 365 Admin Center > Settings > Org settings > Microsoft 365 Backup > Enable. Requires Microsoft 365 Backup add-on license. Configure backup scope for Exchange, SharePoint, and OneDrive.",
       "impact": "Ransomware that encrypts and deletes Exchange, SharePoint, and OneDrive data cannot be recovered if the retention period has expired. Without backup, recovery from destructive attacks requires rebuilding from scratch rather than restoring from a known-good point in time.",
       "rationale": "Microsoft 365 data (Exchange, SharePoint, OneDrive) is recoverable from the recycle bin only within limited windows. A dedicated backup solution provides point-in-time recovery from ransomware, accidental deletion, and malicious destruction that exceeds the recycle bin retention period.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoft-365/backup/backup-overview",
+          "title": "Microsoft Learn — Overview of Microsoft 365 Backup"
+        }
+      ],
       "tags": [
         "business-continuity-disaster-recovery",
         "compliance",
@@ -115185,6 +116015,12 @@
       "remediation": "Enable Microsoft Defender for Endpoint. Navigate to security.microsoft.com > Vulnerability management to review coverage. Ensure devices are onboarded to MDE.",
       "impact": "Known vulnerabilities on managed devices go undetected and unremediated. Attackers who identify these devices via active scanning or from breach intelligence have an unpatched entry point.",
       "rationale": "Vulnerability scanning surfaces known exploitable vulnerabilities in managed device software and OS configuration. Unpatched vulnerabilities are the primary initial access vector for ransomware and targeted attacks.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-vulnerability-management/defender-vulnerability-management",
+          "title": "Microsoft Learn — Microsoft Defender Vulnerability Management"
+        }
+      ],
       "tags": [
         "conditional-access",
         "defender",

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -29,7 +29,17 @@
       "stigControlId": "V-260333",
       "remediation": "Create cloud-only admin accounts instead of using on-premises synced accounts. Entra admin center > Users > New user > Create user (cloud identity).",
       "rationale": "On-premises Active Directory is the primary target in hybrid identity compromise scenarios. Admin accounts synced from on-premises AD inherit the risk of the on-premises environment: an on-premises compromise (ransomware, domain controller breach) immediately provides cloud admin credentials.",
-      "impact": "A compromised on-premises domain controller provides NTLM or Kerberos credentials for any synced admin account. The attacker converts on-premises domain dominance into cloud tenant administrator access without any additional steps."
+      "impact": "A compromised on-premises domain controller provides NTLM or Kerberos credentials for any synced admin account. The attacker converts on-premises domain dominance into cloud tenant administrator access without any additional steps.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/plan-hybrid-identity-design-considerations-overview",
+          "title": "Microsoft Learn — Hybrid identity design considerations"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-SYNCADMIN-001",
@@ -55,7 +65,17 @@
       "cisaScubaControlId": "MS.AAD.7.4v1",
       "remediation": "Replace on-premises synced admin accounts with cloud-only accounts for all Tier-0/1 roles. Entra admin center > Users > identify synced accounts holding directory roles > create cloud-only replacements > migrate role assignments > remove roles from synced accounts.",
       "rationale": "On-premises AD is a frequent initial compromise target. Admin accounts synced from on-premises AD carry the credential risk of the on-premises environment into the cloud: NTLM hash extraction from a domain controller provides working cloud credentials.",
-      "impact": "An attacker who compromises on-premises AD and extracts NTLM hashes for synced admin accounts can pass-the-hash or use harvested credentials to authenticate to Entra ID, directly translating an on-premises breach into cloud administrative access."
+      "impact": "An attacker who compromises on-premises AD and extracts NTLM hashes for synced admin accounts can pass-the-hash or use harvested credentials to authenticate to Entra ID, directly translating an on-premises breach into cloud administrative access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/whatis-phs",
+          "title": "Microsoft Learn — What is password hash synchronization?"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ADMIN-003",
@@ -81,7 +101,17 @@
       "stigControlId": "V-260334",
       "remediation": "Maintain at least two cloud-only emergency access accounts excluded from all Conditional Access policies.",
       "rationale": "Emergency access accounts provide a recovery path when primary admin access is unavailable — for example, if MFA is unavailable or a Conditional Access misconfiguration locks out all admins. Without them, a single configuration error can make the tenant unmanageable.",
-      "impact": "A misconfigured Conditional Access policy or MFA outage can permanently lock all administrators out of the tenant, requiring a time-consuming Microsoft Support escalation to recover."
+      "impact": "A misconfigured Conditional Access policy or MFA outage can permanently lock all administrators out of the tenant, requiring a time-consuming Microsoft Support escalation to recover.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access",
+          "title": "Microsoft Learn — Manage emergency access accounts in Microsoft Entra ID"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ADMIN-001",
@@ -127,7 +157,13 @@
       "cisaScubaControlId": "MS.AAD.1.1v1",
       "remediation": "Create two cloud-only emergency access accounts with permanent Global Administrator roles. Exclude from all Conditional Access policies. Store credentials offline. Entra admin center > Users > New user. Alert on any sign-in via Azure Monitor or Microsoft Sentinel.",
       "rationale": "Break-glass accounts are the recovery mechanism when normal admin access paths fail — MFA outages, misconfigured CA policies, or locked-out credentials. Without them, a configuration error can result in complete loss of tenant management capability.",
-      "impact": "Without break-glass accounts, a misconfigured Conditional Access policy that blocks all admin sign-ins makes the tenant unmanageable. Recovery requires a Microsoft Support escalation that can take hours or days."
+      "impact": "Without break-glass accounts, a misconfigured Conditional Access policy that blocks all admin sign-ins makes the tenant unmanageable. Recovery requires a Microsoft Support escalation that can take hours or days.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access",
+          "title": "Microsoft Learn — Manage emergency access accounts in Microsoft Entra ID"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-CLOUDADMIN-002",
@@ -423,7 +459,17 @@
       "cisaScubaControlId": "MS.DEFENDER.1.3v1",
       "remediation": "Run: New-SafeLinksPolicy -Name \"Safe Links\" -IsEnabled $true; New-SafeLinksRule -Name \"Safe Links\" -SafeLinksPolicy \"Safe Links\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Links > Create a policy covering all users.",
       "rationale": "Safe Links rewrites URLs in emails and Office documents and checks them at click time against Microsoft's threat intelligence. Without it, URLs pointing to malicious sites — including late-stage weaponized links that appear safe at delivery — are not blocked when the user clicks.",
-      "impact": "Users who click malicious URLs are taken directly to phishing pages, credential harvesters, or malware download sites. Time-of-click protection is the only defense against links weaponized after email delivery."
+      "impact": "Users who click malicious URLs are taken directly to phishing pages, credential harvesters, or malware download sites. Time-of-click protection is the only defense against links weaponized after email delivery.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/safe-links-about",
+          "title": "Microsoft Learn — Safe Links in Microsoft Defender for Office 365"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/safe-links-policies-configure",
+          "title": "Microsoft Learn — Set up Safe Links policies"
+        }
+      ]
     },
     {
       "checkId": "DEFENDER-ANTIMALWARE-001",
@@ -502,7 +548,17 @@
       "cisaScubaControlId": "MS.DEFENDER.1.3v1;MS.DEFENDER.3.1v1",
       "remediation": "Run: New-SafeAttachmentPolicy -Name \"Safe Attachments\" -Enable $true -Action Block; New-SafeAttachmentRule -Name \"Safe Attachments\" -SafeAttachmentPolicy \"Safe Attachments\" -RecipientDomainIs (Get-AcceptedDomain).Name. Security admin center > Safe Attachments > Create a policy covering all users.",
       "rationale": "Safe Attachments detonates email attachments in a sandbox before delivery, detecting zero-day malware that signature-based AV would miss. Without it, malicious attachments are only scanned with known signatures and delivered before sandbox analysis completes.",
-      "impact": "Zero-day malware and novel attack tools embedded in Office documents, PDFs, and archives are delivered to users. A single opened attachment can compromise an endpoint and provide an initial foothold in the organization."
+      "impact": "Zero-day malware and novel attack tools embedded in Office documents, PDFs, and archives are delivered to users. A single opened attachment can compromise an endpoint and provide an initial foothold in the organization.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/safe-attachments-about",
+          "title": "Microsoft Learn — Safe Attachments in Microsoft Defender for Office 365"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/safe-attachments-policies-configure",
+          "title": "Microsoft Learn — Set up Safe Attachments policies"
+        }
+      ]
     },
     {
       "checkId": "DEFENDER-SAFEATTACH-002",
@@ -599,7 +655,17 @@
       "cisaScubaControlId": "MS.EXO.3.1v1",
       "remediation": "Connect to Exchange Online and verify accepted domains.",
       "rationale": "SPF (Sender Policy Framework) authorizes which mail servers may send email on behalf of your domain. Without an SPF record, receiving servers cannot verify that email from your domain is legitimate, enabling spoofing and reducing deliverability of legitimate email.",
-      "impact": "Attackers can send email appearing to come from your domain without SPF, DKIM, or DMARC to block them. Phishing campaigns impersonating your organization are more effective when the sending domain has no authentication."
+      "impact": "Attackers can send email appearing to come from your domain without SPF, DKIM, or DMARC to block them. Phishing campaigns impersonating your organization are more effective when the sending domain has no authentication.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/email-authentication-spf-configure",
+          "title": "Microsoft Learn — Set up SPF to help prevent spoofing"
+        },
+        {
+          "url": "https://www.rfc-editor.org/rfc/rfc7208",
+          "title": "RFC 7208 — Sender Policy Framework (SPF) for Authorizing Use of Domains in Email"
+        }
+      ]
     },
     {
       "checkId": "DNS-DKIM-001",
@@ -643,7 +709,17 @@
       "cisaScubaControlId": "MS.EXO.2.1v2;MS.EXO.2.2v3",
       "remediation": "Connect to Exchange Online and verify accepted domains.",
       "rationale": "DMARC (Domain-based Message Authentication, Reporting, and Conformance) instructs receiving mail servers to reject or quarantine emails that fail SPF and DKIM alignment checks, preventing domain impersonation. Without DMARC, any server can send emails that appear to come from your domain.",
-      "impact": "External attackers can send phishing emails appearing to originate from your organization's domain. Employees, customers, and partners receive convincing impersonation emails with no visual indicator of spoofing."
+      "impact": "External attackers can send phishing emails appearing to originate from your organization's domain. Employees, customers, and partners receive convincing impersonation emails with no visual indicator of spoofing.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/email-authentication-dmarc-configure",
+          "title": "Microsoft Learn — Use DMARC to validate email"
+        },
+        {
+          "url": "https://www.rfc-editor.org/rfc/rfc7489",
+          "title": "RFC 7489 — Domain-based Message Authentication, Reporting, and Conformance (DMARC)"
+        }
+      ]
     },
     {
       "checkId": "DEFENDER-MALWARE-002",
@@ -691,7 +767,13 @@
       ],
       "remediation": "Run: Set-HostedConnectionFilterPolicy -Identity <Policy> -IPAllowList @{}. Exchange admin center > Protection > Connection filter > Edit the policy and remove all IP allow list entries.",
       "rationale": "IP allow lists in the connection filter bypass all spam and malware filtering for connections from listed IPs. Shared hosting IPs, CDN exit nodes, and business partner ranges can be abused to relay malicious email that completely bypasses filtering.",
-      "impact": "Malicious email originating from or relayed through an allowed IP is delivered without spam, malware, or phishing inspection. A single compromised host on an allowlisted range can be used to deliver unfiltered malware to all users."
+      "impact": "Malicious email originating from or relayed through an allowed IP is delivered without spam, malware, or phishing inspection. A single compromised host on an allowlisted range can be used to deliver unfiltered malware to all users.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/connection-filter-policies-configure",
+          "title": "Microsoft Learn — Configure connection filter policies in EOP"
+        }
+      ]
     },
     {
       "checkId": "EXO-CONNFILTER-002",
@@ -733,7 +815,17 @@
       ],
       "remediation": "Remove all entries from the 'Allowed domains' list in inbound anti-spam policies. Defender portal > Email & Collaboration > Policies & rules > Threat policies > Anti-spam > edit each inbound policy > Allow & block lists > Allowed domains: remove all entries. Allowed domains bypass both spam and malware filtering.",
       "rationale": "Domains on the anti-spam allow list bypass all spam and malware filtering, including Safe Attachments and Safe Links. This is one of the highest-impact configuration errors in Exchange Online security — a single allowlisted domain eliminates all email-based protections for messages from that domain.",
-      "impact": "Phishing and malware emails originating from allowed domains are delivered to inboxes without any filtering. Attackers who control or compromise an allowed domain have an unobstructed channel for malicious emails."
+      "impact": "Phishing and malware emails originating from allowed domains are delivered to inboxes without any filtering. Attackers who control or compromise an allowed domain have an unobstructed channel for malicious emails.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-spam-protection-about",
+          "title": "Microsoft Learn — Anti-spam protection in EOP"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-spam-policies-configure",
+          "title": "Microsoft Learn — Configure anti-spam policies in EOP"
+        }
+      ]
     },
     {
       "checkId": "DEFENDER-OUTBOUND-001",
@@ -870,7 +962,13 @@
       ],
       "remediation": "Run: Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true. Microsoft Purview > Audit > Start recording user and admin activity.",
       "rationale": "Audit log search is the investigative capability for Microsoft 365 — every admin action, user sign-in, file access, and configuration change is recorded here. Without it enabled, incidents cannot be investigated.",
-      "impact": "Security incidents leave no forensic trail. Breach scope cannot be determined, compliance audit requirements cannot be met, and attackers can operate without leaving a detectable record."
+      "impact": "Security incidents leave no forensic trail. Breach scope cannot be determined, compliance audit requirements cannot be met, and attackers can operate without leaving a detectable record.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/audit-log-enable-disable",
+          "title": "Microsoft Learn — Turn auditing on or off"
+        }
+      ]
     },
     {
       "checkId": "COMPLIANCE-DLP-001",
@@ -893,7 +991,17 @@
       "cisaScubaControlId": "MS.DEFENDER.4.1v2;MS.DEFENDER.4.2v1",
       "remediation": "Microsoft Purview > Data loss prevention > Policies > Create a DLP policy covering sensitive information types relevant to your organization.",
       "rationale": "Data loss prevention policies enforce data handling rules at the point of sharing, preventing users from accidentally or maliciously sending sensitive data (PII, financial, health) to unauthorized recipients.",
-      "impact": "Sensitive data can be sent externally via email, Teams, or file sharing without any controls, inspection, or audit trail. A single misdirected email or shared link can expose thousands of records."
+      "impact": "Sensitive data can be sent externally via email, Teams, or file sharing without any controls, inspection, or audit trail. A single misdirected email or shared link can expose thousands of records.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/dlp-learn-about-dlp",
+          "title": "Microsoft Learn — Learn about Microsoft Purview Data Loss Prevention"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/dlp-create-deploy-policy",
+          "title": "Microsoft Learn — Create and deploy a data loss prevention policy"
+        }
+      ]
     },
     {
       "checkId": "COMPLIANCE-DLP-002",
@@ -914,7 +1022,13 @@
       ],
       "remediation": "Microsoft Purview > Data loss prevention > Policies > Edit an existing policy or create new > Include Teams chat and channel messages location.",
       "rationale": "Teams is a primary communication channel where sensitive information is routinely shared in chat. Without DLP coverage for Teams, conversations containing PII, financial data, or credentials are not inspected or blocked.",
-      "impact": "Sensitive data shared in Teams chats or channels — including PII, payment card data, and internal credentials — is not detected or blocked, creating uncontrolled data exposure paths."
+      "impact": "Sensitive data shared in Teams chats or channels — including PII, payment card data, and internal credentials — is not detected or blocked, creating uncontrolled data exposure paths.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/dlp-microsoft-teams",
+          "title": "Microsoft Learn — Data loss prevention and Microsoft Teams"
+        }
+      ]
     },
     {
       "checkId": "COMPLIANCE-LABELS-001",
@@ -1037,7 +1151,13 @@
       ],
       "remediation": "Intune admin center > Devices > Compliance > Compliance policy settings > Mark devices with no compliance policy assigned as > Not compliant.",
       "rationale": "Devices without a compliance policy assignment are never evaluated against compliance requirements. These devices report as 'unknown' compliance state, and Conditional Access policies that require 'compliant' devices will not block them if the CA policy also allows the unknown state.",
-      "impact": "Unassigned devices bypass device compliance requirements in Conditional Access. An unmanaged or misconfigured device that reaches a 'compliant' CA policy without a compliance policy may be granted access based on an unchecked compliance state."
+      "impact": "Unassigned devices bypass device compliance requirements in Conditional Access. An unmanaged or misconfigured device that reaches a 'compliant' CA policy without a compliance policy may be granted access based on an unchecked compliance state.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/device-compliance-get-started",
+          "title": "Microsoft Learn — Use compliance policies to set rules for devices managed with Intune"
+        }
+      ]
     },
     {
       "checkId": "EXO-ANTIPHISH-001",
@@ -1060,7 +1180,17 @@
       "cisM365Profiles": [],
       "remediation": "Harden the anti-phishing policy. Defender portal > Email & Collaboration > Policies & rules > Threat policies > Anti-phishing > edit default policy: enable mailbox intelligence, enable impersonation protection for key users and domains, set action to Quarantine for impersonation and spoof detections.",
       "rationale": "The anti-phishing policy is the primary defense against impersonation attacks, including executive spoofing and lookalike domain phishing. Without hardened settings, impersonation attempts that bypass DMARC — using lookalike domains, display name spoofing, or compromised external accounts — land in user inboxes.",
-      "impact": "Phishing emails impersonating executives, vendors, or trusted contacts are delivered to users. Business email compromise (BEC) attacks that leverage impersonation cause direct financial loss and credential theft."
+      "impact": "Phishing emails impersonating executives, vendors, or trusted contacts are delivered to users. Business email compromise (BEC) attacks that leverage impersonation cause direct financial loss and credential theft.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-about",
+          "title": "Microsoft Learn — Anti-phishing policies in Microsoft 365"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-phishing-policies-mdo-configure",
+          "title": "Microsoft Learn — Configure anti-phishing policies in Defender for Office 365"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-ENROLL-001",
@@ -1122,7 +1252,17 @@
       "cisM365Profiles": [],
       "remediation": "Enable DKIM signing for each accepted domain. Defender portal > Email & Collaboration > Policies & rules > Threat policies > DKIM > select domain > Enable. Add the two provided CNAME records to your DNS zone before enabling.",
       "rationale": "DKIM (DomainKeys Identified Mail) signs outbound emails with a private key, allowing receivers to verify that the email content was not modified in transit and genuinely originated from your domain. DKIM is required for effective DMARC enforcement.",
-      "impact": "Email from your domain can be spoofed or tampered with in transit without detection. Without DKIM signatures, DMARC enforcement is weakened and phishing emails may pass alignment checks."
+      "impact": "Email from your domain can be spoofed or tampered with in transit without detection. Without DKIM signatures, DMARC enforcement is weakened and phishing emails may pass alignment checks.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/email-authentication-dkim-configure",
+          "title": "Microsoft Learn — Use DKIM to validate outbound email sent from your domain"
+        },
+        {
+          "url": "https://www.rfc-editor.org/rfc/rfc6376",
+          "title": "RFC 6376 — DomainKeys Identified Mail (DKIM) Signatures"
+        }
+      ]
     },
     {
       "checkId": "EXO-MALWARE-001",
@@ -1145,7 +1285,13 @@
       "cisM365Profiles": [],
       "remediation": "Harden the anti-malware policy. Defender portal > Email & Collaboration > Policies & rules > Threat policies > Anti-malware > edit default policy: enable common attachments filter, enable ZAP, configure admin notifications.",
       "rationale": "The malware filter policy is the baseline anti-malware control for Exchange Online. Without proper configuration — common attachment filtering, ZAP, admin notifications — known malware file types are delivered, zero-hour threats linger in inboxes, and infections go unnoticed.",
-      "impact": "Malicious files (executables, script files, Office macros) are delivered to user inboxes. Infected emails delivered before signature updates are not retroactively quarantined without ZAP enabled."
+      "impact": "Malicious files (executables, script files, Office macros) are delivered to user inboxes. Infected emails delivered before signature updates are not retroactively quarantined without ZAP enabled.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/anti-malware-policies-configure",
+          "title": "Microsoft Learn — Configure anti-malware policies in EOP"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-PERUSER-001",
@@ -1196,7 +1342,17 @@
       "cisaScubaControlId": "MS.AAD.3.1v1;MS.AAD.3.2v2",
       "remediation": "Remove privileged admin accounts from Conditional Access policy exclusions. Entra admin center > Security > Conditional Access > review each policy's exclusions. Use PIM just-in-time activation instead of permanent CA exclusions. Retain only break-glass accounts as exclusions.",
       "rationale": "Conditional Access exclusions are necessary for break-glass scenarios but dangerous when applied to privileged admin accounts: an excluded admin bypasses every MFA and compliance requirement, making their credentials a high-value target with no authentication safeguards.",
-      "impact": "Admins in CA exclusion lists authenticate with only a username and password. Credential phishing or spray attacks against these accounts bypass all Conditional Access controls and gain unmediated admin access."
+      "impact": "Admins in CA exclusion lists authenticate with only a username and password. Credential phishing or spray attacks against these accounts bypass all Conditional Access controls and gain unmediated admin access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/troubleshoot-conditional-access",
+          "title": "Microsoft Learn — Troubleshoot Conditional Access policies"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access",
+          "title": "Microsoft Learn — Manage emergency access accounts in Microsoft Entra ID"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-APPS-001",
@@ -1619,7 +1775,17 @@
       ],
       "remediation": "Verify Password Hash Sync status in Azure AD Connect. Entra admin center > Identity > Hybrid management > Azure AD Connect.",
       "rationale": "Password hash sync ensures that Entra ID has a copy of password hashes from on-premises AD. Without it, leaked on-premises credentials cannot be detected by Entra ID's Identity Protection and compromised on-premises accounts can authenticate to cloud services with no cloud-side risk signal.",
-      "impact": "On-premises credential compromises are invisible to Entra ID Identity Protection when password hashes are not synced. Stolen on-premises credentials used in cloud authentication generate no risk signal and are not blocked by risk-based CA policies."
+      "impact": "On-premises credential compromises are invisible to Entra ID Identity Protection when password hashes are not synced. Stolen on-premises credentials used in cloud authentication generate no risk signal and are not blocked by risk-based CA policies.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/hybrid/connect/whatis-phs",
+          "title": "Microsoft Learn — What is password hash synchronization with Microsoft Entra ID?"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-risks",
+          "title": "Microsoft Learn — Risk detections in Microsoft Entra ID Protection"
+        }
+      ]
     },
     {
       "checkId": "EXO-TRANSPORT-002",
@@ -1638,7 +1804,17 @@
       "cisM365Profiles": [],
       "remediation": "Block automatic external forwarding via transport rule. Exchange Admin Center > Mail flow > Rules > New rule: apply to messages where recipient is outside the org and message type is Auto Forward > Block the message. Also disable auto-forwarding in the outbound anti-spam policy.",
       "rationale": "Automatic external forwarding allows users (or compromised accounts) to silently redirect email to external addresses. Without a transport rule blocking this, a single compromised mailbox becomes a persistent data exfiltration channel that survives credential rotation.",
-      "impact": "Compromised mailboxes with auto-forwarding rules silently exfiltrate all incoming email to attacker-controlled addresses. The exfiltration persists through password resets and MFA changes because the forwarding rule is not cleared by authentication remediation."
+      "impact": "Compromised mailboxes with auto-forwarding rules silently exfiltrate all incoming email to attacker-controlled addresses. The exfiltration persists through password resets and MFA changes because the forwarding rule is not cleared by authentication remediation.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/outbound-spam-policies-external-email-forwarding",
+          "title": "Microsoft Learn — Control automatic external email forwarding in Microsoft 365"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/exchange/security-and-compliance/mail-flow-rules/mail-flow-rules",
+          "title": "Microsoft Learn — Mail flow rules in Exchange Online"
+        }
+      ]
     },
     {
       "checkId": "CA-MFA-ADMIN-001",
@@ -1666,7 +1842,13 @@
       "stigControlId": "V-260337",
       "remediation": "Security Defaults enforces MFA for all admin roles. For granular control, disable Security Defaults and create Conditional Access policies.",
       "rationale": "Administrator accounts have access to sensitive configuration, user management, and data across the tenant. Without MFA, a stolen password provides immediate, unrestricted administrative access.",
-      "impact": "A phished or sprayed admin password gives full administrative access. Attackers can create backdoor accounts, disable security policies, and exfiltrate data before the incident is detected."
+      "impact": "A phished or sprayed admin password gives full administrative access. Attackers can create backdoor accounts, disable security policies, and exfiltrate data before the incident is detected.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-admin-mfa",
+          "title": "Microsoft Learn — Require MFA for administrators"
+        }
+      ]
     },
     {
       "checkId": "CA-MFA-ALL-001",
@@ -1694,7 +1876,17 @@
       "stigControlId": "V-260337",
       "remediation": "Security Defaults enforces MFA for all users. For granular control, disable Security Defaults and create Conditional Access policies.",
       "rationale": "MFA is the single most effective control against account takeover from phished or stolen credentials. Without MFA, any user with a compromised password is a lateral movement pivot point into the tenant.",
-      "impact": "Compromised user credentials give full access to email, Teams, SharePoint, and any app the user accesses. Business email compromise (BEC) attacks exploit standard user accounts to intercept payments and exfiltrate data."
+      "impact": "Compromised user credentials give full access to email, Teams, SharePoint, and any app the user accesses. Business email compromise (BEC) attacks exploit standard user accounts to intercept payments and exfiltrate data.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-all-users-mfa",
+          "title": "Microsoft Learn — Require MFA for all users"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/tutorial-enable-azure-mfa",
+          "title": "Microsoft Learn — Enable Microsoft Entra multifactor authentication"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-CA-001",
@@ -1716,7 +1908,13 @@
       "stigControlId": "V-260338",
       "remediation": "Create a Conditional Access policy blocking legacy authentication protocols. Entra admin center > Security > Conditional Access > New policy > Condition: Client apps = Other clients + Exchange ActiveSync clients > Grant: Block access. Monitor legacy auth sign-ins in the sign-in log before enforcing.",
       "rationale": "Legacy authentication protocols (Basic Auth, NTLM via IMAP/POP3/SMTP) do not support MFA. Any enabled legacy auth endpoint is a password-spray target that bypasses every MFA policy.",
-      "impact": "Attackers who identify and spray legacy auth endpoints can authenticate with only a username and password, bypassing all Conditional Access MFA requirements and gaining full account access."
+      "impact": "Attackers who identify and spray legacy auth endpoints can authenticate with only a username and password, bypassing all Conditional Access MFA requirements and gaining full account access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication",
+          "title": "Microsoft Learn — Block legacy authentication with Conditional Access"
+        }
+      ]
     },
     {
       "checkId": "CA-LEGACYAUTH-001",
@@ -1738,7 +1936,17 @@
       "stigControlId": "V-260338",
       "remediation": "Security Defaults blocks legacy authentication protocols. For granular control, disable Security Defaults and create Conditional Access policies.",
       "rationale": "Legacy authentication protocols (Basic Auth, NTLM over SMTP/IMAP/POP3) do not support MFA and cannot be evaluated by Conditional Access policies. Any user with legacy auth enabled is a viable target for password spray attacks that MFA cannot stop.",
-      "impact": "Attackers can spray passwords against legacy protocol endpoints and authenticate successfully even when CA MFA policies are in place. A single compromised account via legacy auth gives full mailbox and Graph API access."
+      "impact": "Attackers can spray passwords against legacy protocol endpoints and authenticate successfully even when CA MFA policies are in place. A single compromised account via legacy auth gives full mailbox and Graph API access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication",
+          "title": "Microsoft Learn — Block legacy authentication with Conditional Access"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/disable-basic-authentication-in-exchange-online",
+          "title": "Microsoft Learn — Disable Basic authentication in Exchange Online"
+        }
+      ]
     },
     {
       "checkId": "CA-SIGNIN-FREQ-001",
@@ -1789,7 +1997,17 @@
       "stigControlId": "V-260339",
       "remediation": "Create a CA policy: Target admin roles > Grant > Require authentication strength > Phishing-resistant MFA. Entra admin center > Protection > Conditional Access.",
       "rationale": "Standard MFA (TOTP, push notification, SMS) is bypassed by AiTM phishing toolkits (e.g., Evilginx, Modlishka) that relay authentication in real time and capture session cookies. Phishing-resistant MFA (FIDO2, Windows Hello, certificate-based) is cryptographically bound to the origin and cannot be relayed by an attacker-controlled proxy.",
-      "impact": "Privileged accounts protected only by TOTP or push MFA are vulnerable to real-time AiTM session hijacking. Attackers capture the post-MFA session token and have full authenticated access without the MFA device."
+      "impact": "Privileged accounts protected only by TOTP or push MFA are vulnerable to real-time AiTM session hijacking. Attackers capture the post-MFA session token and have full authenticated access without the MFA device.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths",
+          "title": "Microsoft Learn — Authentication strengths overview"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-passwordless-security-key",
+          "title": "Microsoft Learn — Enable FIDO2 security key sign-in"
+        }
+      ]
     },
     {
       "checkId": "CA-USERRISK-001",
@@ -1813,7 +2031,17 @@
       "stigControlId": "V-260341",
       "remediation": "Create a CA policy: Target All users > Conditions > User risk > High > Grant > Require password change + MFA. Entra admin center > Protection > Conditional Access.",
       "rationale": "User risk reflects cumulative signals of account compromise — leaked credentials, unusual behavior patterns, and threat intelligence. Without user-risk policies, compromised accounts identified by Identity Protection remain active and accessible until manually reviewed.",
-      "impact": "Users whose credentials are detected in breach databases or flagged by threat intelligence can continue authenticating normally. Attackers with purchased or leaked credentials encounter no additional friction."
+      "impact": "Users whose credentials are detected in breach databases or flagged by threat intelligence can continue authenticating normally. Attackers with purchased or leaked credentials encounter no additional friction.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies",
+          "title": "Microsoft Learn — Configure and enable risk policies"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-protection/concept-identity-protection-risks",
+          "title": "Microsoft Learn — What are risk detections?"
+        }
+      ]
     },
     {
       "checkId": "CA-SIGNINRISK-001",
@@ -1837,7 +2065,13 @@
       "stigControlId": "V-260340",
       "remediation": "Create a CA policy: Target All users > Conditions > Sign-in risk > High, Medium > Grant > Require MFA. Entra admin center > Protection > Conditional Access.",
       "rationale": "Entra ID Identity Protection generates real-time risk scores for sign-in events based on behavioral signals such as impossible travel, atypical locations, and token anomalies. Without risk-based CA policies, these signals are generated but never acted upon — the sign-in succeeds regardless of risk level.",
-      "impact": "High-risk sign-in events (indicating probable account compromise) proceed without any remediation challenge. Attackers operating from anomalous locations or with stolen tokens can authenticate successfully."
+      "impact": "High-risk sign-in events (indicating probable account compromise) proceed without any remediation challenge. Attackers operating from anomalous locations or with stolen tokens can authenticate successfully.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-protection/howto-identity-protection-configure-risk-policies",
+          "title": "Microsoft Learn — Configure and enable risk policies"
+        }
+      ]
     },
     {
       "checkId": "CA-SIGNINRISK-002",
@@ -1861,7 +2095,13 @@
       "stigControlId": "V-260340",
       "remediation": "Security Defaults blocks high-risk sign-ins but does not provide granular medium-risk controls. For full coverage, disable Security Defaults and create Conditional Access policies with Entra ID P2.",
       "rationale": "Medium and high sign-in risk signals indicate a strong likelihood of account compromise. Blocking rather than challenging these sign-ins eliminates the possibility that an attacker could intercept the MFA challenge in a real-time relay attack.",
-      "impact": "Sign-ins flagged at medium or high risk are allowed to complete MFA and gain access. An attacker performing AiTM phishing can relay the MFA challenge in real time and capture the authenticated session."
+      "impact": "Sign-ins flagged at medium or high risk are allowed to complete MFA and gain access. An attacker performing AiTM phishing can relay the MFA challenge in real time and capture the authenticated session.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-conditions#sign-in-risk",
+          "title": "Microsoft Learn — Sign-in risk condition in Conditional Access"
+        }
+      ]
     },
     {
       "checkId": "CA-DEVICE-001",
@@ -1884,7 +2124,17 @@
       "cisaScubaControlId": "MS.AAD.3.6v1",
       "remediation": "Create a CA policy: Target All users > All cloud apps > Grant > Require device to be marked as compliant (or Hybrid Azure AD joined). Entra admin center > Protection > Conditional Access.",
       "rationale": "Device compliance is a key pillar of Zero Trust: verify explicitly that the device is managed, patched, and meets security requirements before granting access. Without device trust as a signal, corporate credentials on a compromised personal device are sufficient for full access.",
-      "impact": "Session tokens stolen from unmanaged or compromised devices provide full access to corporate resources. Malware running on the device can exfiltrate tokens and replay them from attacker-controlled infrastructure."
+      "impact": "Session tokens stolen from unmanaged or compromised devices provide full access to corporate resources. Malware running on the device can exfiltrate tokens and replay them from attacker-controlled infrastructure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-grant",
+          "title": "Microsoft Learn — Conditional Access grant controls (require compliant device)"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-compliant-device",
+          "title": "Microsoft Learn — Require compliant or hybrid joined device"
+        }
+      ]
     },
     {
       "checkId": "CA-DEVICE-002",
@@ -1954,7 +2204,17 @@
       ],
       "remediation": "Create a CA policy: Target All users > Conditions > Authentication flows > Device code flow > Grant > Block access. Entra admin center > Protection > Conditional Access.",
       "rationale": "The device code flow is designed for devices without browsers (e.g., TV apps). Attackers abuse it in device code phishing: they generate a code, convince a user to enter it, and receive a fully authenticated session token without any MFA interaction from the attacker's machine.",
-      "impact": "A user who enters a device code presented by an attacker hands over a session token with full user permissions. The attack is invisible in sign-in logs because the authentication appears to originate from the user's location."
+      "impact": "A user who enters a device code presented by an attacker hands over a session token with full user permissions. The attack is invisible in sign-in logs because the authentication appears to originate from the user's location.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-authentication-flows#device-code-flow",
+          "title": "Microsoft Learn — Authentication flows in Conditional Access (device code flow)"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/plan-conditional-access",
+          "title": "Microsoft Learn — Plan a Conditional Access deployment"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-AUTHMETHOD-003",
@@ -2051,7 +2311,17 @@
       ],
       "remediation": "Run: Update-MgBetaPolicyAuthenticationMethodPolicy with RegistrationEnforcement settings. Entra admin center > Protection > Authentication methods > Registration campaign.",
       "rationale": "MFA capability means the user has registered at least one MFA method. Without a registered method, MFA policies cannot be enforced for the user even if Conditional Access requires it — they fall back to password-only authentication.",
-      "impact": "Users without registered MFA methods bypass MFA enforcement in Conditional Access policies. Their accounts are vulnerable to password-only attacks despite MFA policies appearing to be in place."
+      "impact": "Users without registered MFA methods bypass MFA enforcement in Conditional Access policies. Their accounts are vulnerable to password-only attacks despite MFA policies appearing to be in place.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-mfa-userdevicesettings",
+          "title": "Microsoft Learn — Manage user authentication methods"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-mfa-licensing",
+          "title": "Microsoft Learn — Features and licenses for Microsoft Entra multifactor authentication"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-AUTHMETHOD-001",
@@ -2170,7 +2440,17 @@
       "cisM365Profiles": [],
       "remediation": "Enable unified audit logging. Purview compliance portal > Audit > Search > Start recording user and admin activity. PowerShell: Set-AdminAuditLogConfig -UnifiedAuditLogIngestionEnabled $true",
       "rationale": "Unified audit logging is the foundation of incident response and forensic investigation in Microsoft 365. Without it, there is no record of who accessed what, when, or what configuration changes were made.",
-      "impact": "Security incidents cannot be investigated, breaches cannot be scoped, and compliance audits cannot be satisfied. Attackers can operate for extended periods without any log trail to detect or reconstruct their activities."
+      "impact": "Security incidents cannot be investigated, breaches cannot be scoped, and compliance audits cannot be satisfied. Attackers can operate for extended periods without any log trail to detect or reconstruct their activities.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/audit-log-enable-disable",
+          "title": "Microsoft Learn — Turn auditing on or off"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/audit-solutions-overview",
+          "title": "Microsoft Learn — Microsoft Purview Audit overview"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-PIM-001",
@@ -2196,7 +2476,13 @@
       "stigControlId": "V-260336",
       "remediation": "Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles > Global Administrator > Remove permanent active assignments. Use eligible assignments with time-bound activation.",
       "rationale": "Permanently active privileged roles maintain standing admin access with no time limit or justification requirement. JIT access via PIM limits the window of exposure: even if admin credentials are compromised, the attacker can only act during the brief activation window.",
-      "impact": "Permanently active admin accounts are available for abuse at any time. Credential compromise provides persistent, immediately usable admin access with no activation step to trigger alerts."
+      "impact": "Permanently active admin accounts are available for abuse at any time. Credential compromise provides persistent, immediately usable admin access with no activation step to trigger alerts.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure",
+          "title": "Microsoft Learn — What is Microsoft Entra Privileged Identity Management?"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-PIM-002",
@@ -2240,7 +2526,13 @@
       "cisaScubaControlId": "MS.AAD.7.3v1",
       "remediation": "Entra admin center > Identity Governance > Access reviews > New access review > Review type: Members of a group or Users assigned to a privileged role.",
       "rationale": "Access reviews for privileged roles detect and remove stale, unnecessary, or unauthorized role assignments. Without periodic reviews, accumulation of privileged role assignments creates lateral movement opportunities and violates least-privilege principles.",
-      "impact": "Stale privileged role assignments accumulate over time. Former employees, moved employees, or compromised accounts that retain role assignments provide persistent attack vectors that are never automatically detected or removed."
+      "impact": "Stale privileged role assignments accumulate over time. Former employees, moved employees, or compromised accounts that retain role assignments provide persistent attack vectors that are never automatically detected or removed.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-create-roles-and-resource-roles-review",
+          "title": "Microsoft Learn — Create an access review of Azure resource and Microsoft Entra roles in PIM"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-PIM-004",
@@ -2260,7 +2552,13 @@
       "cisaScubaControlId": "MS.AAD.7.8v1",
       "remediation": "Entra admin center > Identity Governance > PIM > Azure AD roles > Settings > Global Administrator > Require approval to activate > Yes.",
       "rationale": "The Global Administrator role provides complete control over the tenant. Requiring approval for activation means that even a compromised account cannot self-activate the role — an approver must confirm the activation request before access is granted.",
-      "impact": "Without approval requirements, a compromised account with eligible Global Administrator assignment can self-activate the role immediately, granting full tenant control with no human verification required."
+      "impact": "Without approval requirements, a compromised account with eligible Global Administrator assignment can self-activate the role immediately, granting full tenant control with no human verification required.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings",
+          "title": "Microsoft Learn — Configure Microsoft Entra role settings in PIM"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-PIM-005",
@@ -2280,7 +2578,13 @@
       "cisaScubaControlId": "MS.AAD.7.9v1",
       "remediation": "Entra admin center > Identity Governance > PIM > Azure AD roles > Settings > Privileged Role Administrator > Require approval to activate > Yes.",
       "rationale": "The Privileged Role Administrator role controls who has access to other privileged roles. Without approval requirements, a compromised account eligible for this role can assign itself or others to any directory role, including Global Administrator.",
-      "impact": "A compromised account with eligible Privileged Role Administrator assignment can activate the role, then assign Global Administrator to any account, bypassing all access controls in a single step."
+      "impact": "A compromised account with eligible Privileged Role Administrator assignment can activate the role, then assign Global Administrator to any account, bypassing all access controls in a single step.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings",
+          "title": "Microsoft Learn — Configure Microsoft Entra role settings in PIM"
+        }
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-001",
@@ -2320,7 +2624,13 @@
       "cisM365Profiles": [],
       "remediation": "Create a device compliance policy requiring BitLocker, secure boot, and minimum OS version. Intune > Devices > Compliance policies > Create policy > Windows 10 and later. Combine with a Conditional Access policy blocking non-compliant devices from accessing corporate resources.",
       "rationale": "A device compliance policy baseline establishes the minimum security posture required for a managed device. Without it, devices with disabled AV, missing encryption, or outdated OS are evaluated as compliant and receive full access to corporate resources.",
-      "impact": "Devices with critical security gaps — disabled BitLocker, no secure boot, outdated OS — are treated as compliant by Conditional Access and receive full resource access, despite being at high risk of compromise."
+      "impact": "Devices with critical security gaps — disabled BitLocker, no secure boot, outdated OS — are treated as compliant by Conditional Access and receive full resource access, despite being at high risk of compromise.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/device-compliance-get-started",
+          "title": "Microsoft Learn — Use compliance policies to set rules for devices managed with Intune"
+        }
+      ]
     },
     {
       "checkId": "COMPLIANCE-ALERTPOLICY-001",
@@ -2343,7 +2653,13 @@
       "cisM365Profiles": [],
       "remediation": "Microsoft Purview > Alert policies > Review and enable default alert policies. Ensure high-severity policies for suspicious activity, malware, and privilege escalation are active.",
       "rationale": "Alert policies detect anomalous tenant activity — mass data downloads, unusual external sharing, admin permission changes — and notify security teams in near-real-time. Without them, security events are only discovered during periodic log reviews.",
-      "impact": "Anomalous activity such as a user downloading thousands of files or a new admin being created goes undetected until a manual audit or external report. Incident response is delayed by hours or days."
+      "impact": "Anomalous activity such as a user downloading thousands of files or a new admin being created goes undetected until a manual audit or external report. Incident response is delayed by hours or days.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/alert-policies",
+          "title": "Microsoft Learn — Alert policies in Microsoft Purview"
+        }
+      ]
     },
     {
       "checkId": "EXO-AUDIT-001",
@@ -2420,7 +2736,13 @@
       "cisM365Profiles": [],
       "remediation": "Enable BitLocker via Intune endpoint protection policy. Intune > Devices > Configuration profiles > Endpoint protection > BitLocker > require TPM startup, encrypt all drives, back up recovery keys to Entra ID. Assign to all managed Windows device groups.",
       "rationale": "Full-disk encryption (BitLocker) protects data at rest on managed devices. Without it, a lost or stolen device provides physical access to all locally stored corporate data without any password or authentication requirement.",
-      "impact": "A stolen device without disk encryption exposes all locally cached email, documents, credentials, and browser data to anyone with physical access. Data recovery requires no credentials — only attaching the drive to another system."
+      "impact": "A stolen device without disk encryption exposes all locally cached email, documents, credentials, and browser data to anyone with physical access. Data recovery requires no credentials — only attaching the drive to another system.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/encrypt-devices",
+          "title": "Microsoft Learn — Use BitLocker encryption for Windows devices"
+        }
+      ]
     },
     {
       "checkId": "DEFENDER-SECURESCORE-001",
@@ -2464,7 +2786,13 @@
       "cisaScubaControlId": "MS.EXO.1.1v2",
       "remediation": "Run: Set-RemoteDomain -Identity Default -AutoForwardEnabled $false. Also consider transport rules to block client-side forwarding.",
       "rationale": "External mail forwarding creates persistent data exfiltration paths — every email received is silently copied to an external address. Attackers who compromise mailboxes routinely create forwarding rules as a persistence mechanism that survives password resets.",
-      "impact": "All email to a mailbox with an external forwarding rule is exfiltrated silently. The rule survives password changes and MFA re-enrollment, providing persistent mail access long after an account compromise is detected and remediated."
+      "impact": "All email to a mailbox with an external forwarding rule is exfiltrated silently. The rule survives password changes and MFA re-enrollment, providing persistent mail access long after an account compromise is detected and remediated.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-office-365/outbound-spam-policies-external-email-forwarding",
+          "title": "Microsoft Learn — Control automatic external email forwarding in Microsoft 365"
+        }
+      ]
     },
     {
       "checkId": "EXO-TRANSPORT-001",
@@ -2648,7 +2976,13 @@
       "cisaScubaControlId": "MS.EXO.5.1v1",
       "remediation": "Run: Set-TransportConfig -SmtpClientAuthenticationDisabled $true. Disable SMTP AUTH org-wide and enable per-mailbox only where required.",
       "rationale": "SMTP AUTH is a legacy protocol that supports Basic Authentication and is used for sending email from devices and applications. If enabled globally, any client can attempt to authenticate to Exchange using only a username and password, bypassing all modern authentication controls.",
-      "impact": "Attackers can spray passwords against the SMTP AUTH endpoint to compromise mailboxes and use them as relay points for spam, phishing, or internal reconnaissance — all with only a valid username and password."
+      "impact": "Attackers can spray passwords against the SMTP AUTH endpoint to compromise mailboxes and use them as relay points for spam, phishing, or internal reconnaissance — all with only a valid username and password.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/authenticated-client-smtp-submission",
+          "title": "Microsoft Learn — Enable or disable authenticated client SMTP submission (SMTP AUTH)"
+        }
+      ]
     },
     {
       "checkId": "EXO-DIRECTSEND-001",
@@ -2667,7 +3001,13 @@
       "cisM365Profiles": [],
       "remediation": "Connect to Exchange Online PowerShell to check inbound connector configuration.",
       "rationale": "Direct send allows unauthenticated email delivery from internal IP ranges without credentials. Without controls on which systems are authorized to send, any device that can reach Exchange Online can send email appearing to originate from your domain — a spoofing and BEC enabler.",
-      "impact": "An attacker or compromised device on an allowed IP range can send spoofed email appearing to come from any address in your domain, bypassing DMARC (which does not apply to internal relay), enabling BEC and executive impersonation campaigns."
+      "impact": "An attacker or compromised device on an allowed IP range can send spoofed email appearing to come from any address in your domain, bypassing DMARC (which does not apply to internal relay), enabling BEC and executive impersonation campaigns.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-microsoft-365-or-office-365",
+          "title": "Microsoft Learn — How to set up a multifunction device to send email using Microsoft 365"
+        }
+      ]
     },
     {
       "checkId": "SPO-AUTH-001",
@@ -2689,7 +3029,17 @@
       ],
       "remediation": "Run: Set-SPOTenant -LegacyAuthProtocolsEnabled $false. SharePoint admin center > Policies > Access control > Apps that do not use modern authentication > Block access.",
       "rationale": "Legacy SharePoint authentication (pre-modern) does not support MFA, Conditional Access, or token-based controls. Applications using legacy SharePoint auth bypass all modern authentication security controls enforced via CA.",
-      "impact": "Applications or scripts using legacy SharePoint authentication authenticate with only a username and password, bypassing MFA and CA policies. Compromised credentials provide full SharePoint access without any additional control."
+      "impact": "Applications or scripts using legacy SharePoint authentication authenticate with only a username and password, bypassing MFA and CA policies. Compromised credentials provide full SharePoint access without any additional control.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/control-access-from-unmanaged-devices",
+          "title": "Microsoft Learn — Control access from unmanaged devices"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoft-365/admin/security-and-compliance/set-up-multi-factor-authentication",
+          "title": "Microsoft Learn — Set up multifactor authentication for Microsoft 365"
+        }
+      ]
     },
     {
       "checkId": "SPO-B2B-001",
@@ -2740,7 +3090,13 @@
       ],
       "remediation": "Run: Set-SPOTenant -SharingCapability ExistingExternalUserSharingOnly. SharePoint admin center > Policies > Sharing.",
       "rationale": "SharePoint is a primary repository for sensitive organizational documents. Unrestricted external sharing allows any user to share any document with any email address, bypassing data classification controls and creating permanent unauthenticated access links.",
-      "impact": "Sensitive documents including financial data, PII, and IP can be shared externally without audit or approval. Anonymous sharing links persist indefinitely and are discoverable by search engines if not restricted."
+      "impact": "Sensitive documents including financial data, PII, and IP can be shared externally without audit or approval. Anonymous sharing links persist indefinitely and are discoverable by search engines if not restricted.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        }
+      ]
     },
     {
       "checkId": "SPO-OD-001",
@@ -2766,7 +3122,13 @@
       ],
       "remediation": "SharePoint admin center > Policies > Sharing > OneDrive > set to \"Existing guests\" or more restrictive.",
       "rationale": "Unrestricted OneDrive sharing allows users to share any file with anyone externally via anonymous links. OneDrive is connected to SharePoint and subject to the same data exfiltration risks as corporate file servers.",
-      "impact": "Sensitive files stored in OneDrive can be shared externally via unauthenticated anonymous links. A user can exfiltrate any file they have access to — including synchronized SharePoint content — without DLP inspection."
+      "impact": "Sensitive files stored in OneDrive can be shared externally via unauthenticated anonymous links. A user can exfiltrate any file they have access to — including synchronized SharePoint content — without DLP inspection.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        }
+      ]
     },
     {
       "checkId": "SPO-SHARING-002",
@@ -2836,7 +3198,17 @@
       ],
       "remediation": "Run: Set-SPOTenant -DefaultSharingLinkType Direct. SharePoint admin center > Policies > Sharing > File and folder links > Default link type > Specific people.",
       "rationale": "Shareable links that grant access to 'anyone with the link' bypass all identity and device controls. A single leaked link is sufficient to expose the target content to any person, device, or automated system worldwide.",
-      "impact": "Documents shared via Anyone links are accessible without authentication. Links shared in emails, chats, or indexed by search engines expose content permanently, with no audit trail of who accessed it."
+      "impact": "Documents shared via Anyone links are accessible without authentication. Links shared in emails, chats, or indexed by search engines expose content permanently, with no audit trail of who accessed it.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/change-default-sharing-link",
+          "title": "Microsoft Learn — Change the default link type for SharePoint and OneDrive"
+        }
+      ]
     },
     {
       "checkId": "SPO-SHARING-008",
@@ -2952,7 +3324,13 @@
       ],
       "remediation": "Run: Set-SPOTenant -DisallowInfectedFileDownload $true. SharePoint admin center > Policies > Malware protection.",
       "rationale": "SharePoint file storage can be used to host and distribute malware if infected file quarantine is disabled. A malware-infected document uploaded to SharePoint can be synced to all users who have access to the library, spreading the infection across the organization.",
-      "impact": "An infected document uploaded to SharePoint is synced to all users via OneDrive sync clients. A single malicious file can reach hundreds or thousands of endpoints before manual detection."
+      "impact": "An infected document uploaded to SharePoint is synced to all users via OneDrive sync clients. A single malicious file can reach hundreds or thousands of endpoints before manual detection.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/safeguarding-your-data",
+          "title": "Microsoft Learn — How SharePoint safeguards your data"
+        }
+      ]
     },
     {
       "checkId": "SPO-SYNC-001",
@@ -2994,7 +3372,13 @@
       "cisM365Profiles": [],
       "remediation": "Run: Set-SPOSite -Identity <PersonalSiteUrl> -DenyAddAndCustomizePages 1. SharePoint admin center > Settings > Custom Script > prevent users from running custom script on personal sites.",
       "rationale": "Custom scripts on personal sites can execute arbitrary JavaScript in the SharePoint context, enabling attacks that capture user credentials, exfiltrate content, or manipulate SharePoint data using the victim user's session.",
-      "impact": "An attacker or insider who adds a malicious custom script to a SharePoint personal site can steal session cookies, exfiltrate documents, or perform actions in the SharePoint context on behalf of any user who visits the site."
+      "impact": "An attacker or insider who adds a malicious custom script to a SharePoint personal site can steal session cookies, exfiltrate documents, or perform actions in the SharePoint context on behalf of any user who visits the site.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/allow-or-prevent-custom-script",
+          "title": "Microsoft Learn — Allow or prevent custom script"
+        }
+      ]
     },
     {
       "checkId": "SPO-SCRIPT-002",
@@ -3014,7 +3398,13 @@
       "cisM365Profiles": [],
       "remediation": "Run: Set-SPOTenant -DenyAddAndCustomizePagesForSitesCreatedByUser 1. SharePoint admin center > Settings > Custom Script > prevent users from running custom script on self-service created sites.",
       "rationale": "Custom scripts on site collections allow arbitrary JavaScript execution in the SharePoint context. Without restriction, any site collection administrator can inject code that affects all users of that site.",
-      "impact": "A compromised site collection administrator can inject persistent malicious JavaScript into a SharePoint site, affecting all users who access it — enabling credential theft, data exfiltration, and session hijacking at scale."
+      "impact": "A compromised site collection administrator can inject persistent malicious JavaScript into a SharePoint site, affecting all users who access it — enabling credential theft, data exfiltration, and session hijacking at scale.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/allow-or-prevent-custom-script",
+          "title": "Microsoft Learn — Allow or prevent custom script"
+        }
+      ]
     },
     {
       "checkId": "TEAMS-GUEST-001",
@@ -3035,7 +3425,13 @@
       "cisM365Profiles": [],
       "remediation": "Disable or restrict guest access. Teams Admin Center > Org-wide settings > Guest access > Allow guest access in Teams: Off, or restrict calling, meeting, and messaging settings to the minimum required for external collaboration.",
       "rationale": "Guest access to Teams allows external users to participate in channels, chats, and meetings, and by default access the files and conversations in those channels. Without restrictions, any external user invited as a guest can see sensitive internal conversations and documents.",
-      "impact": "External guest users added to Teams channels can access all historical messages and files in those channels. Sensitive business discussions, shared documents, and strategic information are visible to unvetted external parties."
+      "impact": "External guest users added to Teams channels can access all historical messages and files in those channels. Sensitive business discussions, shared documents, and strategic information are visible to unvetted external parties.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoftteams/set-up-guests",
+          "title": "Microsoft Learn — Turn guest access on or off in Microsoft Teams"
+        }
+      ]
     },
     {
       "checkId": "PBI-TENANT-001",
@@ -3122,7 +3518,13 @@
       "cisM365Profiles": [],
       "remediation": "Disable or restrict 'Publish to web'. Power BI Admin portal > Tenant settings > Export and sharing settings > Publish to web: Disabled or Apply to specific security groups. Revoke existing public embed codes via Power BI Admin portal > Embed Codes.",
       "rationale": "'Publish to web' creates unauthenticated, publicly accessible embed codes for Power BI content. Any report published this way is accessible to anyone with the URL, with no authentication, no access control, and no audit trail.",
-      "impact": "Reports published to web are publicly accessible and may be indexed by search engines. Sensitive operational, financial, or customer data embedded in a published report is exposed to the internet indefinitely."
+      "impact": "Reports published to web are publicly accessible and may be indexed by search engines. Sensitive operational, financial, or customer data embedded in a published report is exposed to the internet indefinitely.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/power-bi/admin/service-admin-portal-export-sharing",
+          "title": "Microsoft Learn — Power BI export and sharing settings"
+        }
+      ]
     },
     {
       "checkId": "TEAMS-EXTACCESS-003",
@@ -3277,7 +3679,13 @@
       ],
       "remediation": "Run: Set-CsTeamsMeetingPolicy -Identity Global -AllowAnonymousUsersToJoinMeeting $false. Teams admin center > Meetings > Meeting policies > Global > Anonymous users can join a meeting > Off.",
       "rationale": "Anonymous meeting join allows any user with the meeting link — including those without an account — to join Teams meetings. Meeting links shared accidentally expose internal business discussions to uninvited external parties.",
-      "impact": "Meeting links forwarded or accidentally shared publicly allow unauthorized parties to join internal meetings. Sensitive business discussions, strategy sessions, and confidential presentations can be observed by anonymous attendees."
+      "impact": "Meeting links forwarded or accidentally shared publicly allow unauthorized parties to join internal meetings. Sensitive business discussions, strategy sessions, and confidential presentations can be observed by anonymous attendees.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoftteams/meeting-settings-in-teams",
+          "title": "Microsoft Learn — Manage meeting settings in Microsoft Teams"
+        }
+      ]
     },
     {
       "checkId": "TEAMS-MEETING-002",
@@ -4005,7 +4413,17 @@
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Disable SSPR for administrator accounts. Entra admin center > Protection > Password reset > Properties > set scope to Selected and exclude accounts holding directory roles. Admin password resets should follow a governed helpdesk or PIM workflow.",
       "rationale": "Self-service password reset for administrator accounts is a social engineering risk. If an attacker can trick the SSPR verification process (security questions, registered phone), they can reset the admin password and bypass MFA entirely.",
-      "impact": "A successful SSPR social engineering attack against an admin account provides a new password, effectively revoking any existing session and granting fresh access that does not trigger re-authentication requirements."
+      "impact": "A successful SSPR social engineering attack against an admin account provides a new password, effectively revoking any existing session and granting fresh access that does not trigger re-authentication requirements.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-sspr-howitworks",
+          "title": "Microsoft Learn — How Microsoft Entra self-service password reset works"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-sspr-deployment",
+          "title": "Microsoft Learn — Plan a Microsoft Entra self-service password reset deployment"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ROLEGROUP-001",
@@ -4023,7 +4441,13 @@
       "cisaScubaControlId": "MS.AAD.7.2v1",
       "remediation": "Replace unprotected groups in privileged role assignments with role-assignable groups. Entra admin center > Groups > New group > enable 'Azure AD roles can be assigned to the group'. Recreate the group and migrate the role assignment.",
       "rationale": "Groups used in privileged role assignments that lack the role-assignable property can have their membership modified by group owners or administrators who do not hold the role themselves. This creates an indirect privilege escalation path through group ownership.",
-      "impact": "An attacker who compromises a group owner account can add any user to a group that holds a privileged role, effectively granting that role without a direct role assignment or PIM activation."
+      "impact": "An attacker who compromises a group owner account can add any user to a group that holds a privileged role, effectively granting that role without a direct role assignment or PIM activation.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/groups-create-eligible",
+          "title": "Microsoft Learn — Create a role-assignable group in Microsoft Entra ID"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-PIM-010",
@@ -4066,7 +4490,13 @@
       "cisaScubaControlId": "MS.AAD.7.4v1",
       "remediation": "Disable or delete admin accounts inactive for 90+ days. Entra admin center > Users > sign-in activity column. Review active PIM eligible assignments (Identity Governance > PIM > Assignments) and remove stale principals.",
       "rationale": "Admin accounts that are no longer in use are dormant attack surfaces with standing privileged access. Stale accounts are often overlooked in security reviews and may retain credentials that were never rotated.",
-      "impact": "Credentials for stale admin accounts — whether from phishing, password reuse, or data breaches — provide persistent privileged access. Inactive accounts are rarely monitored, so sign-in activity from a stale account may go undetected for extended periods."
+      "impact": "Credentials for stale admin accounts — whether from phishing, password reuse, or data breaches — provide persistent privileged access. Inactive accounts are rarely monitored, so sign-in activity from a stale account may go undetected for extended periods.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/access-reviews-overview",
+          "title": "Microsoft Learn — What are access reviews in Microsoft Entra ID?"
+        }
+      ]
     },
     {
       "checkId": "FORMS-CONFIG-003",
@@ -4177,7 +4607,17 @@
       "cisaScubaControlId": "MS.INTUNE.1.3v1",
       "remediation": "Investigate: review Intune audit logs for the device wipe events immediately. Intune > Tenant administration > Audit logs > filter by DeviceAction: Wipe. Verify each wipe was authorized. Rotate credentials and initiate incident response if unauthorized activity is confirmed.",
       "rationale": "Mass device wipe activity is an indicator of either an insider threat action or an attacker who has compromised administrative credentials. Detecting this in real time limits the number of devices affected and enables rapid credential revocation.",
-      "impact": "An attacker or malicious insider with Intune write access can wipe all managed devices simultaneously, destroying data and disrupting operations across the entire device fleet before any manual detection."
+      "impact": "An attacker or malicious insider with Intune write access can wipe all managed devices simultaneously, destroying data and disrupting operations across the entire device fleet before any manual detection.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/remote-actions/device-management",
+          "title": "Microsoft Learn — Use the full Wipe, Retire, or manually Unenroll devices using Intune"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/fundamentals/monitor-audit-logs",
+          "title": "Microsoft Learn — Use audit logs to track and monitor events in Intune"
+        }
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-003",
@@ -4195,7 +4635,13 @@
       "impactRationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Teams channel messages and chats.",
       "rationale": "Teams messages and meeting recordings constitute business records subject to the same retention requirements as email. Without a retention policy, Teams data can be permanently deleted, destroying evidence of conversations, decisions, and security-relevant activity.",
-      "impact": "Teams conversations, channel messages, and meeting recordings that should be retained for compliance or legal hold purposes may be permanently deleted, creating the same exposure as email data without a retention policy."
+      "impact": "Teams conversations, channel messages, and meeting recordings that should be retained for compliance or legal hold purposes may be permanently deleted, creating the same exposure as email data without a retention policy.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/retention-policies-teams",
+          "title": "Microsoft Learn — Learn about retention for Microsoft Teams"
+        }
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-002",
@@ -4213,7 +4659,17 @@
       "impactRationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include Exchange email and mailboxes.",
       "rationale": "Email is the primary record of business communications and the most common target in litigation holds and regulatory audits. Without a retention policy, email data may be deleted before the legally required retention period, creating compliance exposure and destroying forensic evidence.",
-      "impact": "Email evidence required for legal holds, regulatory audits, or security investigations may be permanently deleted if no retention policy exists. Data loss creates compliance failures and impedes incident response."
+      "impact": "Email evidence required for legal holds, regulatory audits, or security investigations may be permanently deleted if no retention policy exists. Data loss creates compliance failures and impedes incident response.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/retention-policies-exchange",
+          "title": "Microsoft Learn — Learn about retention for Exchange"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/create-retention-policies",
+          "title": "Microsoft Learn — Create and configure retention policies"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-PIM-009",
@@ -4231,7 +4687,17 @@
       "cisM365ControlId": "",
       "remediation": "Set a time-bound expiry on eligible assignments for Tier-0 roles. Entra admin center > Identity Governance > PIM > Microsoft Entra roles > select role > Settings > Edit > Assignment tab > Expire eligible assignments after (e.g., 12 months). Remove existing permanent eligible assignments and reissue as time-bound.",
       "rationale": "Permanent eligible assignments allow role activation at any time without expiry. Time-bound eligible assignments limit the window during which a compromised account can activate a privileged role — after expiry, the assignment must be renewed through a governed process.",
-      "impact": "A compromised account with a permanent eligible assignment can activate privileged roles indefinitely. Time-bound assignments would limit the attack window, but permanent assignments remove this defense."
+      "impact": "A compromised account with a permanent eligible assignment can activate privileged roles indefinitely. Time-bound assignments would limit the attack window, but permanent assignments remove this defense.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings",
+          "title": "Microsoft Learn — Configure Microsoft Entra role settings in PIM"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-add-role-to-user",
+          "title": "Microsoft Learn — Assign Microsoft Entra roles in PIM"
+        }
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-004",
@@ -4249,7 +4715,13 @@
       "impactRationale": "Failure to retain event logs for a time period consistent with records retention requirements to provide support for after-the-fact investigations of security incidents and to meet statutory, regulatory and contractual retention requirements exposes the tenant to: Emergent.",
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Create or edit a retention policy to include SharePoint sites and OneDrive accounts.",
       "rationale": "SharePoint and OneDrive store documents, collaboration artifacts, and file-based records. Without a retention policy, files can be deleted before their required retention period expires, eliminating records needed for compliance, litigation, and forensic investigations.",
-      "impact": "Documents deleted from SharePoint or OneDrive without a retention policy are permanently purged after the recycle bin period. Records required for compliance attestation or incident investigation may be unrecoverable."
+      "impact": "Documents deleted from SharePoint or OneDrive without a retention policy are permanently purged after the recycle bin period. Records required for compliance attestation or incident investigation may be unrecoverable.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/retention-policies-sharepoint",
+          "title": "Microsoft Learn — Learn about retention for SharePoint and OneDrive"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-PIM-008",
@@ -4274,7 +4746,13 @@
       ],
       "remediation": "Require MFA on Tier-0 role activation. Entra admin center > Identity Governance > PIM > Microsoft Entra roles > select role > Settings > Edit > Activation tab > Require Azure MFA on activation.",
       "rationale": "PIM role activation without MFA requirement means a compromised account can activate Tier-0 roles using only the account's existing session — no MFA challenge at activation. This defeats the purpose of JIT access as a security control.",
-      "impact": "An attacker with a stolen session token or password for an eligible user can activate Tier-0 roles without any additional authentication factor, converting account access to full administrative access silently."
+      "impact": "An attacker with a stolen session token or password for an eligible user can activate Tier-0 roles without any additional authentication factor, converting account access to full administrative access silently.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-how-to-change-default-settings",
+          "title": "Microsoft Learn — Configure Microsoft Entra role settings in PIM"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-002",
@@ -4334,7 +4812,13 @@
       "cisaScubaControlId": "MS.AAD.1.1v1",
       "remediation": "Run: Update-MgPolicyIdentitySecurityDefaultsEnforcementPolicy -IsEnabled $true. Entra admin center > Properties > Manage security defaults.",
       "rationale": "Security Defaults enforce a baseline of MFA for all users and block legacy authentication — but they are incompatible with Conditional Access and are typically disabled when CA policies are in place. A tenant with Security Defaults disabled and insufficient CA policies has no enforced authentication baseline.",
-      "impact": "Tenants without Security Defaults and without equivalent CA policies have no enforced MFA, no legacy auth blocking, and no baseline protection. All users authenticate with passwords only unless individually configured."
+      "impact": "Tenants without Security Defaults and without equivalent CA policies have no enforced MFA, no legacy auth blocking, and no baseline protection. All users authenticate with passwords only unless individually configured.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults",
+          "title": "Microsoft Learn — Security defaults in Microsoft Entra ID"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-APPREG-001",
@@ -4577,7 +5061,13 @@
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Consider creating CA policies that specifically target privileged directory roles with stricter controls (phishing-resistant MFA, compliant devices).",
       "rationale": "Conditional Access policies that target directory roles by name only protect role members at policy evaluation time. Active role assignments added after policy creation are not covered until the policy explicitly includes them. Tier-0 roles without CA coverage are high-privilege accounts with no authentication requirements enforced by CA.",
-      "impact": "A Tier-0 role (e.g., Exchange Administrator, Security Administrator) not covered by CA policies has no enforced MFA, device compliance, or risk signal evaluation. Credential theft for these roles grants unmediated administrative access."
+      "impact": "A Tier-0 role (e.g., Exchange Administrator, Security Administrator) not covered by CA policies has no enforced MFA, device compliance, or risk signal evaluation. Credential theft for these roles grants unmediated administrative access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-users-groups",
+          "title": "Microsoft Learn — Users and groups in Conditional Access policy"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-001",
@@ -4614,7 +5104,17 @@
       "impactRationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Entra admin center > Enterprise applications > review foreign apps with Tier 0 permissions. These permissions have documented attack paths to Global Administrator. Remove or replace with least-privilege alternatives.",
       "rationale": "Applications with dangerous application permissions (not delegated) act as autonomous service accounts that can read, write, and delete data for all users without any user sign-in. Foreign (multi-tenant) apps with these permissions operate from outside the tenant's control plane.",
-      "impact": "A compromised foreign app with application-level permissions can access all user data in the tenant without a user session, without triggering user-based risk signals, and from infrastructure controlled by the publisher."
+      "impact": "A compromised foreign app with application-level permissions can access all user data in the tenant without a user session, without triggering user-based risk signals, and from infrastructure controlled by the publisher.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/graph/permissions-reference",
+          "title": "Microsoft Learn — Microsoft Graph permissions reference"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-004",
@@ -4631,7 +5131,13 @@
       "impactRationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Entra admin center > Enterprise applications > review foreign apps with high-privilege delegated permissions. Revoke admin consent or remove the app.",
       "rationale": "Dangerous delegated permissions grant an app the ability to act as any user who consented to the app. For foreign (multi-tenant) apps, this means the app publisher can trigger API actions using the delegated grant without the user's direct involvement after initial consent.",
-      "impact": "A foreign app with delegated permissions for Mail.ReadWrite or Files.ReadWrite.All can read, send, or delete email and files on behalf of any user who granted consent, enabling persistent exfiltration or impersonation."
+      "impact": "A foreign app with delegated permissions for Mail.ReadWrite or Files.ReadWrite.All can read, send, or delete email and files on behalf of any user who granted consent, enabling persistent exfiltration or impersonation.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-005",
@@ -4652,7 +5158,17 @@
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Entra admin center > Roles and administrators > review roles assigned to foreign service principals. Remove role assignments from untrusted external apps.",
       "rationale": "Entra ID directory roles assigned to foreign (multi-tenant) applications give the external publisher's service control-plane access to the tenant — the same access as a human administrator. These assignments persist across app updates and are not visible in standard role management views.",
-      "impact": "A foreign app with a directory role assignment (e.g., User Administrator, Exchange Administrator) can be used by the external publisher to manage your tenant. If the publisher is compromised, the attacker inherits your directory admin privileges."
+      "impact": "A foreign app with a directory role assignment (e.g., User Administrator, Exchange Administrator) can be used by the external publisher to manage your tenant. If the publisher is compromised, the attacker inherits your directory admin privileges.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/overview-assign-app-owners",
+          "title": "Microsoft Learn — Manage app owners"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-006",
@@ -4706,7 +5222,17 @@
       "impactRationale": "Failure to limit access to security functions to explicitly-authorized privileged users exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Review managed identity permissions. Use narrower permissions (e.g., Mail.Read instead of Mail.ReadWrite). Azure portal > Managed Identity > API permissions.",
       "rationale": "Managed identities are designed to eliminate secrets, but when assigned dangerous application permissions, they become powerful unmonitored agents: no credentials to steal, no MFA to bypass, and API access that scales across all tenant data.",
-      "impact": "A compromised Azure resource whose managed identity holds application-level Graph API permissions can be used to exfiltrate all user mail, read all files, or manipulate directory objects without any credential artifact to detect or rotate."
+      "impact": "A compromised Azure resource whose managed identity holds application-level Graph API permissions can be used to exfiltrate all user mail, read all files, or manipulate directory objects without any credential artifact to detect or rotate.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview",
+          "title": "Microsoft Learn — What are managed identities for Azure resources?"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-009",
@@ -4726,7 +5252,13 @@
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Review managed identities with directory roles. Use Graph API permissions instead of directory roles where possible. Entra admin center > Roles and administrators.",
       "rationale": "Managed identities assigned Entra directory roles operate as privileged administrative agents. Unlike service principals with secrets, managed identities cannot have their credentials rotated — the only remediation for a compromised managed identity is to remove its role assignments.",
-      "impact": "A compromised Azure resource with a managed identity holding a privileged Entra directory role provides administrative access to the tenant from within the Azure compute environment, which may have weaker security controls than the corporate network."
+      "impact": "A compromised Azure resource with a managed identity holding a privileged Entra directory role provides administrative access to the tenant from within the Azure compute environment, which may have weaker security controls than the corporate network.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview",
+          "title": "Microsoft Learn — What are managed identities for Azure resources?"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-GROUP-004",
@@ -4766,7 +5298,13 @@
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Convert sensitive security groups to role-assignable to prevent unauthorized membership changes. Entra admin center > Groups > New group > enable 'Azure AD roles can be assigned to the group'. Recreate affected groups and update any app role or CA policy assignments.",
       "rationale": "Security groups without the role-assignable property can have their membership modified by group owners and certain administrative roles without Global Administrator or Privileged Role Administrator approval. Groups used in Conditional Access policy or app role assignments are high-value targets for membership manipulation.",
-      "impact": "An attacker who compromises a group owner account can add themselves or other accounts to a sensitive group, gaining the access rights associated with that group — potentially including app role permissions or CA policy exclusions."
+      "impact": "An attacker who compromises a group owner account can add themselves or other accounts to a sensitive group, gaining the access rights associated with that group — potentially including app role permissions or CA policy exclusions.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/groups-create-eligible",
+          "title": "Microsoft Learn — Create a role-assignable group in Microsoft Entra ID"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-GROUP-006",
@@ -4805,7 +5343,13 @@
       "impactRationale": "Failure to restrict the assignment of privileged accounts to management-approved personnel and/or roles exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Remove Tier-0/1 Entra directory roles from on-premises synced user accounts. Entra admin center > Users > filter synced accounts > review role assignments. Create cloud-only replacement accounts and migrate role assignments; on-premises compromise must not reach cloud privilege.",
       "rationale": "On-premises synced accounts are controlled by on-premises Active Directory. When these accounts hold Tier-0 or Tier-1 Entra directory roles, an on-premises domain compromise (ransomware, DC compromise) directly translates to cloud admin access.",
-      "impact": "An attacker who compromises on-premises AD can extract credentials for synced admin accounts and use them immediately for cloud administrative access — no additional steps are needed to pivot from on-premises to cloud."
+      "impact": "An attacker who compromises on-premises AD can extract credentials for synced admin accounts and use them immediately for cloud administrative access — no additional steps are needed to pivot from on-premises to cloud.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-MFA-002",
@@ -4826,7 +5370,13 @@
       "impactRationale": "Failure to utilize Multi-Factor Authentication (MFA) to authenticate local access for privileged accounts exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Enable the registration campaign to prompt unregistered users. Entra admin center > Protection > Authentication methods > Registration campaign > Enable. Follow up with users shown in the authentication methods activity report.",
       "rationale": "Even a small percentage of users without MFA methods provides meaningful attack surface. Attackers performing credential spray attacks will find and prioritize accounts where MFA cannot be enforced.",
-      "impact": "Users without MFA method registration can authenticate with only a password in any CA policy that requires MFA, because there is no registered method to satisfy the MFA requirement. These accounts are the weakest link for credential-based attacks."
+      "impact": "Users without MFA method registration can authenticate with only a password in any CA policy that requires MFA, because there is no registered method to satisfy the MFA requirement. These accounts are the weakest link for credential-based attacks.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-methods-activity",
+          "title": "Microsoft Learn — Authentication methods activity reports"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-APPS-002",
@@ -4844,7 +5394,17 @@
       "cisaScubaControlId": "MS.AAD.6.1v1",
       "remediation": "Remove Intune write permissions from app registrations that do not require them. Entra admin center > App registrations > select app > API permissions. Remove DeviceManagementConfiguration.ReadWrite.All and equivalent permissions. Only approved, monitored service principals should hold Intune write access.",
       "rationale": "App registrations with Intune write permissions (DeviceManagementManagedDevices.ReadWrite.All) can wipe, retire, or reconfigure managed devices at scale. If such an app's credentials are compromised, the attacker can destroy device data across the entire tenant in seconds.",
-      "impact": "A compromised service principal with Intune write permissions can mass-wipe managed devices, remove compliance policies, or push malicious configuration profiles to all enrolled endpoints."
+      "impact": "A compromised service principal with Intune write permissions can mass-wipe managed devices, remove compliance policies, or push malicious configuration profiles to all enrolled endpoints.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/role-based-access-control",
+          "title": "Microsoft Learn — Role-based access control with Microsoft Intune"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/graph/permissions-reference#intune-device-management-permissions",
+          "title": "Microsoft Learn — Microsoft Graph Intune device management permissions"
+        }
+      ]
     },
     {
       "checkId": "PURVIEW-RETENTION-005",
@@ -4862,7 +5422,17 @@
       "impactRationale": "Failure to facilitate the implementation of a change management program exposes the tenant to: Inability to maintain individual accountability, Improper assignment of privileged functions, Privilege escalation.",
       "remediation": "Microsoft Purview > Data lifecycle management > Retention policies > Edit each policy in simulation mode and switch it to Enforce once validated.",
       "rationale": "Retention policies in simulation mode do not enforce retention — they only predict what would be retained. Policies must be in Enforce mode to actually preserve or delete content according to the configured rules.",
-      "impact": "A retention policy in simulation mode has no effect on actual data retention. Content that should be preserved can still be deleted, and data that should be automatically disposed of is retained indefinitely — creating both compliance gaps and unintended data accumulation."
+      "impact": "A retention policy in simulation mode has no effect on actual data retention. Content that should be preserved can still be deleted, and data that should be automatically disposed of is retained indefinitely — creating both compliance gaps and unintended data accumulation.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/create-retention-policies",
+          "title": "Microsoft Learn — Create and configure retention policies"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/retention",
+          "title": "Microsoft Learn — Learn about retention policies and retention labels"
+        }
+      ]
     },
     {
       "checkId": "CA-NAMEDLOC-001",
@@ -4884,7 +5454,13 @@
       "stigControlId": "",
       "remediation": "IP-based trusted locations can be spoofed via VPN or proxy. Consider Global Secure Access compliant network checks or country-based locations for stronger assurance. Entra admin center > Protection > Conditional Access > Named locations.",
       "rationale": "IP-based named locations used in CA 'trusted location' exclusions can be spoofed via VPN or proxy. Relying on IP reputation as a trust signal without combining it with device compliance or MFA creates an authentication bypass for any attacker who can route through a trusted IP range.",
-      "impact": "Attackers with access to a trusted IP range (shared hosting, compromised on-premises network, VPN exit node) authenticate without MFA challenges, bypassing the core CA control."
+      "impact": "Attackers with access to a trusted IP range (shared hosting, compromised on-premises network, VPN exit node) authenticate without MFA challenges, bypassing the core CA control.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/location-condition",
+          "title": "Microsoft Learn — Location condition in Conditional Access"
+        }
+      ]
     },
     {
       "checkId": "CA-REPORTONLY-001",
@@ -4951,7 +5527,17 @@
       "stigControlId": "",
       "remediation": "Enroll all Global Administrators in phishing-resistant MFA (FIDO2, Windows Hello for Business, or certificate-based). Entra admin center > Protection > Authentication methods > Policies.",
       "rationale": "Global Administrators control every aspect of the tenant. Standard MFA can be bypassed via adversary-in-the-middle (AiTM) phishing attacks that relay the authentication session. Phishing-resistant MFA (FIDO2, Windows Hello, certificate) eliminates this attack class for the highest-privilege accounts.",
-      "impact": "Global Administrators protected by standard MFA are still vulnerable to AiTM token theft. An attacker who intercepts the session token gains persistent Global Admin access without needing the user's password or MFA device."
+      "impact": "Global Administrators protected by standard MFA are still vulnerable to AiTM token theft. An attacker who intercepts the session token gains persistent Global Admin access without needing the user's password or MFA device.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-authentication-strengths",
+          "title": "Microsoft Learn — Authentication strengths overview"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/howto-authentication-passwordless-security-key",
+          "title": "Microsoft Learn — Enable FIDO2 security key sign-in"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-APPREG-002",
@@ -4995,7 +5581,13 @@
       "stigControlId": "",
       "remediation": "Update HTTP redirect URIs to HTTPS. Non-HTTPS URIs allow token interception via MITM attacks. Entra admin center > App registrations > Authentication.",
       "rationale": "HTTP redirect URIs in app registrations allow OAuth tokens to be sent to non-HTTPS endpoints, exposing them to interception in transit. OAuth authorization codes delivered over HTTP can be captured by a network-positioned attacker.",
-      "impact": "OAuth tokens or authorization codes sent to HTTP endpoints can be intercepted via man-in-the-middle attacks on the same network. An intercepted token grants the attacker the same access as the legitimate application."
+      "impact": "OAuth tokens or authorization codes sent to HTTP endpoints can be intercepted via man-in-the-middle attacks on the same network. An intercepted token grants the attacker the same access as the legitimate application.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity-platform/reply-url",
+          "title": "Microsoft Learn — Redirect URI (reply URL) restrictions"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-APPREG-004",
@@ -5017,7 +5609,13 @@
       "stigControlId": "",
       "remediation": "Replace wildcard redirect URIs with explicit URIs. Wildcards enable open redirect attacks for token theft. Entra admin center > App registrations > Authentication.",
       "rationale": "Wildcard redirect URIs (e.g., https://example.com/*) allow OAuth tokens to be delivered to any path under that domain. If any subdirectory of the registered domain is compromised or supports open redirects, an attacker can craft a URL that sends tokens to an attacker-controlled endpoint.",
-      "impact": "An attacker can craft an authorization request using the legitimate app's client ID but pointing to an attacker-controlled path within the wildcard URI, capturing OAuth tokens without compromising the app itself."
+      "impact": "An attacker can craft an authorization request using the legitimate app's client ID but pointing to an attacker-controlled path within the wildcard URI, capturing OAuth tokens without compromising the app itself.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity-platform/reply-url",
+          "title": "Microsoft Learn — Redirect URI (reply URL) restrictions"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-CONSENT-003",
@@ -5039,7 +5637,13 @@
       "stigControlId": "",
       "remediation": "Entra admin center > Enterprise applications > Consent and permissions > User consent settings > Allow consent only from verified publishers or block user consent entirely.",
       "rationale": "User consent to third-party apps grants those apps access to the user's data (email, files, contacts) on behalf of the user. Without restricting consent to verified publishers, any malicious app can acquire persistent delegated access via a single user consent click.",
-      "impact": "Malicious OAuth apps displayed in consent phishing campaigns acquire delegated access to user mailboxes, files, and contacts. Access persists until explicitly revoked, surviving password changes and MFA events."
+      "impact": "Malicious OAuth apps displayed in consent phishing campaigns acquire delegated access to user mailboxes, files, and contacts. Access persists until explicitly revoked, surviving password changes and MFA events.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/configure-user-consent",
+          "title": "Microsoft Learn — Configure how users consent to applications"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-CONSENT-004",
@@ -5061,7 +5665,17 @@
       "stigControlId": "",
       "remediation": "Review tenant-wide admin consent grants. These grants apply to all users in the tenant. Remove overly broad grants that are no longer needed. Entra admin center > Enterprise applications > filter by Admin consent.",
       "rationale": "Tenant-wide admin consent grants an application permissions for every user in the tenant. An application with admin consent and broad permissions (e.g., Mail.ReadWrite, Files.ReadWrite.All) can read and modify all user data without individual user interaction.",
-      "impact": "A malicious application that obtained tenant-wide admin consent can access all users' mail, files, and calendar data. These grants persist and are rarely reviewed, providing long-term silent data access."
+      "impact": "A malicious application that obtained tenant-wide admin consent can access all users' mail, files, and calendar data. These grants persist and are rarely reviewed, providing long-term silent data access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent",
+          "title": "Microsoft Learn — Grant tenant-wide admin consent to an application"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-consent-requests",
+          "title": "Microsoft Learn — Manage consent requests"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-010",
@@ -5083,7 +5697,17 @@
       "stigControlId": "",
       "remediation": "Entra admin center > App registrations > review internal apps with Tier 0 permissions. Each has a documented path to Global Administrator. Replace with narrower permissions or use managed identities where possible.",
       "rationale": "Applications with Tier 0 permissions (e.g., Directory.ReadWrite.All, RoleManagement.ReadWrite.Directory) can read and modify the entire Entra ID directory, including assigning admin roles to other principals. A compromised app credential is equivalent to a compromised Global Administrator.",
-      "impact": "Credential theft for any app holding Tier 0 permissions grants the attacker full tenant control: ability to create admin accounts, disable CA policies, read all user data, and persist indefinitely without triggering user-facing alerts."
+      "impact": "Credential theft for any app holding Tier 0 permissions grants the attacker full tenant control: ability to create admin accounts, disable CA policies, read all user data, and persist indefinitely without triggering user-facing alerts.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/grant-admin-consent",
+          "title": "Microsoft Learn — Grant tenant-wide admin consent"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/security/privileged-access-workstations/privileged-access-access-model",
+          "title": "Microsoft Learn — Privileged access: enterprise access model (Tier 0)"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-011",
@@ -5105,7 +5729,13 @@
       "stigControlId": "",
       "remediation": "Entra admin center > Enterprise applications > review foreign apps with broad data access (Mail.ReadWrite, Files.ReadWrite.All, etc.). Scope to least-privilege or remove.",
       "rationale": "Tier 1 data permissions (Mail.ReadWrite, Files.ReadWrite.All, Calendars.ReadWrite) grant access to individual user communication and collaboration data. For foreign apps, this data flows to the publisher's infrastructure and is subject to their security and privacy controls, not yours.",
-      "impact": "Foreign apps with Tier 1 data permissions can read all email, files, and calendar data for any user who grants consent. This data leaves your tenant boundary and may be stored, processed, or accessed by the app publisher."
+      "impact": "Foreign apps with Tier 1 data permissions can read all email, files, and calendar data for any user who grants consent. This data leaves your tenant boundary and may be stored, processed, or accessed by the app publisher.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-012",
@@ -5191,7 +5821,17 @@
       "stigControlId": "",
       "remediation": "Migrate privileged service principals from client secrets to certificates or managed identities. A secret on a permanently privileged SP is a persistent backdoor risk.",
       "rationale": "Service principals with client secrets and permanent privileged role assignments combine the two highest risk factors in app identity: a long-lived credential that never expires and a standing privilege that never rotates. This combination is a primary target in cloud supply-chain attacks.",
-      "impact": "A leaked or brute-forced client secret grants the attacker persistent, silent access at Global Admin or equivalent privilege with no user interaction, no MFA challenge, and no sign-in behavior visible in user-based risk signals."
+      "impact": "A leaked or brute-forced client secret grants the attacker persistent, silent access at Global Admin or equivalent privilege with no user interaction, no MFA challenge, and no sign-in behavior visible in user-based risk signals.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/architecture/service-accounts-principal",
+          "title": "Microsoft Learn — Securing service principals in Microsoft Entra ID"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-016",
@@ -5213,7 +5853,13 @@
       "stigControlId": "",
       "remediation": "Remove owners from apps with Tier 0 permissions. An owner of a Tier 0 app can add credentials and impersonate it to escalate to Global Admin. Entra admin center > App registrations > Owners.",
       "rationale": "Application owners can modify app credentials and permissions without additional approval. An app with Tier 0 permissions and an owner who can add credentials creates a privilege escalation path: an attacker who compromises the owner account can immediately add a secret and gain Tier 0 access.",
-      "impact": "Any user listed as an owner of a Tier 0 permission app can add client secrets and use the app's full permissions. This creates an indirect path to tenant compromise via accounts that may not themselves hold privileged roles."
+      "impact": "Any user listed as an owner of a Tier 0 permission app can add client secrets and use the app's full permissions. This creates an indirect path to tenant compromise via accounts that may not themselves hold privileged roles.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/overview-assign-app-owners",
+          "title": "Microsoft Learn — Manage app registration owners"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-017",
@@ -5235,7 +5881,13 @@
       "stigControlId": "",
       "remediation": "Remove owners from apps holding Entra directory roles. Owners can add credentials and impersonate the SP to exercise those roles. Entra admin center > App registrations > Owners.",
       "rationale": "Application owners can add credentials to the app, allowing them to authenticate as the app and exercise its full permissions. When an app holds privileged directory roles, its owners have an indirect path to those privileges without being directly assigned the role.",
-      "impact": "Any user listed as an owner of an app with directory roles can add a client secret, authenticate as the app, and exercise the app's role permissions — without holding the role themselves and without the action appearing in standard privileged role assignment reports."
+      "impact": "Any user listed as an owner of an app with directory roles can add a client secret, authenticate as the app, and exercise the app's role permissions — without holding the role themselves and without the action appearing in standard privileged role assignment reports.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/overview-assign-app-owners",
+          "title": "Microsoft Learn — Manage app registration owners"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-018",
@@ -5279,7 +5931,13 @@
       "stigControlId": "",
       "remediation": "Review apps with Tier 0 permissions that show no sign-in activity. These permissions may have been granted but never used -- remove them to reduce attack surface. Entra admin center > Enterprise applications > Sign-in logs.",
       "rationale": "Apps with Tier 0 permissions that have not signed in recently are unmonitored attack surfaces. Their credentials may still be valid but their activity is not tracked. Credential theft for an inactive app may go undetected for an extended period.",
-      "impact": "A compromised client secret for an inactive Tier 0 app allows an attacker to use the app's permissions without generating user-facing anomalies. Inactivity signals may mask the compromise in log reviews."
+      "impact": "A compromised client secret for an inactive Tier 0 app allows an attacker to use the app's permissions without generating user-facing anomalies. Inactivity signals may mask the compromise in log reviews.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/manage-application-permissions",
+          "title": "Microsoft Learn — Manage and review permissions granted to enterprise apps"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-020",
@@ -5301,7 +5959,13 @@
       "stigControlId": "",
       "remediation": "Investigate foreign apps using Microsoft product names -- they may be social engineering attempts. Verify the publisher and appId against known Microsoft first-party apps. Remove if suspicious.",
       "rationale": "Applications that impersonate Microsoft product names in their display names are a social engineering vector. Users who see 'Microsoft Teams Meeting Add-in' or 'Office 365 Security' in a consent prompt are more likely to approve the consent without scrutiny.",
-      "impact": "Users who grant consent to impersonating apps give external parties persistent delegated access to their data. The Microsoft-branded name increases consent rates and reduces user suspicion."
+      "impact": "Users who grant consent to impersonating apps give external parties persistent delegated access to their data. The Microsoft-branded name increases consent rates and reduces user suspicion.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/application-sign-in-unexpected-user-consent-error",
+          "title": "Microsoft Learn — Unexpected error when performing consent to an application"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ENTAPP-021",
@@ -5345,7 +6009,17 @@
       "stigControlId": "",
       "remediation": "No action needed. Conditional Access policies provide equivalent coverage to Security Defaults.",
       "rationale": "When Security Defaults are disabled, the assumption is that Conditional Access policies provide equivalent coverage. Gaps in CA policy coverage — roles not targeted, users excluded, legacy auth not blocked — create security regressions compared to the Security Defaults baseline.",
-      "impact": "Users or actions not covered by Conditional Access policies are subject to password-only authentication. A CA configuration that appears comprehensive but misses specific roles or legacy auth endpoints provides false assurance of MFA coverage."
+      "impact": "Users or actions not covered by Conditional Access policies are subject to password-only authentication. A CA configuration that appears comprehensive but misses specific roles or legacy auth endpoints provides false assurance of MFA coverage.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults",
+          "title": "Microsoft Learn — Security defaults in Microsoft Entra ID"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/plan-conditional-access",
+          "title": "Microsoft Learn — Plan a Conditional Access deployment"
+        }
+      ]
     },
     {
       "checkId": "EXO-HIDDEN-001",
@@ -5387,7 +6061,13 @@
       "stigControlId": "",
       "remediation": "Ensure SharePointTenantSettings.Read.All permission is consented. Review site sharing levels in SharePoint admin center > Active sites.",
       "rationale": "Site-level sharing settings cannot exceed the tenant-wide sharing policy. If the tenant policy allows sharing with anyone, individual sites must restrict sharing themselves. Without a restrictive tenant policy, every new site defaults to maximum sharing permissions.",
-      "impact": "Sites created without explicit sharing restrictions default to the tenant maximum — potentially allowing anonymous link sharing for all new sites. Sensitive data in default-configured sites is exposed without intentional site-level controls."
+      "impact": "Sites created without explicit sharing restrictions default to the tenant maximum — potentially allowing anonymous link sharing for all new sites. Sensitive data in default-configured sites is exposed without intentional site-level controls.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        }
+      ]
     },
     {
       "checkId": "SPO-SITE-002",
@@ -5409,7 +6089,13 @@
       "stigControlId": "",
       "remediation": "Review site sharing manually in SharePoint admin center > Active sites.",
       "rationale": "Sites containing sensitive data require tighter sharing controls than general-purpose collaboration sites. Without site-level sharing restrictions, sensitive data sites are subject to the same sharing rules as non-sensitive sites, potentially allowing external sharing of regulated content.",
-      "impact": "Sensitive SharePoint sites with default or tenant-maximum sharing settings allow authorized users to share sensitive content with external parties. Data classification controls have no effect if sharing policies do not reflect data sensitivity."
+      "impact": "Sensitive SharePoint sites with default or tenant-maximum sharing settings allow authorized users to share sensitive content with external parties. Data classification controls have no effect if sharing policies do not reflect data sensitivity.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        }
+      ]
     },
     {
       "checkId": "SPO-SITE-003",
@@ -5450,7 +6136,13 @@
       "stigControlId": "",
       "remediation": "Ensure Policy.Read.All permission is consented. Create a CA policy targeting SharePoint Online (00000003-0000-0ff1-ce00-000000000000) or All Cloud Apps.",
       "rationale": "SharePoint contains sensitive documents that require the same access controls as other sensitive resources. Without Conditional Access coverage for SharePoint, unmanaged devices or non-compliant endpoints can access SharePoint content even when other resources are protected by CA policies.",
-      "impact": "Unmanaged or compromised devices can access SharePoint and OneDrive content. Files downloaded to an unmanaged device bypass DLP, endpoint security, and data classification controls."
+      "impact": "Unmanaged or compromised devices can access SharePoint and OneDrive content. Files downloaded to an unmanaged device bypass DLP, endpoint security, and data classification controls.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/control-access-from-unmanaged-devices",
+          "title": "Microsoft Learn — Control access from unmanaged devices"
+        }
+      ]
     },
     {
       "checkId": "SPO-ACCESS-002",
@@ -5509,7 +6201,17 @@
       "impactRationale": "Failure to implement separation of duties for privileged roles allows a single compromised account to perform all administrative functions without oversight, increasing risk of unauthorized changes, data exfiltration, and privilege abuse.",
       "remediation": "Ensure Global Administrator and Privileged Role Administrator roles are assigned to separate accounts. Entra admin center > Identity > Roles & admins. Enable PIM approval workflows for role activation.",
       "rationale": "Separation of duties prevents a single account from holding roles that, in combination, allow self-authorization of sensitive actions — for example, both User Administrator and Billing Administrator. Without SoD, a compromised account with incompatible role combinations can self-escalate or approve its own privileged actions.",
-      "impact": "An account with conflicting admin roles can self-authorize sensitive operations without a second approver. This eliminates the detection and prevention benefit of requiring multiple parties for sensitive actions."
+      "impact": "An account with conflicting admin roles can self-authorize sensitive operations without a second approver. This eliminates the detection and prevention benefit of requiring multiple parties for sensitive actions.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure",
+          "title": "Microsoft Learn — What is Microsoft Entra Privileged Identity Management?"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-TOU-001",
@@ -5542,7 +6244,13 @@
       "impactRationale": "Failure to restrict privileged command execution via remote access enables persistent standing admin access, increasing the attack surface for credential theft, lateral movement, and unauthorized administrative actions.",
       "remediation": "Enable Entra ID PIM. Convert permanent role assignments to eligible. Configure activation to require justification and MFA. Entra admin center > Identity Governance > Privileged Identity Management > Entra ID roles.",
       "rationale": "Remote access sessions from personal or unmanaged devices have weaker security assurances. Requiring PIM activation for privileged commands during remote sessions adds a time-bound, audited step and ensures privileged actions are explicitly authorized even when performed remotely.",
-      "impact": "Privileged commands executed remotely from unmanaged devices bypass endpoint security controls. An attacker who compromises a remote session inherits all standing privileged access of the connected user."
+      "impact": "Privileged commands executed remotely from unmanaged devices bypass endpoint security controls. An attacker who compromises a remote session inherits all standing privileged access of the connected user.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure",
+          "title": "Microsoft Learn — What is Microsoft Entra Privileged Identity Management?"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-MOBILEENCRYPT-001",
@@ -5557,7 +6265,13 @@
       "impactRationale": "Failure to require encryption on mobile devices exposes CUI and sensitive data to unauthorized disclosure if a device is lost, stolen, or physically compromised.",
       "remediation": "Intune admin center > Devices > Compliance > Create/edit iOS and Android compliance policies > Require device encryption.",
       "rationale": "Unencrypted mobile devices expose corporate email, contacts, documents, and app data if lost or stolen. Mobile devices are higher-risk endpoints due to portability and greater likelihood of physical loss.",
-      "impact": "A lost or stolen unencrypted mobile device exposes all locally cached corporate data including email, contacts, Teams messages, and app credentials to anyone with physical access."
+      "impact": "A lost or stolen unencrypted mobile device exposes all locally cached corporate data including email, contacts, Teams messages, and app credentials to anyone with physical access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/device-compliance-get-started",
+          "title": "Microsoft Learn — Device compliance policies in Intune"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-PORTSTORAGE-001",
@@ -5572,7 +6286,13 @@
       "impactRationale": "Failure to restrict portable storage on external systems enables unauthorized data transfer via USB and removable media, increasing risk of data exfiltration and malware introduction.",
       "remediation": "Intune admin center > Devices > Configuration > Create profile > Windows 10 and later > Device restrictions > General > Removable storage: Block.",
       "rationale": "Portable storage devices (USB drives) are a primary vector for data exfiltration and malware introduction. An employee can copy sensitive data to a USB drive undetected if portable storage is not restricted.",
-      "impact": "Sensitive data can be copied to uncontrolled removable media and exfiltrated. Conversely, malware dropped via USB (including BadUSB attacks) can execute on endpoints with unrestricted port access."
+      "impact": "Sensitive data can be copied to uncontrolled removable media and exfiltrated. Conversely, malware dropped via USB (including BadUSB attacks) can execute on endpoints with unrestricted port access.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/device-restrictions-windows-10",
+          "title": "Microsoft Learn — Windows 10/11 device restriction settings in Intune"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-APPCONTROL-001",
@@ -5589,7 +6309,17 @@
       "impactRationale": "Failure to restrict unauthorized software execution allows users to install and run unapproved applications, increasing the attack surface for malware, supply chain compromise, and policy violations.",
       "remediation": "Intune admin center > Devices > Configuration > Create profile > Endpoint protection > Windows Defender Application Control. Alternatively, deploy WDAC via custom OMA-URI.",
       "rationale": "Application control (AppLocker / WDAC) prevents unauthorized software from executing on managed endpoints. Without it, attackers who gain initial access can run any executable, script, or payload without triggering application-based controls.",
-      "impact": "Any downloaded or dropped executable, script, or living-off-the-land binary (LOLBin) can run unobstructed. Attackers can execute ransomware, remote access tools, or credential dumpers without application control restrictions."
+      "impact": "Any downloaded or dropped executable, script, or living-off-the-land binary (LOLBin) can run unobstructed. Attackers can execute ransomware, remote access tools, or credential dumpers without application control restrictions.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/protect/endpoint-security-asr-policy",
+          "title": "Microsoft Learn — Manage Attack surface reduction policies in Intune"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/windows/security/application-security/application-control/app-control-for-business/appcontrol-and-applocker-overview",
+          "title": "Microsoft Learn — App Control for Business and AppLocker overview"
+        }
+      ]
     },
     {
       "checkId": "DEFENDER-VULNSCAN-001",
@@ -5606,7 +6336,13 @@
       "impactRationale": "Failure to perform routine vulnerability scanning leaves known vulnerabilities undetected, allowing attackers to exploit outdated software and misconfigurations across managed endpoints.",
       "remediation": "Enable Microsoft Defender for Endpoint. Navigate to security.microsoft.com > Vulnerability management to review coverage. Ensure devices are onboarded to MDE.",
       "rationale": "Vulnerability scanning surfaces known exploitable vulnerabilities in managed device software and OS configuration. Unpatched vulnerabilities are the primary initial access vector for ransomware and targeted attacks.",
-      "impact": "Known vulnerabilities on managed devices go undetected and unremediated. Attackers who identify these devices via active scanning or from breach intelligence have an unpatched entry point."
+      "impact": "Known vulnerabilities on managed devices go undetected and unremediated. Attackers who identify these devices via active scanning or from breach intelligence have an unpatched entry point.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-vulnerability-management/defender-vulnerability-management",
+          "title": "Microsoft Learn — Microsoft Defender Vulnerability Management"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-FIPS-001",
@@ -5621,7 +6357,17 @@
       "impactRationale": "Failure to enforce FIPS-validated cryptographic algorithms allows the use of weak or non-compliant encryption, potentially exposing CUI and sensitive data to cryptographic attacks.",
       "remediation": "Intune admin center > Devices > Configuration > Create profile > Custom OMA-URI > Add setting: ./Device/Vendor/MSFT/Policy/Config/Cryptography/AllowFipsAlgorithmPolicy = 1.",
       "rationale": "FIPS-validated cryptography ensures that encryption and cryptographic operations on managed devices meet federal security requirements. Non-FIPS algorithms may have known weaknesses or implementation flaws that weaken data protection.",
-      "impact": "Data encrypted with non-FIPS-validated algorithms may be vulnerable to cryptanalytic attacks or algorithmic weaknesses. For FedRAMP and CMMC environments, non-FIPS devices fail compliance attestation."
+      "impact": "Data encrypted with non-FIPS-validated algorithms may be vulnerable to cryptanalytic attacks or algorithmic weaknesses. For FedRAMP and CMMC environments, non-FIPS devices fail compliance attestation.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/windows/security/security-foundations/certification/fips-140-validation",
+          "title": "Microsoft Learn — FIPS 140 validation"
+        },
+        {
+          "url": "https://csrc.nist.gov/publications/detail/fips/140/3/final",
+          "title": "NIST FIPS 140-3 — Security Requirements for Cryptographic Modules"
+        }
+      ]
     },
     {
       "checkId": "DEFENDER-REALTIMESCAN-001",
@@ -5636,7 +6382,13 @@
       "impactRationale": "Failure to enable real-time anti-malware scanning allows threats to execute unchecked, enabling ransomware, trojans, and other malware to persist and spread across the environment.",
       "remediation": "Intune admin center > Endpoint security > Antivirus > Create policy > Microsoft Defender Antivirus > Enable real-time protection.",
       "rationale": "Real-time protection is the primary line of defense against malware executing on endpoints. Without it, malicious files are only caught at scheduled scan intervals, giving attackers a wide window to establish persistence.",
-      "impact": "Malware can execute, establish persistence, and exfiltrate data before any scheduled scan detects it. Endpoint compromise becomes undetected until symptoms appear or a scan runs."
+      "impact": "Malware can execute, establish persistence, and exfiltrate data before any scheduled scan detects it. Endpoint compromise becomes undetected until symptoms appear or a scan runs.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoft-365/security/defender-endpoint/configure-real-time-protection-microsoft-defender-antivirus",
+          "title": "Microsoft Learn — Configure always-on protection in Microsoft Defender Antivirus"
+        }
+      ]
     },
     {
       "checkId": "DEFENDER-SECUREMON-001",
@@ -5688,7 +6440,13 @@
       "impactRationale": "Failure to automatically detect misconfigured or unauthorized components allows configuration drift and rogue devices to persist undetected, creating exploitable gaps in the security perimeter.",
       "remediation": "Enable Defender for Endpoint device discovery. security.microsoft.com > Settings > Device discovery. Ensure devices are onboarded and configuration assessment is active.",
       "rationale": "Automated detection of misconfigured or vulnerable devices identifies gaps in device security posture before attackers exploit them. Without this capability, misconfigured devices remain undetected until they are compromised.",
-      "impact": "Devices with exploitable misconfigurations — open firewall rules, disabled AV, missing patches — are not surfaced for remediation and remain available as attack targets."
+      "impact": "Devices with exploitable misconfigurations — open firewall rules, disabled AV, missing patches — are not surfaced for remediation and remain available as attack targets.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/defender-vulnerability-management/tvm-security-recommendation",
+          "title": "Microsoft Learn — Security recommendations in Defender Vulnerability Management"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-AUTODISC-001",
@@ -5739,7 +6497,13 @@
       "impactRationale": "Failure to extend DLP coverage to Exchange and SharePoint/OneDrive leaves the primary workloads for CUI storage and transmission unprotected against accidental or malicious data exfiltration.",
       "remediation": "Microsoft Purview > Data loss prevention > Policies > Edit existing policies to include Exchange email and SharePoint/OneDrive locations for comprehensive data protection.",
       "rationale": "Exchange email and SharePoint/OneDrive are the highest-volume channels for sensitive data movement. DLP policies covering both ensure consistent enforcement regardless of whether data is emailed or shared via a link.",
-      "impact": "Gaps in DLP coverage between email and collaboration platforms create bypass paths: data blocked via email can be exfiltrated by first uploading to SharePoint and sharing a link externally."
+      "impact": "Gaps in DLP coverage between email and collaboration platforms create bypass paths: data blocked via email can be exfiltrated by first uploading to SharePoint and sharing a link externally.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/dlp-create-deploy-policy",
+          "title": "Microsoft Learn — Create and deploy a data loss prevention policy"
+        }
+      ]
     },
     {
       "checkId": "COMPLIANCE-LABELS-002",
@@ -5757,7 +6521,13 @@
       "impactRationale": "Failure to configure auto-sensitivity labeling relies solely on user discretion to classify CUI, leading to inconsistent labeling that undermines DLP enforcement and data governance controls.",
       "remediation": "Microsoft Purview > Information protection > Auto-labeling > Create a policy to automatically classify sensitive content. Requires Azure Information Protection P2 (E5 or E5 Compliance).",
       "rationale": "Auto-labeling policies classify sensitive content without requiring user action, ensuring that documents containing PII, financial data, or health information are consistently classified and subject to appropriate access and retention controls.",
-      "impact": "Sensitive documents that users fail to manually label are stored and shared without classification-based protections. DLP policies that rely on label conditions will not fire on unclassified content."
+      "impact": "Sensitive documents that users fail to manually label are stored and shared without classification-based protections. DLP policies that rely on label conditions will not fire on unclassified content.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/purview/apply-sensitivity-label-automatically",
+          "title": "Microsoft Learn — Apply a sensitivity label automatically"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-REMOVABLEMEDIA-001",
@@ -5772,7 +6542,13 @@
       "impactRationale": "Failure to block removable media on managed endpoints enables data exfiltration of CUI via USB drives and SD cards, and introduces malware vectors that bypass network-based controls.",
       "remediation": "Block removable storage on managed devices. Intune > Devices > Configuration profiles > New profile > Windows > Device restrictions > General > Removable storage: Block. Assign to all managed device groups.",
       "rationale": "Removable media is a common vector for both data theft and malware introduction. Blocking removable storage prevents exfiltration of data to personal devices and eliminates the attack surface for dropped-USB and supply-chain media attacks.",
-      "impact": "Without removable media restrictions, an insider can copy any accessible data to a USB drive. Dropped USB attacks (maliciously placed drives) can also auto-execute or be manually opened by employees."
+      "impact": "Without removable media restrictions, an insider can copy any accessible data to a USB drive. Dropped USB attacks (maliciously placed drives) can also auto-execute or be manually opened by employees.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/device-restrictions-windows-10",
+          "title": "Microsoft Learn — Windows 10/11 device restriction settings in Intune"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-ADMINROLE-SEPARATION-001",
@@ -5789,7 +6565,17 @@
       "impactRationale": "Failure to separate privileged admin accounts from daily-use accounts violates user/system management separation, increasing the blast radius of account compromise and enabling privilege escalation through shared identity.",
       "remediation": "Create dedicated cloud-only admin accounts separate from daily-use accounts. Admin accounts should hold no Exchange mailbox or E3/E5 licenses. Entra admin center > Users > New user (cloud identity). Assign admin roles only to the dedicated accounts.",
       "rationale": "Daily-use accounts are higher-risk targets — they access email, browse the web, and are more exposed to phishing. Using the same account for admin tasks means a successful phishing attack against a daily-use activity immediately compromises a privileged account.",
-      "impact": "A phished or malware-infected daily-use account that also holds admin roles gives the attacker immediate administrative access to the tenant with no additional steps required."
+      "impact": "A phished or malware-infected daily-use account that also holds admin roles gives the attacker immediate administrative access to the tenant with no additional steps required.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/best-practices",
+          "title": "Microsoft Learn — Best practices for Microsoft Entra roles"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/security/privileged-access-workstations/privileged-access-accounts",
+          "title": "Microsoft Learn — Privileged access: accounts"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-CA-SESSIONFREQ-001",
@@ -5819,7 +6605,17 @@
       "impactRationale": "Failure to restrict PowerShell execution on managed endpoints allows arbitrary script execution, enabling malware deployment, credential theft, and lateral movement that bypasses traditional AV-based controls.",
       "remediation": "Restrict PowerShell execution policy on managed endpoints. Intune > Devices > Configuration profiles > Settings catalog > search 'Turn on Script Execution' > set to AllSigned or RemoteSigned. Assign to all managed Windows device groups.",
       "rationale": "Unrestricted PowerShell execution on managed endpoints allows any script — downloaded, embedded in documents, or dropped by malware — to run without signature verification. PowerShell is the most commonly abused living-off-the-land technique in modern attacks.",
-      "impact": "Malicious PowerShell scripts execute without restriction: credential dumpers, reverse shells, ransomware droppers, and exfiltration tools all commonly use PowerShell and are blocked only when execution policy is enforced."
+      "impact": "Malicious PowerShell scripts execute without restriction: credential dumpers, reverse shells, ransomware droppers, and exfiltration tools all commonly use PowerShell and are blocked only when execution policy is enforced.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/settings-catalog",
+          "title": "Microsoft Learn — Use the settings catalog to configure settings on Windows devices"
+        },
+        {
+          "url": "https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.security/set-executionpolicy",
+          "title": "Microsoft Learn — Set-ExecutionPolicy"
+        }
+      ]
     },
     {
       "checkId": "ENTRA-SESSIONAUTH-001",
@@ -5834,7 +6630,13 @@
       "impactRationale": "Failure to block legacy authentication protocols allows sessions to be established without modern authentication mechanisms, undermining communications session authenticity and enabling credential-spraying and man-in-the-middle attacks.",
       "remediation": "Block legacy authentication via Conditional Access. Entra admin center > Security > Conditional Access > New policy > target all users > Condition: Client apps = Other clients + Exchange ActiveSync > Grant: Block access. Alternatively, enable the Microsoft-managed legacy auth block policy.",
       "rationale": "Legacy authentication protocols cannot be evaluated by Conditional Access policies. Enabling these protocols for any user creates a pathway around every MFA requirement in the tenant.",
-      "impact": "Attackers targeting legacy auth endpoints (IMAP, POP3, EAS, SMTP AUTH) can authenticate with only a username and password, bypassing MFA policies that apply to modern authentication flows."
+      "impact": "Attackers targeting legacy auth endpoints (IMAP, POP3, EAS, SMTP AUTH) can authenticate with only a username and password, bypassing MFA policies that apply to modern authentication flows.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/block-legacy-authentication",
+          "title": "Microsoft Learn — Block legacy authentication with Conditional Access"
+        }
+      ]
     },
     {
       "checkId": "SPO-CUIACCESS-001",
@@ -5851,7 +6653,17 @@
       "impactRationale": "Failure to restrict SharePoint external sharing allows CUI stored in cloud digital media to be accessed by unauthorized external parties, violating media access controls and data governance requirements.",
       "remediation": "Restrict SharePoint external sharing to prevent CUI exposure. SharePoint Admin Center > Policies > Sharing > set external sharing to 'Existing guests only' or 'Only people in your organization'. Apply sensitivity labels and CA policies to CUI-classified sites.",
       "rationale": "CUI (Controlled Unclassified Information) has specific access and handling requirements under NIST 800-171 and CMMC. External sharing of SharePoint sites containing CUI without controls may expose regulated data to unauthorized parties.",
-      "impact": "CUI stored in SharePoint can be shared with external parties who are not authorized to access it, creating regulatory compliance violations and potentially triggering mandatory breach reporting."
+      "impact": "CUI stored in SharePoint can be shared with external parties who are not authorized to access it, creating regulatory compliance violations and potentially triggering mandatory breach reporting.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off",
+          "title": "Microsoft Learn — Manage sharing settings for SharePoint and OneDrive"
+        },
+        {
+          "url": "https://csrc.nist.gov/publications/detail/sp/800-171/rev-2/final",
+          "title": "NIST SP 800-171 Rev. 2 — Protecting CUI in Non-Federal Systems"
+        }
+      ]
     },
     {
       "checkId": "BACKUP-ENABLED-001",
@@ -5868,7 +6680,13 @@
       "impactRationale": "Failure to enable Microsoft 365 Backup for SharePoint, OneDrive, and Exchange leaves backup CUI without verified confidentiality protection, increasing risk of data loss or unauthorized disclosure from backup storage.",
       "remediation": "Enable Microsoft 365 Backup in the admin center. Microsoft 365 Admin Center > Settings > Org settings > Microsoft 365 Backup > Enable. Requires Microsoft 365 Backup add-on license. Configure backup scope for Exchange, SharePoint, and OneDrive.",
       "rationale": "Microsoft 365 data (Exchange, SharePoint, OneDrive) is recoverable from the recycle bin only within limited windows. A dedicated backup solution provides point-in-time recovery from ransomware, accidental deletion, and malicious destruction that exceeds the recycle bin retention period.",
-      "impact": "Ransomware that encrypts and deletes Exchange, SharePoint, and OneDrive data cannot be recovered if the retention period has expired. Without backup, recovery from destructive attacks requires rebuilding from scratch rather than restoring from a known-good point in time."
+      "impact": "Ransomware that encrypts and deletes Exchange, SharePoint, and OneDrive data cannot be recovered if the retention period has expired. Without backup, recovery from destructive attacks requires rebuilding from scratch rather than restoring from a known-good point in time.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/microsoft-365/backup/backup-overview",
+          "title": "Microsoft Learn — Overview of Microsoft 365 Backup"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-VPNCONFIG-001",
@@ -5882,7 +6700,13 @@
       "impactRationale": "Allowing split tunneling on VPN-connected devices permits simultaneous access to organizational systems and untrusted networks, creating a data exfiltration pathway and bypassing organizational security controls.",
       "remediation": "Disable VPN split tunneling on managed devices. Intune > Devices > Configuration profiles > New profile > Windows > VPN > disable split tunneling (route all traffic through VPN). Assign to all devices used for remote access.",
       "rationale": "Split tunneling routes only corporate traffic through the VPN while allowing direct internet access for other traffic. This allows DNS and web traffic from the device to bypass corporate security controls (proxy, DNS filtering) and enables attackers who compromise web traffic to intercept sessions.",
-      "impact": "A device using split tunneling can have its non-corporate traffic intercepted or manipulated by a network-positioned attacker. Malware using direct internet connectivity bypasses corporate network security controls entirely."
+      "impact": "A device using split tunneling can have its non-corporate traffic intercepted or manipulated by a network-positioned attacker. Malware using direct internet connectivity bypasses corporate network security controls entirely.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/vpn-settings-configure",
+          "title": "Microsoft Learn — Add VPN settings on devices using Intune"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-WIFI-001",
@@ -5899,7 +6723,13 @@
       "impactRationale": "Failure to enforce enterprise-grade WiFi authentication (WPA2-Enterprise/EAP-TLS) allows unauthorized devices to connect to corporate wireless networks and exposes CUI transmitted over unencrypted or weakly-encrypted channels.",
       "remediation": "Deploy a Wi-Fi configuration profile requiring WPA2/WPA3-Enterprise authentication. Intune > Devices > Configuration profiles > New profile > Windows > Wi-Fi > set Security type: WPA2-Enterprise, Authentication method: Certificates. Assign to managed device groups.",
       "rationale": "Open or WPA2-Personal Wi-Fi networks are vulnerable to passive capture and WPA2 handshake attacks. WPA2/WPA3-Enterprise with certificate-based authentication prevents credential theft and ensures only enrolled devices connect to corporate networks.",
-      "impact": "Devices connecting to open or pre-shared-key Wi-Fi networks can have their traffic captured and decrypted. WPA2-Personal networks are vulnerable to handshake capture and offline brute force of the pre-shared key."
+      "impact": "Devices connecting to open or pre-shared-key Wi-Fi networks can have their traffic captured and decrypted. WPA2-Personal networks are vulnerable to handshake capture and offline brute force of the pre-shared key.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/mem/intune/configuration/wi-fi-settings-configure",
+          "title": "Microsoft Learn — Configure Wi-Fi settings for devices in Intune"
+        }
+      ]
     },
     {
       "checkId": "CA-REMOTEDEVICE-001",
@@ -5913,7 +6743,13 @@
       "impactRationale": "Without device compliance requirements scoped to remote (non-corporate-network) access, unmanaged or compromised endpoints can authenticate to organizational systems from external networks, violating least privilege for remote access.",
       "remediation": "Require device compliance for remote access. Entra admin center > Security > Conditional Access > New policy > target all users > Condition: Device platforms or named locations > Grant: Require device to be marked as compliant. Combine with Intune compliance policies.",
       "rationale": "Remote access from unmanaged devices bypasses endpoint detection, patch enforcement, and data loss controls. A corporate credential entered on a personal or public device may be stolen by keyloggers or malware running on that device.",
-      "impact": "Unmanaged remote devices can be compromised and used to relay authenticated sessions to attacker infrastructure. Without device compliance enforcement, there is no assurance that the device accessing sensitive data is trustworthy."
+      "impact": "Unmanaged remote devices can be compromised and used to relay authenticated sessions to attacker infrastructure. Without device compliance enforcement, there is no assurance that the device accessing sensitive data is trustworthy.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/howto-conditional-access-policy-compliant-device",
+          "title": "Microsoft Learn — Require compliant or hybrid joined device"
+        }
+      ]
     },
     {
       "checkId": "INTUNE-REMOTEVPN-001",

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -937,6 +937,10 @@ def main():
         if rationale:
             check_obj["rationale"] = rationale
 
+        references = cm.get("references", [])
+        if references:
+            check_obj["references"] = references
+
         tags = derive_tags(check_obj)
         if tags:
             check_obj["tags"] = tags


### PR DESCRIPTION
## Summary

- Adds `references` arrays to all 110 Critical/High severity M365 checks in `scf-check-mapping.json`
- Each entry links to the authoritative Microsoft Learn doc, RFC, or NIST SP for that control
- Fixes a gap in `Build-Registry.py`: `references` was not being read and passed through to `registry.json` (impact/rationale were wired but references was silently dropped)
- Regenerates `registry.json` — 110 checks now carry populated `references` arrays

## Collectors covered

| Collector | Checks |
|---|---|
| CAEvaluator (Conditional Access) | 13 |
| Entra (Identity) | ~25 |
| ExchangeOnline | ~18 |
| Intune | ~10 |
| Defender | ~8 |
| SharePoint | ~8 |
| Teams | ~8 |
| DNS | ~6 |
| Compliance/Purview | ~8 |
| Forms, EntApp, StrykerReadiness | ~6 |

## Test plan

- [x] `Invoke-Pester tests/ -Output Minimal` — 281/281 passed
- [x] Build-Registry.py runs cleanly — 1,092 checks produced
- [x] 110 checks have `references` in registry.json (verified)
- [x] Schema v2.2.0 unchanged — `references` was already in schema definition

Closes #212 Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)