### PR TITLE
feat(data): add remediation text for all 814 AZ/WIN checks

### DIFF
--- a/data/az-assess-source-checks.json
+++ b/data/az-assess-source-checks.json
@@ -8439,7 +8439,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enforce password history' is set to '24 or more password(' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Enforce password history: 24 or more passwords. Or: secpol.msc > Account Policies > Password Policy > Enforce password history"
   },
   {
     "checkId": "WIN-ACCOUNT-002",
@@ -8461,7 +8462,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Maximum password age' is set to '365 or fewer days, but n' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Maximum password age: 365 or fewer days (but not 0). Or: secpol.msc > Account Policies > Password Policy > Maximum password age"
   },
   {
     "checkId": "WIN-ACCOUNT-003",
@@ -8483,7 +8485,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Minimum password age' is set to '1 or more day(s)'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Minimum password age: 1 or more day. Or: secpol.msc > Account Policies > Password Policy > Minimum password age"
   },
   {
     "checkId": "WIN-ACCOUNT-004",
@@ -8505,7 +8508,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Minimum password length' is set to '14 or more character(' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Minimum password length: 14 or more characters. Or: secpol.msc > Account Policies > Password Policy > Minimum password length"
   },
   {
     "checkId": "WIN-ACCOUNT-005",
@@ -8527,7 +8531,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Password must meet complexity requirements' is set to 'En' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Password must meet complexity requirements: Enabled. Or: secpol.msc > Account Policies > Password Policy > Password must meet complexity requirements"
   },
   {
     "checkId": "WIN-ACCOUNT-006",
@@ -8549,7 +8554,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Relax minimum password length limits' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Relax minimum password length limits: Enabled. Or: secpol.msc > Account Policies > Password Policy > Relax minimum password length limits"
   },
   {
     "checkId": "WIN-ACCOUNT-007",
@@ -8571,7 +8577,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Store passwords using reversible encryption' is set to 'D' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Store passwords using reversible encryption: Disabled. Or: secpol.msc > Account Policies > Password Policy > Store passwords using reversible encryption"
   },
   {
     "checkId": "WIN-ACCOUNT-008",
@@ -8593,7 +8600,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Account lockout duration' is set to '15 or more minute(s)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy > Account lockout duration: 15 or more minutes. Or: secpol.msc > Account Policies > Account Lockout Policy > Account lockout duration"
   },
   {
     "checkId": "WIN-ACCOUNT-009",
@@ -8615,7 +8623,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Account lockout threshold' is set to '5 or fewer invalid ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy > Account lockout threshold: 5 or fewer invalid logon attempts (not 0). Or: secpol.msc > Account Policies > Account Lockout Policy > Account lockout threshold"
   },
   {
     "checkId": "WIN-ACCOUNT-010",
@@ -8637,7 +8646,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow Administrator account lockout' is set to 'Enabled' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy > Allow Administrator account lockout: Enabled (MS only). Or: secpol.msc > Account Policies > Account Lockout Policy > Allow Administrator account lockout"
   },
   {
     "checkId": "WIN-ACCOUNT-011",
@@ -8659,7 +8669,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Reset account lockout counter after' is set to '15 or mor' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy > Reset account lockout counter after: 15 or more minutes. Or: secpol.msc > Account Policies > Account Lockout Policy > Reset account lockout counter after"
   },
   {
     "checkId": "WIN-AUDIT-001",
@@ -8681,7 +8692,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Access Credential Manager as a trusted caller' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Access Credential Manager as a trusted caller: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment > Access Credential Manager as a trusted caller"
   },
   {
     "checkId": "WIN-AUDIT-002",
@@ -8703,7 +8715,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Access this computer from the network' is set to 'Adminis' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Access this computer from the network: Administrators, Authenticated Users, ENTERPRISE DOMAIN CONTROLLERS (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-003",
@@ -8725,7 +8738,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Access this computer from the network'  is set to 'Admini' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Access this computer from the network: Administrators, Authenticated Users (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-004",
@@ -8747,7 +8761,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Act as part of the operating system' is set to 'No One'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Act as part of the operating system: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment > Act as part of the operating system"
   },
   {
     "checkId": "WIN-AUDIT-005",
@@ -8769,7 +8784,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Add workstations to domain' is set to 'Administ' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Add workstations to domain: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment > Add workstations to domain"
   },
   {
     "checkId": "WIN-AUDIT-006",
@@ -8791,7 +8807,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Adjust memory quotas for a process' is set to 'Administra' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Adjust memory quotas for a process: Administrators, LOCAL SERVICE, NETWORK SERVICE. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-007",
@@ -8813,7 +8830,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow log on locally' is set to 'Administrators, ENTERPRI' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Allow log on locally: Administrators, ENTERPRISE DOMAIN CONTROLLERS (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-008",
@@ -8835,7 +8853,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow log on locally' is set to 'Administrators' (MS only' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Allow log on locally: Administrators (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-009",
@@ -8857,7 +8876,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Allow log on through Remote Desktop Services' i' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Allow log on through Remote Desktop Services: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-010",
@@ -8879,7 +8899,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Allow log on through Remote Desktop Services' i' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Allow log on through Remote Desktop Services: Administrators, Remote Desktop Users (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-011",
@@ -8901,7 +8922,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Back up files and directories' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Back up files and directories: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment > Back up files and directories"
   },
   {
     "checkId": "WIN-AUDIT-012",
@@ -8923,7 +8945,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Change the system time' is set to 'Administrato' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Change the system time: Administrators, LOCAL SERVICE. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-013",
@@ -8945,7 +8968,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Create a pagefile' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create a pagefile: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment > Create a pagefile"
   },
   {
     "checkId": "WIN-AUDIT-014",
@@ -8967,7 +8991,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Create a token object' is set to 'No One'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create a token object: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment > Create a token object"
   },
   {
     "checkId": "WIN-AUDIT-015",
@@ -8989,7 +9014,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Create global objects' is set to 'Administrators, LOCAL S' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create global objects: Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-016",
@@ -9011,7 +9037,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Create permanent shared objects' is set to 'No One'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create permanent shared objects: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-017",
@@ -9033,7 +9060,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Create symbolic links' is set to 'Administrators' (DC onl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create symbolic links: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-018",
@@ -9055,7 +9083,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Create symbolic links' is set to 'Administrators, NT VIRT' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create symbolic links: Administrators, NT VIRTUAL MACHINE\\Virtual Machines (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-019",
@@ -9077,7 +9106,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Debug programs' is set to 'Administrators'' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Debug programs: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment > Debug programs"
   },
   {
     "checkId": "WIN-AUDIT-020",
@@ -9099,7 +9129,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Deny access to this computer from the network' to include' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny access to this computer from the network: include Guests (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-021",
@@ -9121,7 +9152,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Deny access to this computer from the network' to include' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny access to this computer from the network: Guests, Local account and member of Administrators group (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-022",
@@ -9143,7 +9175,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Deny log on as a batch job' to include 'Guests'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on as a batch job: include Guests. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-023",
@@ -9165,7 +9198,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Deny log on as a service' to include 'Guests'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on as a service: include Guests. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-024",
@@ -9187,7 +9221,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Deny log on locally' to include 'Guests'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on locally: include Guests. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-025",
@@ -9209,7 +9244,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Deny log on through Remote Desktop Services' to include '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on through Remote Desktop Services: include Guests (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-026",
@@ -9231,7 +9267,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Deny log on through Remote Desktop Services' is set to 'G' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on through Remote Desktop Services: Guests, Local account (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-027",
@@ -9253,7 +9290,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable computer and user accounts to be trusted for deleg' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Enable computer and user accounts to be trusted for delegation: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-028",
@@ -9275,7 +9313,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable computer and user accounts to be trusted for deleg' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Enable computer and user accounts to be trusted for delegation: (blank — No One) (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-029",
@@ -9297,7 +9336,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Force shutdown from a remote system' is set to ' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Force shutdown from a remote system: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-030",
@@ -9319,7 +9359,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Generate security audits' is set to 'LOCAL SERVICE, NETWO' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Generate security audits: LOCAL SERVICE, NETWORK SERVICE, RESTRICTED SERVICES\\PrintSpoolerService. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-031",
@@ -9341,7 +9382,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Impersonate a client after authentication' is set to 'Adm' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Impersonate a client after authentication: Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE, RESTRICTED SERVICES\\PrintSpoolerService (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-032",
@@ -9363,7 +9405,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Impersonate a client after authentication' is set to 'Adm' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Impersonate a client after authentication: Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE, RESTRICTED SERVICES\\PrintSpoolerService (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-033",
@@ -9385,7 +9428,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Increase scheduling priority' is set to 'Administrators, ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Increase scheduling priority: Administrators, Window Manager\\Window Manager Group. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-034",
@@ -9407,7 +9451,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Load and unload device drivers' is set to 'Administrators' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Load and unload device drivers: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-035",
@@ -9429,7 +9474,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Lock pages in memory' is set to 'No One'' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Lock pages in memory: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-036",
@@ -9451,7 +9497,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Log on as a batch job' is set to 'Administrators' (DC Onl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Log on as a batch job: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-037",
@@ -9473,7 +9520,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Manage auditing and security log' is set to 'Administrato' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Manage auditing and security log: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-038",
@@ -9495,7 +9543,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Manage auditing and security log' is set to 'Administrato' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Manage auditing and security log: Administrators (MS only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-039",
@@ -9517,7 +9566,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Modify an object label' is set to 'No One'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Modify an object label: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-040",
@@ -9539,7 +9589,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Modify firmware environment values' is set to 'Administra' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Modify firmware environment values: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-041",
@@ -9561,7 +9612,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Perform volume maintenance tasks' is set to 'Administrato' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Perform volume maintenance tasks: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-042",
@@ -9583,7 +9635,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Profile single process' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Profile single process: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-043",
@@ -9605,7 +9658,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Profile system performance' is set to 'Administrators, NT' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Profile system performance: Administrators, NT SERVICE\\WdiServiceHost. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-044",
@@ -9627,7 +9681,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Replace a process level token' is set to 'LOCAL SERVICE, ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Replace a process level token: LOCAL SERVICE, NETWORK SERVICE. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-045",
@@ -9649,7 +9704,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Restore files and directories' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Restore files and directories: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-046",
@@ -9671,7 +9727,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Shut down the system' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Shut down the system: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-047",
@@ -9693,7 +9750,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Synchronize directory service data' is set to 'No One' (D' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Synchronize directory service data: (blank — No One) (DC only). Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-048",
@@ -9715,7 +9773,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Take ownership of files or other objects' is set to 'Admi' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Take ownership of files or other objects: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment"
   },
   {
     "checkId": "WIN-AUDIT-049",
@@ -9737,7 +9796,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Accounts: Guest account status' is set to 'Disabled' (MS ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Accounts: Guest account status: Disabled (MS only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-050",
@@ -9759,7 +9819,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Accounts: Limit local account use of blank passwords to c' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Accounts: Limit local account use of blank passwords to console logon only: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-051",
@@ -9781,7 +9842,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Configure 'Accounts: Rename administrator account'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Accounts: Rename administrator account: set to a non-default name. Or: secpol.msc > Local Policies > Security Options > Accounts: Rename administrator account"
   },
   {
     "checkId": "WIN-AUDIT-052",
@@ -9803,7 +9865,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Configure 'Accounts: Rename guest account'' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Accounts: Rename guest account: set to a non-default name. Or: secpol.msc > Local Policies > Security Options > Accounts: Rename guest account"
   },
   {
     "checkId": "WIN-AUDIT-053",
@@ -9825,7 +9888,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit: Force audit policy subcategory settings (Windows V' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Audit: Force audit policy subcategory settings to override audit policy category settings: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-054",
@@ -9847,7 +9911,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit: Shut down system immediately if unable to log secu' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Audit: Shut down system immediately if unable to log security audits: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-055",
@@ -9869,7 +9934,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Devices: Prevent users from installing printer drivers' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Devices: Prevent users from installing printer drivers: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-056",
@@ -9891,7 +9957,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Domain controller: Allow server operators to schedule tas' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: Allow server operators to schedule tasks: Disabled (DC only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-057",
@@ -9913,7 +9980,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Domain controller: Allow vulnerable Netlogon secure chann' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: Allow vulnerable Netlogon secure channel connections: Not Configured (DC only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-058",
@@ -9935,7 +10003,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Domain controller: LDAP server channel binding token requ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: LDAP server channel binding token requirements: Always (DC only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-059",
@@ -9957,7 +10026,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Domain controller: LDAP server signing requirements Enfor' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: LDAP server signing requirements: Require signing (DC only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-060",
@@ -9979,7 +10049,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Domain controller: Refuse machine account password change' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: Refuse machine account password changes: Disabled (DC only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-061",
@@ -10001,7 +10072,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Domain member: Digitally encrypt or sign secure channel d' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Digitally encrypt or sign secure channel data (always): Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-062",
@@ -10023,7 +10095,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Domain member: Digitally encrypt secure channel data (whe' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Digitally encrypt secure channel data (when possible): Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-063",
@@ -10045,7 +10118,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Domain member: Digitally sign secure channel data (when p' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Digitally sign secure channel data (when possible): Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-064",
@@ -10067,7 +10141,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Domain member: Disable machine account password' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Disable machine account password changes: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-065",
@@ -10089,7 +10164,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Domain member: Maximum machine account password age' is s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Maximum machine account password age: 30 or fewer days (not 0). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-066",
@@ -10111,7 +10187,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Domain member: Require strong (Windows 2000 or later) ses' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Require strong (Windows 2000 or later) session key: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-067",
@@ -10133,7 +10210,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Interactive logon: Do not require CTRL+ALT+DEL'' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Do not require CTRL+ALT+DEL: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-068",
@@ -10155,7 +10233,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Interactive logon: Don't display last signed-in' is set t' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Don't display last signed-in: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-069",
@@ -10177,7 +10256,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Interactive logon: Machine inactivity limit' is set to '9' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Machine inactivity limit: 900 or fewer seconds (not 0). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-070",
@@ -10199,7 +10279,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Configure 'Interactive logon: Message text for users attempting t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Message text for users attempting to log on: configure with organizational legal notice text. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-071",
@@ -10221,7 +10302,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Configure 'Interactive logon: Message title for users attempting ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Message title for users attempting to log on: configure with organizational title text. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-072",
@@ -10243,7 +10325,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Interactive logon: Number of previous logons to cache (in' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Number of previous logons to cache: 4 or fewer (MS only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-073",
@@ -10265,7 +10348,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Interactive logon: Prompt user to change password before ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Prompt user to change password before expiration: 5 to 14 days. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-074",
@@ -10287,7 +10371,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Interactive logon: Require Domain Controller Authenticati' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Require Domain Controller Authentication to unlock workstation: Enabled (MS only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-075",
@@ -10309,7 +10394,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Interactive logon: Smart card removal behavior' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Smart card removal behavior: Lock Workstation (or higher). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-076",
@@ -10331,7 +10417,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Microsoft network client: Digitally sign communications (' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network client: Digitally sign communications (always): Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-077",
@@ -10353,7 +10440,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Microsoft network client: Send unencrypted pass' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network client: Send unencrypted password to third-party SMB servers: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-078",
@@ -10375,7 +10463,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Microsoft network server: Amount of idle time required be' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network server: Amount of idle time required before suspending session: 15 or fewer minutes. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-079",
@@ -10397,7 +10486,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Microsoft network server: Digitally sign communications (' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network server: Digitally sign communications (always): Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-080",
@@ -10419,7 +10509,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Microsoft network server: Disconnect clients when logon h' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network server: Disconnect clients when logon hours expire: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-081",
@@ -10441,7 +10532,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Microsoft network server: Server SPN target name validati' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network server: Server SPN target name validation level: Accept if provided by client (or higher) (MS only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-082",
@@ -10463,7 +10555,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Network access: Allow anonymous SID/Name transl' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Allow anonymous SID/Name translation: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-083",
@@ -10485,7 +10578,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Do not allow anonymous enumeration of SAM' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Do not allow anonymous enumeration of SAM accounts: Enabled (MS only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-084",
@@ -10507,7 +10601,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Do not allow anonymous enumeration of SAM' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Do not allow anonymous enumeration of SAM accounts and shares: Enabled (MS only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-085",
@@ -10529,7 +10624,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Do not allow storage of passwords and cre' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Do not allow storage of passwords and credentials for network authentication: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-086",
@@ -10551,7 +10647,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Network access: Let Everyone permissions apply ' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Let Everyone permissions apply to anonymous users: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-087",
@@ -10573,7 +10670,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Named Pipes that can be accessed anonymou' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Named Pipes that can be accessed anonymously: (configured per DC requirements). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-088",
@@ -10595,7 +10693,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Named Pipes that can be accessed anonymou' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Named Pipes that can be accessed anonymously: (blank — empty list) (MS only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-089",
@@ -10617,7 +10716,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Remotely accessible registry paths' is co' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Remotely accessible registry paths: configure per CIS benchmark. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-090",
@@ -10639,7 +10739,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Remotely accessible registry paths and su' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Remotely accessible registry paths and sub-paths: configure per CIS benchmark. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-091",
@@ -10661,7 +10762,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Restrict anonymous access to Named Pipes ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Restrict anonymous access to Named Pipes and Shares: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-092",
@@ -10683,7 +10785,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Restrict clients allowed to make remote c' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Restrict clients allowed to make remote calls to SAM: Administrators: Remote Access: Allow (MS only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-093",
@@ -10705,7 +10808,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network access: Shares that can be accessed anonymously' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Shares that can be accessed anonymously: (blank — None). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-094",
@@ -10727,7 +10831,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Network access: Sharing and security model for ' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Sharing and security model for local accounts: Classic - local users authenticate as themselves. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-095",
@@ -10749,7 +10854,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: Allow Local System to use computer iden' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Allow Local System to use computer identity for NTLM: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-096",
@@ -10771,7 +10877,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Overly permissive user rights assignment for 'Ensure 'Network security: Allow LocalSystem NULL sessio' allows non-administrative principals to perform privileged OS operations."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Allow LocalSystem NULL session fallback: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-097",
@@ -10793,7 +10900,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Network Security: Allow PKU2U authentication requests to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network Security: Allow PKU2U authentication requests to this computer to use online identities: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-098",
@@ -10815,7 +10923,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: Configure encryption types allowed for ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Configure encryption types allowed for Kerberos: AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-099",
@@ -10837,7 +10946,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Network security: Force logoff when logon hours expire' i' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Force logoff when logon hours expire: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-100",
@@ -10859,7 +10969,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: LAN Manager authentication level' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: LAN Manager authentication level: Send NTLMv2 response only. Refuse LM & NTLM. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-101",
@@ -10881,7 +10992,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: LDAP client encryption requirements' is' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: LDAP client encryption requirements: Negotiate sealing (or higher). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-102",
@@ -10903,7 +11015,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: LDAP client signing requirements' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: LDAP client signing requirements: Negotiate signing (or higher). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-103",
@@ -10925,7 +11038,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: Minimum session security for NTLM SSP b' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Minimum session security for NTLM SSP based clients: Require NTLMv2 session security, Require 128-bit encryption. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-104",
@@ -10947,7 +11061,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: Minimum session security for NTLM SSP b' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Minimum session security for NTLM SSP based servers: Require NTLMv2 session security, Require 128-bit encryption. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-105",
@@ -10969,7 +11084,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Network security: Restrict NTLM: Audit Incoming NTLM Traf' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Restrict NTLM: Audit Incoming NTLM Traffic: Enable auditing for all accounts. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-106",
@@ -10991,7 +11107,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: Restrict NTLM: Audit NTLM authenticatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Restrict NTLM: Audit NTLM authentication in this domain: Enable all (DC only). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-107",
@@ -11013,7 +11130,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Network security: Restrict NTLM: Outgoing NTLM traffic to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Restrict NTLM: Outgoing NTLM traffic to remote servers: Audit all (or higher). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-108",
@@ -11035,7 +11153,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Shutdown: Allow system to be shut down without having to ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Shutdown: Allow system to be shut down without having to log on: Disabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-109",
@@ -11057,7 +11176,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'System objects: Require case insensitivity for non-Window' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > System objects: Require case insensitivity for non-Windows subsystems: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-110",
@@ -11079,7 +11199,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'System objects: Strengthen default permissions of interna' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > System objects: Strengthen default permissions of internal system objects (e.g. Symbolic Links): Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-111",
@@ -11101,7 +11222,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'User Account Control: Admin Approval Mode for the Built-i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Admin Approval Mode for the Built-in Administrator account: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-112",
@@ -11123,7 +11245,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'User Account Control: Behavior of the elevation prompt fo' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Behavior of the elevation prompt for administrators in Admin Approval Mode: Prompt for consent on the secure desktop (or higher). Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-113",
@@ -11145,7 +11268,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'User Account Control: Behavior of the elevation prompt fo' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Behavior of the elevation prompt for standard users: Automatically deny elevation requests. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-114",
@@ -11167,7 +11291,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'User Account Control: Detect application installations an' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Detect application installations and prompt for elevation: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-115",
@@ -11189,7 +11314,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'User Account Control: Only elevate UIAccess applications ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Only elevate UIAccess applications that are installed in secure locations: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-116",
@@ -11211,7 +11337,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'User Account Control: Run all administrators in Admin App' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Run all administrators in Admin Approval Mode: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-117",
@@ -11233,7 +11360,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'User Account Control: Switch to the secure desktop when p' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Switch to the secure desktop when prompting for elevation: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-AUDIT-118",
@@ -11255,7 +11383,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'User Account Control: Virtualize file and registry write ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Virtualize file and registry write failures to per-user locations: Enabled. Or: secpol.msc > Local Policies > Security Options"
   },
   {
     "checkId": "WIN-SERVICES-001",
@@ -11277,7 +11406,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Print Spooler (Spooler)' is set to 'Disabled' (DC only)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "services.msc > Print Spooler > Properties > Startup type: Disabled > Stop service. Or via Group Policy: GPMC > Computer Configuration\\Windows Settings\\Security Settings\\System Services > Print Spooler: Disabled (DC only). Or: Stop-Service -Name Spooler -Force; Set-Service -Name Spooler -StartupType Disabled"
   },
   {
     "checkId": "WIN-SERVICES-002",
@@ -11299,7 +11429,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Print Spooler (Spooler)' is set to 'Disabled' (MS only)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "services.msc > Print Spooler > Properties > Startup type: Disabled > Stop service. Or via Group Policy: GPMC > Computer Configuration\\Windows Settings\\Security Settings\\System Services > Print Spooler: Disabled (MS only). Or: Stop-Service -Name Spooler -Force; Set-Service -Name Spooler -StartupType Disabled"
   },
   {
     "checkId": "WIN-FIREWALL-001",
@@ -11321,7 +11452,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Firewall state' is set to 'On (' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Windows Defender Firewall: Domain: Firewall state: On. Or: wf.msc > Windows Defender Firewall Properties > Domain Profile > Firewall state: On"
   },
   {
     "checkId": "WIN-FIREWALL-002",
@@ -11343,7 +11475,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Inbound connections' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Inbound connections: Block (default). Or: wf.msc > Domain Profile > Inbound connections: Block"
   },
   {
     "checkId": "WIN-FIREWALL-003",
@@ -11365,7 +11498,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Settings: Display a notificatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Settings: Display a notification: No. Or: wf.msc > Domain Profile > Settings > Display a notification: No"
   },
   {
     "checkId": "WIN-FIREWALL-004",
@@ -11387,7 +11521,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Logging: Name' is configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Logging: Name: configure a path (e.g., %SystemRoot%\\System32\\logfiles\\firewall\\pfirewall.log). Or: wf.msc > Domain Profile > Logging"
   },
   {
     "checkId": "WIN-FIREWALL-005",
@@ -11409,7 +11544,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Logging: Size limit (KB): 16,384 or greater. Or: wf.msc > Domain Profile > Logging > Size limit"
   },
   {
     "checkId": "WIN-FIREWALL-006",
@@ -11431,7 +11567,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Logging: Log dropped packets' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Logging: Log dropped packets: Yes. Or: wf.msc > Domain Profile > Logging > Log dropped packets"
   },
   {
     "checkId": "WIN-FIREWALL-007",
@@ -11453,7 +11590,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Logging: Log successful connect' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Logging: Log successful connections: Yes. Or: wf.msc > Domain Profile > Logging > Log successful connections"
   },
   {
     "checkId": "WIN-FIREWALL-008",
@@ -11475,7 +11613,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Firewall state' is set to 'On ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Firewall state: On. Or: wf.msc > Private Profile > Firewall state: On"
   },
   {
     "checkId": "WIN-FIREWALL-009",
@@ -11497,7 +11636,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Inbound connections' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Inbound connections: Block (default). Or: wf.msc > Private Profile > Inbound connections: Block"
   },
   {
     "checkId": "WIN-FIREWALL-010",
@@ -11519,7 +11659,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Settings: Display a notificati' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Settings: Display a notification: No. Or: wf.msc > Private Profile > Settings > Display a notification: No"
   },
   {
     "checkId": "WIN-FIREWALL-011",
@@ -11541,7 +11682,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Logging: Name' is configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Logging: Name: configure a path. Or: wf.msc > Private Profile > Logging > Log file name"
   },
   {
     "checkId": "WIN-FIREWALL-012",
@@ -11563,7 +11705,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Logging: Size limit (KB): 16,384 or greater. Or: wf.msc > Private Profile > Logging > Size limit"
   },
   {
     "checkId": "WIN-FIREWALL-013",
@@ -11585,7 +11728,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Logging: Log dropped packets' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Logging: Log dropped packets: Yes. Or: wf.msc > Private Profile > Logging > Log dropped packets"
   },
   {
     "checkId": "WIN-FIREWALL-014",
@@ -11607,7 +11751,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Logging: Log successful connec' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Logging: Log successful connections: Yes. Or: wf.msc > Private Profile > Logging > Log successful connections"
   },
   {
     "checkId": "WIN-FIREWALL-015",
@@ -11629,7 +11774,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Firewall state' is set to 'On (' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Firewall state: On. Or: wf.msc > Public Profile > Firewall state: On"
   },
   {
     "checkId": "WIN-FIREWALL-016",
@@ -11651,7 +11797,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Inbound connections' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Inbound connections: Block (default). Or: wf.msc > Public Profile > Inbound connections: Block"
   },
   {
     "checkId": "WIN-FIREWALL-017",
@@ -11673,7 +11820,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Settings: Display a notificatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Settings: Display a notification: No. Or: wf.msc > Public Profile > Settings > Display a notification: No"
   },
   {
     "checkId": "WIN-FIREWALL-018",
@@ -11695,7 +11843,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Settings: Apply local firewall ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Settings: Apply local firewall rules: No. Or: wf.msc > Public Profile > Settings > Apply local firewall rules: No"
   },
   {
     "checkId": "WIN-FIREWALL-019",
@@ -11717,7 +11866,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Settings: Apply local connectio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Settings: Apply local connection security rules: No. Or: wf.msc > Public Profile > Settings > Apply local connection security rules: No"
   },
   {
     "checkId": "WIN-FIREWALL-020",
@@ -11739,7 +11889,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Logging: Name' is configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Logging: Name: configure a path. Or: wf.msc > Public Profile > Logging > Log file name"
   },
   {
     "checkId": "WIN-FIREWALL-021",
@@ -11761,7 +11912,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Logging: Size limit (KB): 16,384 or greater. Or: wf.msc > Public Profile > Logging > Size limit"
   },
   {
     "checkId": "WIN-FIREWALL-022",
@@ -11783,7 +11935,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Logging: Log dropped packets' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Logging: Log dropped packets: Yes. Or: wf.msc > Public Profile > Logging > Log dropped packets"
   },
   {
     "checkId": "WIN-FIREWALL-023",
@@ -11805,7 +11958,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Logging: Log successful connect' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Logging: Log successful connections: Yes. Or: wf.msc > Public Profile > Logging > Log successful connections"
   },
   {
     "checkId": "WIN-AUDIT-119",
@@ -11827,7 +11981,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Credential Validation' is set to 'Success and Failu' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Logon > Audit Credential Validation: Success and Failure. Or: auditpol.exe /set /subcategory:\"Credential Validation\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-120",
@@ -11849,7 +12004,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Kerberos Authentication Service' is set to 'Success' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Logon > Audit Kerberos Authentication Service: Success and Failure (DC only). Or: auditpol.exe /set /subcategory:\"Kerberos Authentication Service\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-121",
@@ -11871,7 +12027,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Kerberos Service Ticket Operations' is set to 'Succ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Logon > Audit Kerberos Service Ticket Operations: Success and Failure (DC only). Or: auditpol.exe /set /subcategory:\"Kerberos Service Ticket Operations\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-122",
@@ -11893,7 +12050,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Audit Application Group Management' is set to 'Success an' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Application Group Management: Success and Failure. Or: auditpol.exe /set /subcategory:\"Application Group Management\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-123",
@@ -11915,7 +12073,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Computer Account Management' is set to include 'Suc' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Computer Account Management: Success (DC only). Or: auditpol.exe /set /subcategory:\"Computer Account Management\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-124",
@@ -11937,7 +12096,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Distribution Group Management' is set to include 'S' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Distribution Group Management: Success (DC only). Or: auditpol.exe /set /subcategory:\"Distribution Group Management\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-125",
@@ -11959,7 +12119,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Audit Other Account Management Events' is set to include ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Other Account Management Events: Success (DC only). Or: auditpol.exe /set /subcategory:\"Other Account Management Events\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-126",
@@ -11981,7 +12142,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Security Group Management' is set to include 'Succe' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Security Group Management: Success. Or: auditpol.exe /set /subcategory:\"Security Group Management\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-127",
@@ -12003,7 +12165,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit User Account Management' is set to 'Success and Fai' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit User Account Management: Success and Failure. Or: auditpol.exe /set /subcategory:\"User Account Management\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-128",
@@ -12025,7 +12188,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit PNP Activity' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Detailed Tracking > Audit PNP Activity: Success. Or: auditpol.exe /set /subcategory:\"Plug and Play Events\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-129",
@@ -12047,7 +12211,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Audit Process Creation' is set to include 'Success'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Detailed Tracking > Audit Process Creation: Success. Or: auditpol.exe /set /subcategory:\"Process Creation\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-130",
@@ -12069,7 +12234,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Directory Service Access' is set to include 'Failur' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\DS Access > Audit Directory Service Access: Failure (DC only). Or: auditpol.exe /set /subcategory:\"Directory Service Access\" /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-131",
@@ -12091,7 +12257,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Directory Service Changes' is set to include 'Succe' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\DS Access > Audit Directory Service Changes: Success (DC only). Or: auditpol.exe /set /subcategory:\"Directory Service Changes\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-132",
@@ -12113,7 +12280,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Audit Account Lockout' is set to include 'Failure'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Account Lockout: Failure. Or: auditpol.exe /set /subcategory:\"Account Lockout\" /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-133",
@@ -12135,7 +12303,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Group Membership' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Group Membership: Success. Or: auditpol.exe /set /subcategory:\"Group Membership\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-134",
@@ -12157,7 +12326,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Logoff' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Logoff: Success. Or: auditpol.exe /set /subcategory:\"Logoff\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-135",
@@ -12179,7 +12349,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Logon' is set to 'Success and Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Logon: Success and Failure. Or: auditpol.exe /set /subcategory:\"Logon\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-136",
@@ -12201,7 +12372,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and F' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Other Logon/Logoff Events: Success and Failure. Or: auditpol.exe /set /subcategory:\"Other Logon/Logoff Events\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-137",
@@ -12223,7 +12395,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Special Logon' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Special Logon: Success. Or: auditpol.exe /set /subcategory:\"Special Logon\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-138",
@@ -12245,7 +12418,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Detailed File Share' is set to include 'Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access > Audit Detailed File Share: Failure. Or: auditpol.exe /set /subcategory:\"Detailed File Share\" /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-139",
@@ -12267,7 +12441,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit File Share' is set to 'Success and Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access > Audit File Share: Success and Failure. Or: auditpol.exe /set /subcategory:\"File Share\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-140",
@@ -12289,7 +12464,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Other Object Access Events' is set to 'Success and ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access > Audit Other Object Access Events: Success and Failure. Or: auditpol.exe /set /subcategory:\"Other Object Access Events\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-141",
@@ -12311,7 +12487,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Removable Storage' is set to 'Success and Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access > Audit Removable Storage: Success and Failure. Or: auditpol.exe /set /subcategory:\"Removable Storage\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-142",
@@ -12333,7 +12510,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Audit Policy Change' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit Audit Policy Change: Success. Or: auditpol.exe /set /subcategory:\"Audit Policy Change\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-143",
@@ -12355,7 +12533,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Authentication Policy Change' is set to include 'Su' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit Authentication Policy Change: Success. Or: auditpol.exe /set /subcategory:\"Authentication Policy Change\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-144",
@@ -12377,7 +12556,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Authorization Policy Change' is set to include 'Suc' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit Authorization Policy Change: Success. Or: auditpol.exe /set /subcategory:\"Authorization Policy Change\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-145",
@@ -12399,7 +12579,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Audit MPSSVC Rule-Level Policy Change' is set to 'Success' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit MPSSVC Rule-Level Policy Change: Success and Failure. Or: auditpol.exe /set /subcategory:\"MPSSVC Rule-Level Policy Change\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-146",
@@ -12421,7 +12602,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Other Policy Change Events' is set to include 'Fail' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit Other Policy Change Events: Failure. Or: auditpol.exe /set /subcategory:\"Other Policy Change Events\" /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-147",
@@ -12443,7 +12625,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Sensitive Privilege Use' is set to 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Privilege Use > Audit Sensitive Privilege Use: Success and Failure. Or: auditpol.exe /set /subcategory:\"Sensitive Privilege Use\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-148",
@@ -12465,7 +12648,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Audit IPsec Driver' is set to 'Success and Failure'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit IPsec Driver: Success and Failure. Or: auditpol.exe /set /subcategory:\"IPsec Driver\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-149",
@@ -12487,7 +12671,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Other System Events' is set to 'Success and Failure' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit Other System Events: Success and Failure. Or: auditpol.exe /set /subcategory:\"Other System Events\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-AUDIT-150",
@@ -12509,7 +12694,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Security State Change' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit Security State Change: Success. Or: auditpol.exe /set /subcategory:\"Security State Change\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-151",
@@ -12531,7 +12717,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit Security System Extension' is set to include 'Succe' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit Security System Extension: Success. Or: auditpol.exe /set /subcategory:\"Security System Extension\" /success:enable"
   },
   {
     "checkId": "WIN-AUDIT-152",
@@ -12553,7 +12740,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit System Integrity' is set to 'Success and Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit System Integrity: Success and Failure. Or: auditpol.exe /set /subcategory:\"System Integrity\" /success:enable /failure:enable"
   },
   {
     "checkId": "WIN-CONFIG-001",
@@ -12575,7 +12763,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Online Tips' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Control Panel\\Regional and Language Options > Allow Online Tips: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-002",
@@ -12597,7 +12786,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Prevent enabling lock screen camera' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Control Panel\\Personalization > Prevent enabling lock screen camera: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-003",
@@ -12619,7 +12809,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Prevent enabling lock screen slide show' is set to 'Enabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Control Panel\\Personalization > Prevent enabling lock screen slide show: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-004",
@@ -12641,7 +12832,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow users to enable online speech recognition services'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Speech > Allow users to enable online speech recognition services: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-005",
@@ -12663,7 +12855,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Apply UAC restrictions to local accounts on network logon' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply UAC restrictions to local accounts on network logons via registry: HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System > LocalAccountTokenFilterPolicy: 0 (MS only). Or deploy MSS ADMX templates and enable the setting in GPMC."
   },
   {
     "checkId": "WIN-CONFIG-006",
@@ -12685,7 +12878,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure SMB v1 client driver' is set to 'Enabled: Disab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Configure SMB v1 client driver: Enabled: Disable driver. Or: sc.exe config mrxsmb10 start= disabled && sc.exe stop mrxsmb10"
   },
   {
     "checkId": "WIN-CONFIG-007",
@@ -12707,7 +12901,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure SMB v1 server' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Disable SMB v1 server: Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force. Or: GPMC > Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Configure SMB v1 server: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-008",
@@ -12729,7 +12924,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable Certificate Padding' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System > Enable Certificate Padding: Enabled. Or via registry: HKLM\\Software\\Microsoft\\Cryptography\\Wintrust\\Config > EnableCertPaddingCheck: 1"
   },
   {
     "checkId": "WIN-CONFIG-009",
@@ -12751,7 +12947,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable Structured Exception Handling Overwrite Protection' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Enable SEHOP via registry: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\kernel > DisableExceptionChainValidation: 0. Or deploy MSS ADMX and enable 'MSS: Enable Structured Exception Handling Overwrite Protection (SEHOP)': Enabled in GPMC."
   },
   {
     "checkId": "WIN-CONFIG-010",
@@ -12773,7 +12970,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'NetBT NodeType configuration' is set to 'Enabled: P-node ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Configure NetBT NodeType configuration: Enabled: P-node. Or via registry: HKLM\\SYSTEM\\CurrentControlSet\\Services\\NetBT\\Parameters > NodeType: 2"
   },
   {
     "checkId": "WIN-CONFIG-011",
@@ -12795,7 +12993,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon' is set to '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (AutoAdminLogon) Enable Automatic Logon: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-012",
@@ -12817,7 +13016,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing prot' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (DisableIPSourceRouting IPv6): Enabled: Highest protection"
   },
   {
     "checkId": "WIN-CONFIG-013",
@@ -12839,7 +13039,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'MSS: (DisableIPSourceRouting) IP source routing protectio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (DisableIPSourceRouting): Enabled: Highest protection"
   },
   {
     "checkId": "WIN-CONFIG-014",
@@ -12861,7 +13062,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'MSS: (EnableICMPRedirect) Allow ICMP redirects to overrid' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (EnableICMPRedirect): Disabled"
   },
   {
     "checkId": "WIN-CONFIG-015",
@@ -12883,7 +13085,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'MSS: (KeepAliveTime) How often keep-alive packets are sen' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (KeepAliveTime): Enabled: 300,000 or 5 minutes"
   },
   {
     "checkId": "WIN-CONFIG-016",
@@ -12905,7 +13108,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'MSS: (NoNameReleaseOnDemand) Allow the computer to ignore' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (NoNameReleaseOnDemand): Enabled"
   },
   {
     "checkId": "WIN-CONFIG-017",
@@ -12927,7 +13131,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'MSS: (PerformRouterDiscovery) Allow IRDP to detect and co' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (PerformRouterDiscovery): Disabled"
   },
   {
     "checkId": "WIN-CONFIG-018",
@@ -12949,7 +13154,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'MSS: (SafeDllSearchMode) Enable Safe DLL search mode' is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (SafeDllSearchMode): Enabled"
   },
   {
     "checkId": "WIN-CONFIG-019",
@@ -12971,7 +13177,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'MSS: (TcpMaxDataRetransmissions IPv6) How many times unac' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (TcpMaxDataRetransmissions IPv6): Enabled: 3"
   },
   {
     "checkId": "WIN-CONFIG-020",
@@ -12993,7 +13200,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'MSS: (TcpMaxDataRetransmissions) How many times unacknowl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (TcpMaxDataRetransmissions): Enabled: 3"
   },
   {
     "checkId": "WIN-CONFIG-021",
@@ -13015,7 +13223,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'MSS: (WarningLevel) Percentage threshold for the security' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (WarningLevel): Enabled: 90% or less"
   },
   {
     "checkId": "WIN-CONFIG-022",
@@ -13037,7 +13246,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configure multicast DNS (mDNS) protocol' is set to 'Disab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Configure multicast DNS (mDNS) protocol: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-023",
@@ -13059,7 +13269,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure NetBIOS settings' is set to 'Enabled: Disable N' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Configure NetBIOS settings: Enabled: Disable NetBIOS name resolution on public networks"
   },
   {
     "checkId": "WIN-CONFIG-024",
@@ -13081,7 +13292,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn off default IPv6 DNS Servers' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Turn off default IPv6 DNS Servers: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-025",
@@ -13103,7 +13315,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn off multicast name resolution' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Turn off multicast name resolution: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-026",
@@ -13125,7 +13338,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable Font Providers' is set to 'Disabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Enable Font Providers: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-027",
@@ -13147,7 +13361,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit client does not support encryption' is set to 'Enab' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Audit client does not support encryption: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-028",
@@ -13169,7 +13384,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit client does not support signing' is set to 'Enabled' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Audit client does not support signing: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-029",
@@ -13191,7 +13407,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit insecure guest logon' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Audit insecure guest logon: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-030",
@@ -13213,7 +13430,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable authentication rate limiter' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Enable authentication rate limiter: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-031",
@@ -13235,7 +13453,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable remote mailslots' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Enable remote mailslots: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-032",
@@ -13257,7 +13476,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Mandate the minimum version of SMB' is set to 'Enabled: 3' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Mandate the minimum version of SMB: Enabled: 3.1.1"
   },
   {
     "checkId": "WIN-CONFIG-033",
@@ -13279,7 +13499,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set authentication rate limiter delay (milliseconds)' is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Set authentication rate limiter delay (milliseconds): Enabled: 2000 or more"
   },
   {
     "checkId": "WIN-CONFIG-034",
@@ -13301,7 +13522,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit insecure guest logon' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Audit insecure guest logon: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-035",
@@ -13323,7 +13545,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit server does not support encryption' is set to 'Enab' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Audit server does not support encryption: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-036",
@@ -13345,7 +13568,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Audit server does not support signing' is set to 'Enabled' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Audit server does not support signing: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-037",
@@ -13367,7 +13591,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable insecure guest logons' is set to 'Disabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Enable insecure guest logons: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-038",
@@ -13389,7 +13614,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable remote mailslots' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Enable remote mailslots: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-039",
@@ -13411,7 +13637,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Mandate the minimum version of SMB' is set to 'Enabled: 3' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Mandate the minimum version of SMB: Enabled: 3.1.1"
   },
   {
     "checkId": "WIN-CONFIG-040",
@@ -13433,7 +13660,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require Encryption' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Require Encryption: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-041",
@@ -13455,7 +13683,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Link-Layer Topology Discovery > Turn on Mapper I/O (LLTDIO) driver: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-042",
@@ -13477,7 +13706,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Link-Layer Topology Discovery > Turn on Responder (RSPNDR) driver: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-043",
@@ -13499,7 +13729,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn off Microsoft Peer-to-Peer Networking Services' is s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Microsoft Peer-to-Peer Networking Services > Turn off Microsoft Peer-to-Peer Networking Services: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-044",
@@ -13521,7 +13752,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Prohibit installation and configuration of Network Bridge' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Network Connections > Prohibit installation and configuration of Network Bridge on your DNS domain network: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-045",
@@ -13543,7 +13775,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Prohibit use of Internet Connection Sharing on your DNS d' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Network Connections > Prohibit use of Internet Connection Sharing on your DNS domain network: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-046",
@@ -13565,7 +13798,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require domain users to elevate when setting a network's ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Network Connections > Require domain users to elevate when setting a network's location: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-047",
@@ -13587,7 +13821,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Hardened UNC Paths' is set to 'Enabled, with \"Require Mut' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Network Provider > Hardened UNC Paths: Enabled. Configure \\\\*\\NETLOGON and \\\\*\\SYSVOL with RequireMutualAuthentication=1, RequireIntegrity=1, RequirePrivacy=1"
   },
   {
     "checkId": "WIN-CONFIG-048",
@@ -13609,7 +13844,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Disable IPv6 (Ensure TCPIP6 Parameter 'DisabledComponents' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Disable IPv6 via registry: HKLM\\SYSTEM\\CurrentControlSet\\Services\\TCPIP6\\Parameters > DisabledComponents: 0xFF (255). Or: Set-NetAdapterBinding -Name '*' -ComponentID ms_tcpip6 -Enabled $false"
   },
   {
     "checkId": "WIN-CONFIG-049",
@@ -13631,7 +13867,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configuration of wireless settings using Windows Connect ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Wireless Lan Service\\WLAN Settings > Configuration of wireless settings using Windows Connect Now: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-050",
@@ -13653,7 +13890,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Prohibit access of the Windows Connect Now wizards' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Wireless Lan Service\\WLAN Settings > Prohibit access of the Windows Connect Now wizards: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-051",
@@ -13675,7 +13913,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Minimize the number of simultaneous connections to the In' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Windows Connection Manager > Minimize the number of simultaneous connections to the Internet or a Windows Domain: Enabled: 3 = Prevent Wi-Fi when on Ethernet"
   },
   {
     "checkId": "WIN-CONFIG-052",
@@ -13697,7 +13936,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Prohibit connection to non-domain networks when connected' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Windows Connection Manager > Prohibit connection to non-domain networks when connected to domain authenticated network: Enabled (MS only)"
   },
   {
     "checkId": "WIN-CONFIG-053",
@@ -13719,7 +13959,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow Print Spooler to accept client connections' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Allow Print Spooler to accept client connections: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-054",
@@ -13741,7 +13982,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Redirection Guard' is set to 'Enabled: Redirect' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure Redirection Guard: Enabled: Redirection Guard Enabled"
   },
   {
     "checkId": "WIN-CONFIG-055",
@@ -13763,7 +14005,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure RPC connection settings: Protocol to use for ou' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC connection settings: Protocol to use for outgoing RPC connections: Enabled: RPC over TCP"
   },
   {
     "checkId": "WIN-CONFIG-056",
@@ -13785,7 +14028,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure RPC connection settings: Use authentication for' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC connection settings: Use authentication for outgoing RPC connections: Enabled: Default"
   },
   {
     "checkId": "WIN-CONFIG-057",
@@ -13807,7 +14051,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure RPC listener settings: Protocols to allow for i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC listener settings: Protocols to allow for incoming RPC connections: Enabled: RPC over TCP"
   },
   {
     "checkId": "WIN-CONFIG-058",
@@ -13829,7 +14074,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure RPC listener settings: Authentication protocol ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC listener settings: Authentication protocol to use for incoming RPC connections: Enabled: Negotiate (or higher)"
   },
   {
     "checkId": "WIN-CONFIG-059",
@@ -13851,7 +14097,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure RPC over TCP port' is set to 'Enabled: 0'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC over TCP port: Enabled: 0"
   },
   {
     "checkId": "WIN-CONFIG-060",
@@ -13873,7 +14120,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure RPC packet level privacy setting for incoming c' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC packet level privacy setting for incoming connections: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-061",
@@ -13895,7 +14143,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Windows protected print' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure Windows protected print: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-062",
@@ -13917,7 +14166,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Limits print driver installation to Administrators' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Limits print driver installation to Administrators: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-063",
@@ -13939,7 +14189,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Manage processing of Queue-specific files' is set to 'Ena' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Manage processing of Queue-specific files: Enabled: Limit Queue-specific files to Color profiles"
   },
   {
     "checkId": "WIN-CONFIG-064",
@@ -13961,7 +14212,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Point and Print Restrictions: When installing drivers for' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Point and Print Restrictions: When installing drivers for a new connection: Enabled: Show warning and elevation prompt"
   },
   {
     "checkId": "WIN-CONFIG-065",
@@ -13983,7 +14235,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Point and Print Restrictions: When updating drivers for a' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Point and Print Restrictions: When updating drivers for an existing connection: Enabled: Show warning and elevation prompt"
   },
   {
     "checkId": "WIN-CONFIG-066",
@@ -14005,7 +14258,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require IPPS for IPP printers' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Require IPPS for IPP printers: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-067",
@@ -14027,7 +14281,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set TLS/SSL security policy for IPP printers: Disallow in' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Set TLS/SSL security policy for IPP printers: Disallow invalid certificate authority: Enabled: Checked"
   },
   {
     "checkId": "WIN-CONFIG-068",
@@ -14049,7 +14304,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set TLS/SSL security policy for IPP printers: Disallow no' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Set TLS/SSL security policy for IPP printers: Disallow non-server certificates: Enabled: Checked"
   },
   {
     "checkId": "WIN-CONFIG-069",
@@ -14071,7 +14327,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set TLS/SSL security policy for IPP printers: Disallow in' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Set TLS/SSL security policy for IPP printers: Disallow invalid certificate common name: Enabled: Checked"
   },
   {
     "checkId": "WIN-CONFIG-070",
@@ -14093,7 +14350,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set TLS/SSL security policy for IPP printers: Disallow in' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Set TLS/SSL security policy for IPP printers: Disallow invalid certificate date: Enabled: Checked"
   },
   {
     "checkId": "WIN-CONFIG-071",
@@ -14115,7 +14373,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off notifications network usage' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Start Menu and Taskbar\\Notifications > Turn off notifications network usage: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-072",
@@ -14137,7 +14396,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Include command line in process creation events' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Audit Process Creation > Include command line in process creation events: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-073",
@@ -14159,7 +14419,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Encryption Oracle Remediation' is set to 'Enabled: Force ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Credentials Delegation > Encryption Oracle Remediation: Enabled: Force Updated Clients"
   },
   {
     "checkId": "WIN-CONFIG-074",
@@ -14181,7 +14442,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Remote host allows delegation of non-exportable credentia' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Credentials Delegation > Remote host allows delegation of non-exportable credentials: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-075",
@@ -14203,7 +14465,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security' is set to 'Enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-076",
@@ -14225,7 +14488,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Select Platform Se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Select Platform Security Level: Secure Boot (or higher)"
   },
   {
     "checkId": "WIN-CONFIG-077",
@@ -14247,7 +14511,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Virtualization Bas' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Virtualization Based Protection of Code Integrity: Enabled with UEFI lock"
   },
   {
     "checkId": "WIN-CONFIG-078",
@@ -14269,7 +14534,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Require UEFI Memor' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Require UEFI Memory Attributes Table: True (checked)"
   },
   {
     "checkId": "WIN-CONFIG-079",
@@ -14291,7 +14557,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Credential Guard C' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Credential Guard Configuration: Enabled with UEFI lock (MS only)"
   },
   {
     "checkId": "WIN-CONFIG-080",
@@ -14313,7 +14580,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Credential Guard C' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Credential Guard Configuration: Disabled (DC only)"
   },
   {
     "checkId": "WIN-CONFIG-081",
@@ -14335,7 +14603,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Secure Launch Conf' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Secure Launch Configuration: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-082",
@@ -14357,7 +14626,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Prevent automatic download of applications associated wit' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Installation\\Device Installation Restrictions > Prevent automatic download of applications associated with device metadata: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-083",
@@ -14379,7 +14649,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Boot-Start Driver Initialization Policy' is set to 'Enabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Early Launch Antimalware > Boot-Start Driver Initialization Policy: Enabled: Good, unknown and bad but critical"
   },
   {
     "checkId": "WIN-CONFIG-084",
@@ -14401,7 +14672,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable / disable CLFS logfile authentication' is set to '' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\CLFS Logfile > Enable / disable CLFS logfile authentication: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-085",
@@ -14423,7 +14695,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configure security policy processing: Do not apply during' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Group Policy\\Security Policy Processing > Configure security policy processing: Do not apply during periodic background processing: Enabled: FALSE"
   },
   {
     "checkId": "WIN-CONFIG-086",
@@ -14445,7 +14718,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure security policy processing: Process even if the' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Group Policy\\Security Policy Processing > Configure security policy processing: Process even if the Group Policy objects have not changed: Enabled: TRUE"
   },
   {
     "checkId": "WIN-CONFIG-087",
@@ -14467,7 +14741,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Continue experiences on this device' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Group Policy > Continue experiences on this device: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-088",
@@ -14489,7 +14764,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off background refresh of Group Policy' is set to 'D' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Group Policy > Turn off background refresh of Group Policy: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-089",
@@ -14511,7 +14787,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn off downloading of print drivers over HTTP' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off downloading of print drivers over HTTP: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-090",
@@ -14533,7 +14810,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off handwriting personalization data sharing' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off handwriting personalization data sharing: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-091",
@@ -14555,7 +14833,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off handwriting recognition error reporting' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off handwriting recognition error reporting: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-092",
@@ -14577,7 +14856,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Internet Connection Wizard if URL connection is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-093",
@@ -14599,7 +14879,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Internet download for Web publishing and online ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Internet download for Web publishing and online ordering wizards: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-094",
@@ -14621,7 +14902,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn off printing over HTTP' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off printing over HTTP: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-095",
@@ -14643,7 +14925,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Registration if URL connection is referring to M' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Registration if URL connection is referring to Microsoft.com: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-096",
@@ -14665,7 +14948,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Search Companion content file updates' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Search Companion content file updates: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-097",
@@ -14687,7 +14971,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off the \"Order Prints\" picture task' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off the \"Order Prints\" picture task: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-098",
@@ -14709,7 +14994,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off the \"Publish to Web\" task for files and folders'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off the \"Publish to Web\" task for files and folders: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-099",
@@ -14731,7 +15017,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off the Windows Messenger Customer Experience Improv' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off the Windows Messenger Customer Experience Improvement Program: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-100",
@@ -14753,7 +15040,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Windows Customer Experience Improvement Program'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Windows Customer Experience Improvement Program: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-101",
@@ -14775,7 +15063,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Windows Error Reporting: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-102",
@@ -14797,7 +15086,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Support device authentication using certificate' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Kerberos > Support device authentication using certificate: Enabled: Automatic"
   },
   {
     "checkId": "WIN-CONFIG-103",
@@ -14819,7 +15109,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enumeration policy for external devices incompatible with' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Kernel DMA Protection > Enumeration policy for external devices incompatible with Kernel DMA Protection: Enabled: Block All"
   },
   {
     "checkId": "WIN-CONFIG-104",
@@ -14841,7 +15132,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure password backup directory' is set to 'Enabled: ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Configure password backup directory: Enabled: Active Directory (or Azure Active Directory)"
   },
   {
     "checkId": "WIN-CONFIG-105",
@@ -14863,7 +15155,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not allow password expiration time longer than require' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Do not allow password expiration time longer than required by policy: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-106",
@@ -14885,7 +15178,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable password encryption' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Enable password encryption: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-107",
@@ -14907,7 +15201,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Password Settings: Password Complexity' is set to 'Enable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Password Settings: Password Complexity: Enabled: Large letters + small letters + numbers + special characters (or Passphrase)"
   },
   {
     "checkId": "WIN-CONFIG-108",
@@ -14929,7 +15224,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Password Settings: Password Length' is set to 'Enabled: 1' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Password Settings: Password Length: Enabled: 15 or more"
   },
   {
     "checkId": "WIN-CONFIG-109",
@@ -14951,7 +15247,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Password Settings: Password Age (Days)' is set to 'Enable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Password Settings: Password Age (Days): Enabled: 30 or fewer"
   },
   {
     "checkId": "WIN-CONFIG-110",
@@ -14973,7 +15270,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Post-authentication actions: Grace period (hours)' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Post-authentication actions: Grace period (hours): Enabled: 8 or fewer hours (not 0)"
   },
   {
     "checkId": "WIN-CONFIG-111",
@@ -14995,7 +15293,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Post-authentication actions: Actions' is set to 'Enabled:' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Post-authentication actions: Actions: Enabled: Reset the password and logoff the managed account (or higher)"
   },
   {
     "checkId": "WIN-CONFIG-112",
@@ -15017,7 +15316,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Custom SSPs and APs to be loaded into LSASS' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Local Security Authority > Allow Custom SSPs and APs to be loaded into LSASS: Disabled (DC only)"
   },
   {
     "checkId": "WIN-CONFIG-113",
@@ -15039,7 +15339,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configures LSASS to run as a protected process' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Local Security Authority > Configures LSASS to run as a protected process: Enabled: Enabled with UEFI Lock"
   },
   {
     "checkId": "WIN-CONFIG-114",
@@ -15061,7 +15362,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Disallow copying of user input methods to the system acco' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Disallow copying of user input methods to the system account for sign-in: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-115",
@@ -15083,7 +15385,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Block user from showing account details on sign-in' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Block user from showing account details on sign-in: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-116",
@@ -15105,7 +15408,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Do not display network selection UI' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Do not display network selection UI: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-117",
@@ -15127,7 +15431,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not enumerate connected users on domain-joined compute' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Do not enumerate connected users on domain-joined computers: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-118",
@@ -15149,7 +15454,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enumerate local users on domain-joined computers' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Enumerate local users on domain-joined computers: Disabled (MS only)"
   },
   {
     "checkId": "WIN-CONFIG-119",
@@ -15171,7 +15477,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off app notifications on the lock screen' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Turn off app notifications on the lock screen: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-120",
@@ -15193,7 +15500,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn on convenience PIN sign-in' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Turn on convenience PIN sign-in: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-121",
@@ -15215,7 +15523,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Block NetBIOS-based discovery for domain controller locat' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Net Logon\\DC Locator DNS Records > Block NetBIOS-based discovery for domain controller location: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-122",
@@ -15237,7 +15546,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Clipboard synchronization across devices' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\OS Policies > Allow Clipboard synchronization across devices: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-123",
@@ -15259,7 +15569,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow upload of User Activities' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\User Profile > Allow upload of User Activities: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-124",
@@ -15281,7 +15592,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow network connectivity during connected-standby (on b' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Power Management\\Sleep Settings > Allow network connectivity during connected-standby (on battery): Disabled"
   },
   {
     "checkId": "WIN-CONFIG-125",
@@ -15303,7 +15615,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow network connectivity during connected-standby (plug' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Power Management\\Sleep Settings > Allow network connectivity during connected-standby (plugged in): Disabled"
   },
   {
     "checkId": "WIN-CONFIG-126",
@@ -15325,7 +15638,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require a password when a computer wakes (on battery)' is' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Power Management\\Sleep Settings > Require a password when a computer wakes (on battery): Enabled"
   },
   {
     "checkId": "WIN-CONFIG-127",
@@ -15347,7 +15661,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require a password when a computer wakes (plugged in)' is' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Power Management\\Sleep Settings > Require a password when a computer wakes (plugged in): Enabled"
   },
   {
     "checkId": "WIN-CONFIG-128",
@@ -15369,7 +15684,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configure Offer Remote Assistance' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Remote Assistance > Configure Offer Remote Assistance: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-129",
@@ -15391,7 +15707,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configure Solicited Remote Assistance' is set to 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Remote Assistance > Configure Solicited Remote Assistance: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-130",
@@ -15413,7 +15730,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Remote Procedure Call > Enable RPC Endpoint Mapper Client Authentication: Enabled (MS only)"
   },
   {
     "checkId": "WIN-CONFIG-131",
@@ -15435,7 +15753,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Restrict Unauthenticated RPC clients' is set to 'Enabled:' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Remote Procedure Call > Restrict Unauthenticated RPC clients: Enabled: Authenticated (MS only)"
   },
   {
     "checkId": "WIN-CONFIG-132",
@@ -15457,7 +15776,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure validation of ROCA-vulnerable WHfB keys during ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Security Account Manager > Configure validation of ROCA-vulnerable WHfB keys during authentication: Enabled: Block (DC only)"
   },
   {
     "checkId": "WIN-CONFIG-133",
@@ -15479,7 +15799,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure SAM change password RPC methods policy' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Security Account Manager > Configure SAM change password RPC methods policy: Enabled: Allow strong encryption change password RPC method only (DC only)"
   },
   {
     "checkId": "WIN-CONFIG-134",
@@ -15501,7 +15822,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure SAM change password RPC methods policy' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Security Account Manager > Configure SAM change password RPC methods policy: Enabled: Block all change password RPC methods (MS only)"
   },
   {
     "checkId": "WIN-CONFIG-135",
@@ -15523,7 +15845,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Microsoft Support Diagnostic Tool: Turn on MSDT interacti' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Troubleshooting and Diagnostics\\Microsoft Support Diagnostic Tool > Turn on MSDT interactive communication with support provider: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-136",
@@ -15545,7 +15868,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable/Disable PerfTrack' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Performance Control Panel\\WDI > Enable/Disable PerfTrack: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-137",
@@ -15567,7 +15891,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off the advertising ID' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off the advertising ID: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-138",
@@ -15589,7 +15914,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable Windows NTP Client' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Windows Time Service\\Time Providers > Enable Windows NTP Client: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-139",
@@ -15611,7 +15937,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable Windows NTP Server' is set to 'Disabled' (MS only)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Windows Time Service\\Time Providers > Enable Windows NTP Server: Disabled (MS only)"
   },
   {
     "checkId": "WIN-CONFIG-140",
@@ -15633,7 +15960,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow a Windows app to share application data between use' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\App Package Deployment > Allow a Windows app to share application data between users: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-141",
@@ -15655,7 +15983,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Not allow per-user unsigned packages to install by defaul' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Not allow per-user unsigned packages to install by default: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-142",
@@ -15677,7 +16006,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow Microsoft accounts to be optional' is set to 'Enabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft accounts > Allow Microsoft accounts to be optional: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-143",
@@ -15699,7 +16029,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Disallow Autoplay for non-volume devices' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\AutoPlay Policies > Disallow Autoplay for non-volume devices: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-144",
@@ -15721,7 +16052,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set the default behavior for AutoRun' is set to 'Enabled:' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\AutoPlay Policies > Set the default behavior for AutoRun: Enabled: Do not execute any autorun commands"
   },
   {
     "checkId": "WIN-CONFIG-145",
@@ -15743,7 +16075,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn off Autoplay' is set to 'Enabled: All drives'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\AutoPlay Policies > Turn off Autoplay: Enabled: All drives"
   },
   {
     "checkId": "WIN-CONFIG-146",
@@ -15765,7 +16098,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure enhanced anti-spoofing' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Biometrics\\Facial Features > Configure enhanced anti-spoofing: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-147",
@@ -15787,7 +16121,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Use of Camera' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Camera > Allow Use of Camera: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-148",
@@ -15809,7 +16144,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off cloud consumer account state content' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Turn off cloud consumer account state content: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-149",
@@ -15831,7 +16167,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off cloud optimized content' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Turn off cloud optimized content: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-150",
@@ -15853,7 +16190,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require pin for pairing' is set to 'Enabled: First Time' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Connect > Require pin for pairing: Enabled: First Time (or Always)"
   },
   {
     "checkId": "WIN-CONFIG-151",
@@ -15875,7 +16213,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not display the password reveal button' is set to 'Ena' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Credential User Interface > Do not display the password reveal button: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-152",
@@ -15897,7 +16236,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enumerate administrator accounts on elevation' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Credential User Interface > Enumerate administrator accounts on elevation: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-153",
@@ -15919,7 +16259,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow Diagnostic Data' is set to 'Enabled: Diagnostic dat' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Allow Diagnostic Data: Enabled: Diagnostic data off (not recommended) or Send required diagnostic data"
   },
   {
     "checkId": "WIN-CONFIG-154",
@@ -15941,7 +16282,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Authenticated Proxy usage for the Connected Use' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Configure Authenticated Proxy usage for the Connected User Experience and Telemetry service: Enabled: Disable Authenticated Proxy usage"
   },
   {
     "checkId": "WIN-CONFIG-155",
@@ -15963,7 +16305,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Do not show feedback notifications' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Do not show feedback notifications: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-156",
@@ -15985,7 +16328,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable OneSettings Auditing' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Enable OneSettings Auditing: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-157",
@@ -16007,7 +16351,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Limit Diagnostic Log Collection' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Limit Diagnostic Log Collection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-158",
@@ -16029,7 +16374,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Limit Dump Collection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Limit Dump Collection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-159",
@@ -16051,7 +16397,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable App Installer' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-160",
@@ -16073,7 +16420,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable App Installer Experimental Features' is set to 'Di' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer Experimental Features: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-161",
@@ -16095,7 +16443,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable App Installer Hash Override' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer Hash Override: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-162",
@@ -16117,7 +16466,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable App Installer Local Archive Malware Scan Override'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer Local Archive Malware Scan Override: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-163",
@@ -16139,7 +16489,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable App Installer ms-appinstaller protocol' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer ms-appinstaller protocol: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-164",
@@ -16161,7 +16512,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable App Installer Microsoft Store Source Certificate V' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer Microsoft Store Source Certificate Validation Bypass: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-165",
@@ -16183,7 +16535,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Enable Windows Package Manager command line interfaces' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable Windows Package Manager command line interfaces: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-166",
@@ -16205,7 +16558,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Application: Control Event Log behavior when the log file' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Application > Control Event Log behavior when the log file reaches its maximum size: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-167",
@@ -16227,7 +16581,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Application: Specify the maximum log file size (KB)' is s' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Application > Specify the maximum log file size (KB): Enabled: 32,768 or greater"
   },
   {
     "checkId": "WIN-CONFIG-168",
@@ -16249,7 +16604,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Security: Control Event Log behavior when the log file re' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Security > Control Event Log behavior when the log file reaches its maximum size: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-169",
@@ -16271,7 +16627,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Security: Specify the maximum log file size (KB)' is set ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Security > Specify the maximum log file size (KB): Enabled: 196,608 or greater"
   },
   {
     "checkId": "WIN-CONFIG-170",
@@ -16293,7 +16650,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Setup: Control Event Log behavior when the log file reach' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Setup > Control Event Log behavior when the log file reaches its maximum size: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-171",
@@ -16315,7 +16673,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Setup: Specify the maximum log file size (KB)' is set to ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Setup > Specify the maximum log file size (KB): Enabled: 32,768 or greater"
   },
   {
     "checkId": "WIN-CONFIG-172",
@@ -16337,7 +16696,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'System: Control Event Log behavior when the log file reac' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\System > Control Event Log behavior when the log file reaches its maximum size: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-173",
@@ -16359,7 +16719,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'System: Specify the maximum log file size (KB)' is set to' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\System > Specify the maximum log file size (KB): Enabled: 32,768 or greater"
   },
   {
     "checkId": "WIN-CONFIG-174",
@@ -16381,7 +16742,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Do not apply the Mark of the Web tag to files copied from' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\File Explorer > Do not apply the Mark of the Web tag to files copied from insecure sources: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-175",
@@ -16403,7 +16765,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Data Execution Prevention for Explorer' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\File Explorer > Turn off Data Execution Prevention for Explorer: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-176",
@@ -16425,7 +16788,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off heap termination on corruption' is set to 'Disab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\File Explorer > Turn off heap termination on corruption: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-177",
@@ -16447,7 +16811,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off shell protocol protected mode' is set to 'Disabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\File Explorer > Turn off shell protocol protected mode: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-178",
@@ -16469,7 +16834,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off location' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Location and Sensors\\Windows Location Provider > Turn off location: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-179",
@@ -16491,7 +16857,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow Message Service Cloud Sync' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Messaging > Allow Message Service Cloud Sync: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-180",
@@ -16513,7 +16880,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Block all consumer Microsoft account user authentication'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft accounts > Block all consumer Microsoft account user authentication: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-181",
@@ -16535,7 +16903,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure detection for potentially unwanted applications' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure detection for potentially unwanted applications: Enabled: Block"
   },
   {
     "checkId": "WIN-CONFIG-182",
@@ -16557,7 +16926,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Control whether exclusions are visible to local users' is' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Control whether exclusions are visible to local users: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-183",
@@ -16579,7 +16949,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable EDR in block mode' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Enable EDR in block mode: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-184",
@@ -16601,7 +16972,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configure local setting override for reporting to Microso' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\MAPS > Configure local setting override for reporting to Microsoft MAPS: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-185",
@@ -16623,7 +16995,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Join Microsoft MAPS' is set to 'Enabled: Advanced'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\MAPS > Join Microsoft MAPS: Enabled: Advanced"
   },
   {
     "checkId": "WIN-CONFIG-186",
@@ -16645,7 +17018,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Attack Surface Reduction rules' is set to 'Enab' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Microsoft Defender Exploit Guard\\Attack Surface Reduction > Configure Attack Surface Reduction rules: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-187",
@@ -16667,7 +17041,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Attack Surface Reduction rules: Set the state f' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Microsoft Defender Exploit Guard\\Attack Surface Reduction > Configure Attack Surface Reduction rules: Set the state for each ASR rule: configure per CIS benchmark table"
   },
   {
     "checkId": "WIN-CONFIG-188",
@@ -16689,7 +17064,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Prevent users and apps from accessing dangerous websites'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Microsoft Defender Exploit Guard\\Network Protection > Prevent users and apps from accessing dangerous websites: Enabled: Block"
   },
   {
     "checkId": "WIN-CONFIG-189",
@@ -16711,7 +17087,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Enable file hash computation feature' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\MpEngine > Enable file hash computation feature: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-190",
@@ -16733,7 +17110,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Convert warn verdict to block' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\MpEngine > Convert warn verdict to block: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-191",
@@ -16755,7 +17133,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure real-time protection and Security Intelligence ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure real-time protection and Security Intelligence Updates during OOBE: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-192",
@@ -16777,7 +17156,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Scan all downloaded files and attachments' is set to 'Ena' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Real-time Protection > Scan all downloaded files and attachments: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-193",
@@ -16799,7 +17179,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off real-time protection' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Real-time Protection > Turn off real-time protection: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-194",
@@ -16821,7 +17202,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn on behavior monitoring' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Real-time Protection > Turn on behavior monitoring: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-195",
@@ -16843,7 +17225,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn on script scanning' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Real-time Protection > Turn on script scanning: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-196",
@@ -16865,7 +17248,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Brute-Force Protection aggressiveness' is set t' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure Brute-Force Protection aggressiveness: Enabled: Medium (or higher)"
   },
   {
     "checkId": "WIN-CONFIG-197",
@@ -16887,7 +17271,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Remote Encryption Protection Mode' is set to 'E' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure Remote Encryption Protection Mode: Enabled: Audit (or higher)"
   },
   {
     "checkId": "WIN-CONFIG-198",
@@ -16909,7 +17294,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure how aggressively Remote Encryption Protection b' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure how aggressively Remote Encryption Protection blocks threats: Enabled: Medium (or higher)"
   },
   {
     "checkId": "WIN-CONFIG-199",
@@ -16931,7 +17317,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configure Watson events' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Reporting > Configure Watson events: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-200",
@@ -16953,7 +17340,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Scan excluded files and directories during quick scans' i' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Scan excluded files and directories during quick scans: Enabled: 1"
   },
   {
     "checkId": "WIN-CONFIG-201",
@@ -16975,7 +17363,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Scan packed executables' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Scan packed executables: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-202",
@@ -16997,7 +17386,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Scan removable drives' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Scan removable drives: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-203",
@@ -17019,7 +17409,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Trigger a quick scan after X days without any scans' is s' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Trigger a quick scan after X days without any scans: Enabled: 7"
   },
   {
     "checkId": "WIN-CONFIG-204",
@@ -17041,7 +17432,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn on e-mail scanning' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Turn on e-mail scanning: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-205",
@@ -17063,7 +17455,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn off Push To Install service' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Push To Install > Turn off Push To Install service: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-206",
@@ -17085,7 +17478,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Do not allow passwords to be saved' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Connections > Do not allow passwords to be saved: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-207",
@@ -17107,7 +17501,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Restrict Remote Desktop Services users to a single Remote' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Connections > Restrict Remote Desktop Services users to a single Remote Desktop Services session: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-208",
@@ -17129,7 +17524,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow UI Automation redirection' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Allow UI Automation redirection: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-209",
@@ -17151,7 +17547,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not allow COM port redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow COM port redirection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-210",
@@ -17173,7 +17570,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not allow drive redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow drive redirection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-211",
@@ -17195,7 +17593,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not allow location redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow location redirection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-212",
@@ -17217,7 +17616,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not allow LPT port redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow LPT port redirection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-213",
@@ -17239,7 +17639,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not allow supported Plug and Play device redirection' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow supported Plug and Play device redirection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-214",
@@ -17261,7 +17662,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not allow WebAuthn redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow WebAuthn redirection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-215",
@@ -17283,7 +17685,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Restrict clipboard transfer from server to client' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Restrict clipboard transfer from server to client: Enabled: Disable clipboard transfers from server to client"
   },
   {
     "checkId": "WIN-CONFIG-216",
@@ -17305,7 +17708,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Always prompt for password upon connection' is set to 'En' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Always prompt for password upon connection: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-217",
@@ -17327,7 +17731,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require secure RPC communication' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Require secure RPC communication: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-218",
@@ -17349,7 +17754,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require use of specific security layer for remote (RDP) c' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Require use of specific security layer for remote (RDP) connections: Enabled: SSL"
   },
   {
     "checkId": "WIN-CONFIG-219",
@@ -17371,7 +17777,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Require user authentication for remote connections by usi' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Require user authentication for remote connections by using Network Level Authentication: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-220",
@@ -17393,7 +17800,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set client connection encryption level' is set to 'Enable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Set client connection encryption level: Enabled: High Level"
   },
   {
     "checkId": "WIN-CONFIG-221",
@@ -17415,7 +17823,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set time limit for active but idle Remote Desktop Service' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Session Time Limits > Set time limit for active but idle Remote Desktop Services sessions: Enabled: 15 minutes or less (not Never)"
   },
   {
     "checkId": "WIN-CONFIG-222",
@@ -17437,7 +17846,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Set time limit for disconnected sessions' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Session Time Limits > Set time limit for disconnected sessions: Enabled: 1 minute"
   },
   {
     "checkId": "WIN-CONFIG-223",
@@ -17459,7 +17869,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Do not delete temp folders upon exit' is set to 'Disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Temporary Folders > Do not delete temp folders upon exit: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-224",
@@ -17481,7 +17892,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Do not use temporary folders per session' is set to 'Disa' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Temporary Folders > Do not use temporary folders per session: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-225",
@@ -17503,7 +17915,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Prevent downloading of enclosures' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\RSS Feeds > Prevent downloading of enclosures: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-226",
@@ -17525,7 +17938,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Cloud Search' is set to 'Enabled: Disable Cloud Sea' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Search > Allow Cloud Search: Enabled: Disable Cloud Search"
   },
   {
     "checkId": "WIN-CONFIG-227",
@@ -17547,7 +17961,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow indexing of encrypted files' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Search > Allow indexing of encrypted files: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-228",
@@ -17569,7 +17984,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow search highlights' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Search > Allow search highlights: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-229",
@@ -17591,7 +18007,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off KMS Client Online AVS Validation' is set to 'Ena' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Software Protection Platform > Turn off KMS Client Online AVS Validation: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-230",
@@ -17613,7 +18030,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Windows Defender SmartScreen' is set to 'Enable' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Defender SmartScreen\\Explorer > Configure Windows Defender SmartScreen: Enabled: Warn and prevent bypass"
   },
   {
     "checkId": "WIN-CONFIG-231",
@@ -17635,7 +18053,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow suggested apps in Windows Ink Workspace' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Ink Workspace > Allow suggested apps in Windows Ink Workspace: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-232",
@@ -17657,7 +18076,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Windows Ink Workspace' is set to 'Enabled: On, but ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Ink Workspace > Allow Windows Ink Workspace: Enabled: On, but disallow access above lock (or Disabled)"
   },
   {
     "checkId": "WIN-CONFIG-233",
@@ -17679,7 +18099,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow user control over installs' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Installer > Allow user control over installs: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-234",
@@ -17701,7 +18122,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Always install with elevated privileges' is set to 'Disab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Installer > Always install with elevated privileges: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-235",
@@ -17723,7 +18145,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Prevent Internet Explorer security prompt for Windows Ins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Installer > Prevent Internet Explorer security prompt for Windows Installer scripts: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-236",
@@ -17745,7 +18168,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configure the transmission of the user's password in the ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Logon Options > Configure the transmission of the user's password in the content of MPR notifications sent by winlogon: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-237",
@@ -17767,7 +18191,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Sign-in and lock last interactive user automatically afte' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Logon Options > Sign-in and lock last interactive user automatically after a restart: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-238",
@@ -17789,7 +18214,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn on PowerShell Script Block Logging' is set to 'Enabl' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows PowerShell > Turn on PowerShell Script Block Logging: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-239",
@@ -17811,7 +18237,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn on PowerShell Transcription' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows PowerShell > Turn on PowerShell Transcription: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-240",
@@ -17833,7 +18260,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Basic authentication' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Client > Allow Basic authentication: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-241",
@@ -17855,7 +18283,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow unencrypted traffic' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Client > Allow unencrypted traffic: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-242",
@@ -17877,7 +18306,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Disallow Digest authentication' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Client > Disallow Digest authentication: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-243",
@@ -17899,7 +18329,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Basic authentication' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Service > Allow Basic authentication: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-244",
@@ -17921,7 +18352,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow remote server management through WinRM' is set to '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Service > Allow remote server management through WinRM: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-245",
@@ -17943,7 +18375,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow unencrypted traffic' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Service > Allow unencrypted traffic: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-246",
@@ -17965,7 +18398,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Disallow WinRM from storing RunAs credentials' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Service > Disallow WinRM from storing RunAs credentials: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-247",
@@ -17987,7 +18421,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Allow Remote Shell Access' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Shell > Allow Remote Shell Access: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-248",
@@ -18009,7 +18444,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Prevent users from modifying settings' is set to 'Enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Security\\App and Browser protection > Prevent users from modifying settings: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-249",
@@ -18031,7 +18467,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'No auto-restart with logged on users for scheduled automa' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage end user experience > No auto-restart with logged on users for scheduled automatic updates installations: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-250",
@@ -18053,7 +18490,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Configure Automatic Updates' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage end user experience > Configure Automatic Updates: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-251",
@@ -18075,7 +18513,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Automatic Updates: Scheduled install day' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage end user experience > Configure Automatic Updates: Scheduled install day: 0 - Every day"
   },
   {
     "checkId": "WIN-CONFIG-252",
@@ -18097,7 +18536,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Manage preview builds' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage preview builds > Manage preview builds: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-253",
@@ -18119,7 +18559,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Select when Quality Updates are received' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage updates offered from Windows Update > Select when Quality Updates are received: Enabled: 0 days"
   },
   {
     "checkId": "WIN-CONFIG-254",
@@ -18141,7 +18582,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Disable HTTP proxy features: Disable WPAD' is set to 'Ena' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Internet Explorer\\Internet Control Panel\\Advanced Page > Disable HTTP proxy features: Disable WPAD: Enabled: Checked"
   },
   {
     "checkId": "WIN-CONFIG-255",
@@ -18163,7 +18605,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Disable HTTP proxy features: Disable proxy authentication' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Internet Explorer\\Internet Control Panel\\Advanced Page > Disable HTTP proxy features: Disable proxy authentication: Enabled: Disable authentication over loopback interfaces (or higher)"
   },
   {
     "checkId": "WIN-CONFIG-256",
@@ -18185,7 +18628,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off toast notifications on the lock screen' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Push Notifications > Turn off toast notifications on the lock screen: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-257",
@@ -18207,7 +18651,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Help Experience Improvement Program' is set to '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Help Experience Improvement Program > Turn off Help Experience Improvement Program: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-258",
@@ -18229,7 +18674,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Do not preserve zone information in file attachments' is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Attachment Manager > Do not preserve zone information in file attachments: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-259",
@@ -18251,7 +18697,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Notify antivirus programs when opening attachments' is se' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Attachment Manager > Notify antivirus programs when opening attachments: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-260",
@@ -18273,7 +18720,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Configure Windows spotlight on lock screen' is set to 'Di' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Configure Windows spotlight on lock screen: Disabled"
   },
   {
     "checkId": "WIN-CONFIG-261",
@@ -18295,7 +18743,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Do not suggest third-party content in Windows spotlight' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Do not suggest third-party content in Windows spotlight: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-262",
@@ -18317,7 +18766,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Do not use diagnostic data for tailored experiences' is s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Do not use diagnostic data for tailored experiences: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-263",
@@ -18339,7 +18789,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Turn off all Windows spotlight features' is set to 'Enabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Turn off all Windows spotlight features: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-264",
@@ -18361,7 +18812,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Turn off Spotlight collection on Desktop' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Turn off Spotlight collection on Desktop: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-265",
@@ -18383,7 +18835,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Prevent users from sharing files within their profile.' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Network Sharing > Prevent users from sharing files within their profile: Enabled"
   },
   {
     "checkId": "WIN-CONFIG-266",
@@ -18405,6 +18858,7 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Prevent Codec Download' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Media Player\\Networking > Prevent Codec Download: Enabled"
   }
 ]

--- a/data/az-assess-source-checks.json
+++ b/data/az-assess-source-checks.json
@@ -24,7 +24,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Excessive Owner assignments violate least privilege and expand the attack surface for subscription takeover."
-    }
+    },
+    "remediation": "Azure Portal > Subscriptions > [subscription] > Access control (IAM) > Role assignments. Review Owner role assignments. Remove accounts that do not require Owner. Reduce to 2-3 maximum. Use Privileged Identity Management (PIM) for eligible assignments instead."
   },
   {
     "checkId": "AZ-GOVERNANCE-002",
@@ -51,7 +52,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Absence of locks allows accidental or malicious deletion of production resources with no rollback protection."
-    }
+    },
+    "remediation": "Azure Portal > Subscriptions > [subscription] > Resource locks > Add. Create a Delete or ReadOnly lock on the subscription. Or: az lock create --name <LOCK> --resource-group <RG> --lock-type CanNotDelete"
   },
   {
     "checkId": "AZ-GOVERNANCE-003",
@@ -78,7 +80,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Unreviewed policy non-compliance indicates configuration drift from the security baseline."
-    }
+    },
+    "remediation": "Azure Portal > Policy > Compliance. Review non-compliant resources and remediate using the provided remediation tasks. Set up automated remediation tasks for supported policies."
   },
   {
     "checkId": "AZ-IDENTITY-001",
@@ -105,7 +108,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Guest accounts are often over-privileged and rarely reviewed, creating persistent unauthorized access paths."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Users > All users > Filter by 'Guest'. Review and remove guest accounts that are no longer needed. Or use Microsoft Entra access reviews: Identity Governance > Access reviews > New access review > Guests."
   },
   {
     "checkId": "AZ-IDENTITY-002",
@@ -132,7 +136,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Expired credentials on active service principals indicate unmanaged automation that may have been compromised or abandoned."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > App registrations > All applications > filter for apps with expired credentials. Remove expired certificates and secrets: [app] > Certificates & secrets. Delete expired entries and rotate active credentials."
   },
   {
     "checkId": "AZ-IDENTITY-003",
@@ -159,7 +164,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Service principals with stored secrets are a common attack vector; managed identities eliminate secret management overhead."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Enterprise applications > All applications. Review service principals using service principal credentials vs. managed identities. Where feasible, migrate app authentication to managed identities to eliminate credential management."
   },
   {
     "checkId": "AZ-NETWORK-001",
@@ -186,7 +192,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Internet-exposed RDP is consistently exploited for ransomware deployment and lateral movement."
-    }
+    },
+    "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Find and modify or delete any rule allowing RDP (TCP 3389) from source 'Any' or 'Internet'. Use Azure Bastion for RDP access instead."
   },
   {
     "checkId": "AZ-NETWORK-002",
@@ -213,7 +220,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Internet-exposed SSH is a top attack vector for Linux VM compromise and cryptomining deployments."
-    }
+    },
+    "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Find and modify or delete any rule allowing SSH (TCP 22) from source 'Any' or 'Internet'. Use Azure Bastion for SSH access instead."
   },
   {
     "checkId": "AZ-NETWORK-003",
@@ -240,7 +248,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Public IPs without NSGs expose the VM attack surface directly to the internet."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Networking. Review if a public IP is assigned. Remove or dissociate public IPs from VMs that do not require direct internet exposure. Use Azure Bastion or load balancers instead."
   },
   {
     "checkId": "AZ-STORAGE-001",
@@ -267,7 +276,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Public blob containers have caused numerous data breaches through accidental exposure of sensitive files."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Allow Blob anonymous access: Disabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --allow-blob-public-access false"
   },
   {
     "checkId": "AZ-STORAGE-002",
@@ -294,7 +304,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Unencrypted HTTP transfers can expose storage access keys and data to network-level interception."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Secure transfer required: Enabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --https-only true"
   },
   {
     "checkId": "AZ-STORAGE-003",
@@ -321,7 +332,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "TLS 1.0/1.1 vulnerabilities allow downgrade attacks against storage communications."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Minimum TLS version: TLS 1.2. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --min-tls-version TLS1_2"
   },
   {
     "checkId": "AZ-KEYVAULT-001",
@@ -348,7 +360,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Without soft delete, a deleted Key Vault permanently destroys all cryptographic material, potentially causing application outages."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Settings > Properties > Soft-delete: Enabled. Or: az keyvault update --resource-group <RG> --name <VAULT> --enable-soft-delete true. Note: soft-delete cannot be disabled once enabled."
   },
   {
     "checkId": "AZ-KEYVAULT-002",
@@ -375,7 +388,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Without purge protection, an attacker with Key Vault delete permissions can permanently destroy all secrets, keys, and certificates."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Settings > Properties > Purge protection: Enable. Or: az keyvault update --resource-group <RG> --name <VAULT> --enable-purge-protection true"
   },
   {
     "checkId": "AZ-KEYVAULT-003",
@@ -402,7 +416,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Keys without expiry never rotate, allowing long-term exploitation of any compromise without detection."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Objects > Keys and Secrets. Set expiration dates on all keys and secrets. Or: az keyvault key set-attributes --vault-name <VAULT> --name <KEY> --expires <DATE>"
   },
   {
     "checkId": "AZ-DEFENDER-001",
@@ -429,7 +444,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Without paid Defender plans, threat detection and vulnerability scanning are absent for critical workloads."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans. Enable required Defender plans (Servers, Storage, SQL, etc.)."
   },
   {
     "checkId": "AZ-DEFENDER-002",
@@ -456,7 +472,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "A low secure score indicates widespread unresolved security findings that increase risk of compromise."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Overview > Secure score. Review failing recommendations and remediate to raise the secure score above the organizational threshold."
   },
   {
     "checkId": "AZ-DEFENDER-003",
@@ -483,7 +500,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "VMs without monitoring agents are invisible to Defender for Cloud threat detection."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Auto provisioning. Enable auto provisioning for Log Analytics agent and other monitoring extensions."
   },
   {
     "checkId": "AZ-MONITOR-001",
@@ -510,7 +528,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Without a Log Analytics workspace, audit log collection cannot be centralized, making incident investigation impossible."
-    }
+    },
+    "remediation": "Azure Portal > Log Analytics workspaces > Create. Create a workspace in the appropriate region. Connect resources by configuring Diagnostic Settings on each resource to send logs to this workspace."
   },
   {
     "checkId": "AZ-MONITOR-002",
@@ -537,7 +556,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Silent policy deletion can remove compliance guardrails without anyone noticing until the next audit."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete policy assignment'. Action group: notify security team. Or: az monitor activity-log alert create with operationName=Microsoft.Authorization/policyAssignments/delete"
   },
   {
     "checkId": "AZ-VM-001",
@@ -564,7 +584,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Unencrypted VM disks expose CUI if the underlying hardware is repurposed or physically accessed."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Disks. Enable Azure Disk Encryption: Extensions > Add > Azure Disk Encryption. Or: az vm encryption enable --resource-group <RG> --name <VM> --disk-encryption-keyvault <VAULT>"
   },
   {
     "checkId": "AZ-VM-002",
@@ -591,7 +612,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "VMs without endpoint protection are undefended against malware, ransomware, and fileless attacks."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Extensions + applications. Install Microsoft Antimalware extension. Or: az vm extension set --resource-group <RG> --vm-name <VM> --name IaaSAntimalware --publisher Microsoft.Azure.Security"
   },
   {
     "checkId": "AZ-SQL-001",
@@ -618,7 +640,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Unencrypted SQL databases expose CUI stored in database files and backups."
-    }
+    },
+    "remediation": "Azure Portal > SQL databases > [database] > Security > Transparent data encryption. Set to On. Or: az sql db tde set --resource-group <RG> --server <SERVER> --database <DB> --status Enabled"
   },
   {
     "checkId": "AZ-SQL-002",
@@ -645,7 +668,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Without auditing, SQL Server access and schema changes are untracked and cannot be investigated after a breach."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Security > Auditing > Enable Azure SQL Auditing: On. Set log destination to Log Analytics or Storage Account. Or: az sql server audit-policy update --resource-group <RG> --name <SERVER> --state Enabled"
   },
   {
     "checkId": "AZ-SQL-003",
@@ -672,7 +696,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Overly broad SQL firewall rules expose the database server to unauthorized connection attempts from anywhere in Azure or the internet."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Security > Firewalls and virtual networks. Review firewall rules. Remove rules with start IP 0.0.0.0 and end IP 255.255.255.255. Replace with specific IP ranges or VNet rules."
   },
   {
     "checkId": "AZ-AKS-001",
@@ -699,7 +724,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Without RBAC, all authenticated users have unrestricted access to Kubernetes API operations including cluster-admin capabilities."
-    }
+    },
+    "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > Enable Kubernetes RBAC. Or: az aks update --resource-group <RG> --name <CLUSTER> --enable-aad --enable-azure-rbac"
   },
   {
     "checkId": "AZ-AKS-002",
@@ -726,7 +752,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Without network policies, a compromised pod can communicate freely with all other pods, enabling lateral movement."
-    }
+    },
+    "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > Network policy. Select Azure or Calico. Or: az aks update --resource-group <RG> --name <CLUSTER> --network-policy azure"
   },
   {
     "checkId": "AZ-AKS-003",
@@ -753,7 +780,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Without Azure AD integration, AKS authentication relies on local credentials that bypass organizational MFA and conditional access policies."
-    }
+    },
+    "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > AKS-managed Azure Active Directory: Enable. Or: az aks update --resource-group <RG> --name <CLUSTER> --enable-aad --aad-admin-group-object-ids <GROUP-ID>"
   },
   {
     "checkId": "AZ-ANALYTICS-001",
@@ -775,7 +803,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Deploying Databricks outside a customer-managed VNet limits network isolation and increases exposure of cluster traffic to shared infrastructure."
-    }
+    },
+    "remediation": "Create or migrate the Databricks workspace to a customer-managed VNet: Azure Portal > Azure Databricks > [workspace] > Networking. VNet injection must be configured at workspace creation time."
   },
   {
     "checkId": "AZ-ANALYTICS-002",
@@ -797,7 +826,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Missing NSG rules on Databricks subnets allow unrestricted lateral movement between subnets, enabling exfiltration or pivot from a compromised cluster node."
-    }
+    },
+    "remediation": "Associate NSGs with the Databricks public and private subnets: Azure Portal > Virtual networks > [VNet] > Subnets > [subnet] > Network security group. Attach NSGs restricting inbound and outbound access per Databricks network requirements."
   },
   {
     "checkId": "AZ-ANALYTICS-003",
@@ -819,7 +849,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Unencrypted inter-node cluster traffic exposes data in process to passive interception within the virtual network."
-    }
+    },
+    "remediation": "Azure Portal > Azure Databricks > [workspace] > Encryption. Enable cluster encryption (encryption at rest covers data on cluster nodes). For encryption in transit between workers, configure at cluster level via spark.databricks.encryption.enabled."
   },
   {
     "checkId": "AZ-ANALYTICS-004",
@@ -841,7 +872,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Local Databricks accounts not synced from Entra ID bypass centralised lifecycle management, creating orphaned access after offboarding."
-    }
+    },
+    "remediation": "Azure Portal > Azure Databricks > [workspace] > Settings > Microsoft Entra ID. Enable Entra ID sync or configure SCIM provisioning to synchronize users and groups from Entra ID to Databricks."
   },
   {
     "checkId": "AZ-ANALYTICS-005",
@@ -863,7 +895,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Without Unity Catalog, data access controls and audit trails are per-workspace rather than centralised, increasing risk of unauthorised data access across workspaces."
-    }
+    },
+    "remediation": "Azure Portal > Azure Databricks > [workspace] > Settings > Unity Catalog. Create or attach a Unity Catalog metastore via Azure Databricks account console. Unity Catalog must be enabled for centralized data governance."
   },
   {
     "checkId": "AZ-ANALYTICS-006",
@@ -885,7 +918,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Long-lived or unrestricted PATs provide persistent API access; a leaked token without expiry can be used indefinitely to exfiltrate data or execute jobs."
-    }
+    },
+    "remediation": "In the Databricks workspace: Settings > Admin Console > Workspace settings > Personal access tokens. Set the maximum token lifetime (e.g., 90 days) and disable the ability to create tokens without expiration."
   },
   {
     "checkId": "AZ-ANALYTICS-007",
@@ -907,7 +941,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Without diagnostic logs, user actions and cluster events are unauditable, delaying detection and forensic investigation of suspicious activity."
-    }
+    },
+    "remediation": "Azure Portal > Azure Databricks > [workspace] > Diagnostic settings > Add diagnostic setting. Enable dbfs and cluster event log categories and send to Log Analytics Workspace."
   },
   {
     "checkId": "AZ-ANALYTICS-008",
@@ -929,7 +964,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Without customer-managed keys, Microsoft-managed keys control data access; a compromised cloud admin account can decrypt data without tenant knowledge."
-    }
+    },
+    "remediation": "Azure Portal > Azure Databricks > [workspace] > Encryption. Enable customer-managed keys (CMK) for the managed storage account. CMK must be configured in the Azure Key Vault and linked at workspace creation or updated via az databricks workspace update."
   },
   {
     "checkId": "AZ-ANALYTICS-009",
@@ -951,7 +987,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Public IPs on cluster nodes expose worker traffic directly to the internet, enabling port scanning, exploitation, and data exfiltration without VNet traversal."
-    }
+    },
+    "remediation": "Azure Portal > Azure Databricks > [workspace] > Networking. Enable 'No Public IP' (Secure cluster connectivity). This setting must be configured at workspace creation time. Existing workspaces require migration."
   },
   {
     "checkId": "AZ-ANALYTICS-010",
@@ -973,7 +1010,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Public network access to the workspace control plane exposes authentication endpoints to brute force and credential stuffing attacks from the internet."
-    }
+    },
+    "remediation": "Azure Portal > Azure Databricks > [workspace] > Networking > Public network access: Disabled. This restricts the Databricks control plane endpoint to private network access only."
   },
   {
     "checkId": "AZ-ANALYTICS-011",
@@ -995,7 +1033,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Without private endpoints, workspace traffic traverses public Microsoft backbone infrastructure, increasing exposure to interception and reducing network isolation guarantees."
-    }
+    },
+    "remediation": "Azure Portal > Azure Databricks > [workspace] > Networking > Private endpoint connections > Add. Create a private endpoint in the VNet and configure private DNS to resolve the workspace URL to the private IP."
   },
   {
     "checkId": "AZ-COMPUTE-001",
@@ -1017,7 +1056,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Privileged VM access without MFA allows a single compromised credential to grant full control of a virtual machine, enabling persistent access, lateral movement, and data exfiltration."
-    }
+    },
+    "remediation": "Azure Portal > Defender for Cloud > Workload protections > Just-in-time VM access. Enable JIT on VMs and configure MFA via Conditional Access for Entra ID accounts that have VM administrator access."
   },
   {
     "checkId": "AZ-IDENTITY-004",
@@ -1039,7 +1079,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Unrestricted tenant creation allows any user to establish a shadow tenant, bypassing organizational security policies and creating unmonitored administrative domains."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Users > User settings > Restrict non-admin users from creating tenants: Yes. Save."
   },
   {
     "checkId": "AZ-IDENTITY-005",
@@ -1061,7 +1102,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Requiring only one reset method reduces the assurance that the requester is the legitimate account owner, enabling account takeover via a single compromised factor."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Users > Password reset > Authentication methods. Set 'Number of methods required to reset' to 2."
   },
   {
     "checkId": "AZ-IDENTITY-006",
@@ -1083,7 +1125,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "A high lockout threshold permits extensive password guessing before triggering account lockout, substantially increasing the success probability of brute force attacks."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Authentication methods > Password protection > Lockout threshold. Set to 10 or lower. Save."
   },
   {
     "checkId": "AZ-IDENTITY-007",
@@ -1105,7 +1148,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that account 'Lockout duration in seconds' is greater than' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Authentication methods > Password protection > Lockout duration in seconds. Set to 60 or higher. Save."
   },
   {
     "checkId": "AZ-IDENTITY-008",
@@ -1127,7 +1171,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that a 'Custom banned password list' is set to 'Enforce'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Authentication methods > Password protection > Custom banned password list: Enforce. Add organizational terms to the banned list. Save."
   },
   {
     "checkId": "AZ-IDENTITY-009",
@@ -1149,7 +1194,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that 'Number of days before users are asked to re-confirm ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Users > Password reset > Registration > Number of days before users are asked to re-confirm their authentication information. Set to a value greater than 0 (recommended: 180 days)."
   },
   {
     "checkId": "AZ-IDENTITY-010",
@@ -1171,7 +1217,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that 'Notify users on password resets?' is set to 'Yes'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Users > Password reset > Notifications > Notify users on password resets: Yes. Save."
   },
   {
     "checkId": "AZ-IDENTITY-011",
@@ -1193,7 +1240,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Notify all admins when other admins reset their pass' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Users > Password reset > Notifications > Notify all admins when other admins reset their password: Yes. Save."
   },
   {
     "checkId": "AZ-IDENTITY-012",
@@ -1215,7 +1263,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'User consent for applications' is set to 'Do not all' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Enterprise applications > Consent and permissions > User consent settings > User consent for applications: Do not allow user consent. Save."
   },
   {
     "checkId": "AZ-IDENTITY-013",
@@ -1237,7 +1286,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'User consent for applications' is set to 'Allow user' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Enterprise applications > Consent and permissions > User consent settings > User consent for applications: Allow user consent for apps from verified publishers, for selected permissions. Save."
   },
   {
     "checkId": "AZ-IDENTITY-014",
@@ -1259,7 +1309,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Users can register applications' is set to 'No'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Users > User settings > App registrations > Users can register applications: No. Save."
   },
   {
     "checkId": "AZ-IDENTITY-015",
@@ -1281,7 +1332,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Guest users access restrictions' is set to 'Guest us' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > External identities > External collaboration settings > Guest user access: Guest user access is restricted to properties and memberships of their own directory objects. Save."
   },
   {
     "checkId": "AZ-IDENTITY-016",
@@ -1303,7 +1355,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Guest invite restrictions' is set to 'Only users ass' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > External identities > External collaboration settings > Guest invite restrictions. Select 'Only users assigned to specific admin roles can invite guest users' or 'No one in the organization can invite guest users'. Save."
   },
   {
     "checkId": "AZ-IDENTITY-017",
@@ -1325,7 +1378,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Restrict access to Microsoft Entra admin center' is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Users > User settings > Restrict access to Microsoft Entra admin center: Yes. Save."
   },
   {
     "checkId": "AZ-IDENTITY-018",
@@ -1347,7 +1401,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Restrict user ability to access groups features in M' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Groups > General settings > Restrict user ability to access groups features in the My Groups portal: Yes. Save."
   },
   {
     "checkId": "AZ-IDENTITY-019",
@@ -1369,7 +1424,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Users can create security groups in Azure portals, A' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Groups > General settings > Users can create security groups in Azure portals, API or PowerShell: No. Save."
   },
   {
     "checkId": "AZ-IDENTITY-020",
@@ -1391,7 +1447,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Owners can manage group membership requests in My Gr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Groups > General settings > Owners can manage group membership requests in My Groups: No. Save."
   },
   {
     "checkId": "AZ-IDENTITY-021",
@@ -1413,7 +1470,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Users can create Microsoft 365 groups in Azure porta' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Groups > General settings > Users can create Microsoft 365 groups in Azure portals, API or PowerShell: No. Save."
   },
   {
     "checkId": "AZ-IDENTITY-022",
@@ -1435,7 +1493,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure that 'Require Multifactor Authentication to register or jo' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Devices > Device settings > Require Multifactor Authentication to register or join devices with Microsoft Entra: Yes. Save."
   },
   {
     "checkId": "AZ-IDENTITY-023",
@@ -1457,7 +1516,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that no custom subscription administrator roles exist' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Subscriptions > [subscription] > Access control (IAM) > Roles. Review custom roles with subscription-level administrator permissions. Remove or redesign roles granting more than necessary. Prefer built-in roles."
   },
   {
     "checkId": "AZ-IDENTITY-024",
@@ -1479,7 +1539,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that a custom role is assigned permissions for administeri' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Subscriptions > [subscription] > Access control (IAM) > Roles > Add custom role. Create a custom role with Microsoft.Authorization/locks/* permissions and assign only to designated lock administrators."
   },
   {
     "checkId": "AZ-IDENTITY-025",
@@ -1501,7 +1562,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Subscription leaving Microsoft Entra tenant' and 'Su' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Billing > Properties > Subscription entering/leaving tenant policies. Set both to 'Permit no one'. Save."
   },
   {
     "checkId": "AZ-IDENTITY-026",
@@ -1523,7 +1585,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure fewer than 5 users have global administrator assignment' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Roles and administrators > Global administrator. Review assignments. Ensure fewer than 5 users have this role. Use Privileged Identity Management (PIM) for eligible assignments."
   },
   {
     "checkId": "AZ-IDENTITY-027",
@@ -1545,7 +1608,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure there are between 2 and 3 subscription owners' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Subscriptions > [subscription] > Access control (IAM) > Role assignments. Filter by Owner role. Ensure 2-3 users or groups are assigned. Add or remove as needed."
   },
   {
     "checkId": "AZ-IDENTITY-028",
@@ -1567,7 +1631,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure passwordless authentication methods are considered' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Authentication methods. Enable Windows Hello for Business, FIDO2 security keys, or Microsoft Authenticator passwordless sign-in. Configure Conditional Access to require passwordless for target users."
   },
   {
     "checkId": "AZ-IDENTITY-029",
@@ -1589,7 +1654,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'security defaults' is enabled in Microsoft Entra ID' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Overview > Properties > Manage security defaults: Enable security defaults. Note: incompatible with Conditional Access policies. If CA policies are in use, disable security defaults and configure equivalent CA policies."
   },
   {
     "checkId": "AZ-IDENTITY-030",
@@ -1611,7 +1677,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure that 'multifactor authentication' is 'enabled' for all use' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Require MFA for all users and all cloud apps. Or use the 'Require MFA for all users' template under Security defaults."
   },
   {
     "checkId": "AZ-IDENTITY-031",
@@ -1633,7 +1700,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure that 'Allow users to remember multifactor authentication o' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Multifactor authentication > Service settings. Uncheck 'Allow users to remember multi-factor authentication on devices they trust'. Save."
   },
   {
     "checkId": "AZ-IDENTITY-032",
@@ -1655,7 +1723,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'trusted locations' are defined' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Named locations. Define trusted IP ranges for the organization. Reference them in CA policies to restrict or allow access from known locations."
   },
   {
     "checkId": "AZ-IDENTITY-033",
@@ -1677,7 +1746,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that an exclusionary geographic Conditional Access policy ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Configure a policy that blocks sign-ins from countries the organization does not operate in. Use Named Locations (country-based) as the condition."
   },
   {
     "checkId": "AZ-IDENTITY-034",
@@ -1699,7 +1769,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that an exclusionary device code flow policy is considered' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Block device code flow: grant = Block. Conditions = Authentication flows > Device code flow. Scope to all users or privileged accounts at minimum."
   },
   {
     "checkId": "AZ-IDENTITY-035",
@@ -1721,7 +1792,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure that a multifactor authentication policy exists for all us' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies. Verify a policy exists requiring MFA for All users accessing all cloud apps. Use the 'Require multifactor authentication for all users' template if not present."
   },
   {
     "checkId": "AZ-IDENTITY-036",
@@ -1743,7 +1815,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure that multifactor authentication is required for risky sign' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies. Create a policy requiring MFA when sign-in risk is Medium or above: Conditions = Sign-in risk: Medium, High. Grant = Require MFA."
   },
   {
     "checkId": "AZ-IDENTITY-037",
@@ -1765,7 +1838,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure that multifactor authentication is required for Windows Az' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Require MFA for Windows Azure Service Management API: Cloud apps = Windows Azure Service Management API. Grant = Require MFA."
   },
   {
     "checkId": "AZ-IDENTITY-038",
@@ -1787,7 +1861,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure that multifactor authentication is required to access Micr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Require MFA for Microsoft Admin Portals: Cloud apps = Microsoft Admin Portals. Grant = Require MFA."
   },
   {
     "checkId": "AZ-IDENTITY-039",
@@ -1809,7 +1884,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure a Token Protection Conditional Access policy is considered' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Enable Token Protection (requires Entra ID P2). Conditions = All apps. Session = Token Protection: Enabled."
   },
   {
     "checkId": "AZ-IDENTITY-040",
@@ -1831,7 +1907,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Azure admin accounts are not used for daily operation' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Roles and administrators > Global administrator. Ensure admin accounts are separate from daily-use accounts. Admin accounts should not have assigned licenses or email access for non-administrative tasks."
   },
   {
     "checkId": "AZ-IDENTITY-041",
@@ -1853,7 +1930,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that guest users are reviewed on a regular basis' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Identity Governance > Access reviews > New access review. Configure a recurring access review for Guest users in all groups and applications. Set reviewer to group owners or specific users."
   },
   {
     "checkId": "AZ-IDENTITY-042",
@@ -1875,7 +1953,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that use of the 'User Access Administrator' role is restri' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Roles and administrators > User Access Administrator. Review all assignments. Remove assignments that are not time-limited via PIM. Use PIM eligible assignments for this role."
   },
   {
     "checkId": "AZ-IDENTITY-043",
@@ -1897,7 +1976,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that all 'privileged' role assignments are periodically re' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles. Configure access reviews for all privileged role assignments. Set review frequency to quarterly or monthly."
   },
   {
     "checkId": "AZ-IDENTITY-044",
@@ -1919,7 +1999,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure disabled user accounts do not have read, write, or owner p' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Subscriptions > Access control (IAM) > Role assignments. Filter by disabled accounts. Remove all role assignments (read, write, owner) from disabled user accounts."
   },
   {
     "checkId": "AZ-IDENTITY-045",
@@ -1941,7 +2022,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Tenant Creator' role assignments are periodically reviewe' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles > Tenant Creator. Review active and eligible assignments. Remove unnecessary assignments and configure PIM access review."
   },
   {
     "checkId": "AZ-IDENTITY-046",
@@ -1963,7 +2045,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure all non-privileged role assignments are periodically revie' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Microsoft Entra admin center > Identity Governance > Privileged Identity Management > Azure resources. Configure access reviews for non-privileged role assignments (Contributor, Reader) across subscriptions and resource groups. Set review frequency to quarterly."
   },
   {
     "checkId": "AZ-GOVERNANCE-004",
@@ -1985,7 +2068,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Resource Locks are set for Mission-Critical Azure Res' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > [Resource] > Settings > Locks > Add lock. Apply CanNotDelete or ReadOnly locks to mission-critical resources (e.g., VNets, Key Vaults, Storage Accounts). Or: az lock create --name <LOCK> --resource-group <RG> --resource-type <TYPE> --resource <NAME> --lock-type CanNotDelete"
   },
   {
     "checkId": "AZ-GOVERNANCE-005",
@@ -2007,7 +2091,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Azure Monitor Resource Logging is Enabled for All Ser' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > [Resource] > Diagnostic settings > Add diagnostic setting. Enable all appropriate log categories and route to Log Analytics Workspace, Storage Account, or Event Hub. Repeat for each Azure resource type in use."
   },
   {
     "checkId": "AZ-GOVERNANCE-006",
@@ -2029,7 +2114,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that SKU Basic/Consumption is not used on artifacts that n' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > [Service]. Review the pricing tier of critical services. Upgrade from Free/Basic/Consumption to Standard or Premium tiers that support diagnostic logging and monitoring integration."
   },
   {
     "checkId": "AZ-GOVERNANCE-007",
@@ -2051,7 +2137,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that a 'Diagnostic Setting' exists for Subscription Activi' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Activity log > Export Activity Logs > Add diagnostic setting. Enable all Administrative and Security log categories and send to Log Analytics Workspace."
   },
   {
     "checkId": "AZ-GOVERNANCE-008",
@@ -2073,7 +2160,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Diagnostic Setting captures appropriate categories' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Activity log > Diagnostic settings > [setting]. Verify that Administrative, Security, Alert, and Policy log categories are all enabled."
   },
   {
     "checkId": "AZ-GOVERNANCE-009",
@@ -2095,7 +2183,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure the storage account containing the container with activity' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [activity log storage account] > Settings > Encryption. Set 'Encryption type' to Customer-managed keys and link to an Azure Key Vault key."
   },
   {
     "checkId": "AZ-GOVERNANCE-010",
@@ -2117,7 +2206,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that logging for Azure Key Vault is 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Monitoring > Diagnostic settings > Add diagnostic setting. Enable AuditEvent log category and send to Log Analytics Workspace. Retention: 90 days minimum."
   },
   {
     "checkId": "AZ-GOVERNANCE-011",
@@ -2139,7 +2229,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Network Security Group Flow logs are captured and sen' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Network security groups > [NSG] > Monitoring > NSG flow logs > Create. Select the NSG, a storage account, and a Log Analytics Workspace. Enable Flow Logs v2 and set retention to 90 days."
   },
   {
     "checkId": "AZ-GOVERNANCE-012",
@@ -2161,7 +2252,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that logging for Azure AppService 'HTTP logs' is enabled' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Monitoring > Diagnostic settings > Add diagnostic setting. Enable 'AppServiceHTTPLogs' category and send to Log Analytics Workspace."
   },
   {
     "checkId": "AZ-GOVERNANCE-013",
@@ -2183,7 +2275,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that virtual network flow logs are captured and sent to Lo' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Virtual networks > [VNet] > Monitoring > Flow logs. Enable VNet flow logs and send to Log Analytics Workspace. Set retention to 90 days minimum."
   },
   {
     "checkId": "AZ-GOVERNANCE-014",
@@ -2205,7 +2298,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that a Microsoft Entra diagnostic setting exists to send M' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Entra ID > Monitoring > Diagnostic settings > Add diagnostic setting. Enable MicrosoftGraphActivityLogs and route to Log Analytics Workspace or Storage Account."
   },
   {
     "checkId": "AZ-GOVERNANCE-015",
@@ -2227,7 +2321,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that a Microsoft Entra diagnostic setting exists to send M' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Entra ID > Monitoring > Diagnostic settings > Add diagnostic setting. Enable AuditLogs, SignInLogs, and NonInteractiveUserSignInLogs categories and route to Log Analytics Workspace."
   },
   {
     "checkId": "AZ-GOVERNANCE-016",
@@ -2249,7 +2344,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Intune logs are captured and sent to Log Analytics' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Intune > Reports > Diagnostic settings > Add diagnostic setting. Enable IntuneAuditLogs and IntuneOperationalLogs and route to Log Analytics Workspace."
   },
   {
     "checkId": "AZ-GOVERNANCE-017",
@@ -2271,7 +2367,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create Policy Assignmen' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log signal 'Create policy assignment'. Action group: notify security team. Or: az monitor activity-log alert create --resource-group <RG> --name <ALERT> --condition category=Policy and operationName=Microsoft.Authorization/policyAssignments/write"
   },
   {
     "checkId": "AZ-GOVERNANCE-018",
@@ -2293,7 +2390,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete Policy Assignmen' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log signal 'Delete policy assignment'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-019",
@@ -2315,7 +2413,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create or Update Networ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Create or update network security group'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-020",
@@ -2337,7 +2436,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete Network Security' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete network security group'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-021",
@@ -2359,7 +2459,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create or Update Securi' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Create or update security solutions'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-022",
@@ -2381,7 +2482,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete Security Solutio' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete security solutions'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-023",
@@ -2403,7 +2505,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create or Update SQL Se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Create or update SQL server firewall rule'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-024",
@@ -2425,7 +2528,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete SQL Server Firew' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete SQL server firewall rule'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-025",
@@ -2447,7 +2551,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create or Update Public' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Create or update public IP address'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-026",
@@ -2469,7 +2574,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete Public IP Addres' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete public IP address'. Action group: notify security team."
   },
   {
     "checkId": "AZ-GOVERNANCE-027",
@@ -2491,7 +2597,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that an Activity Log Alert exists for Service Health' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log signal 'Service Health'. Configure for all event types (Service Issues, Planned Maintenance, Health Advisories). Action group: notify operations team."
   },
   {
     "checkId": "AZ-GOVERNANCE-028",
@@ -2513,7 +2620,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure Application Insights are Configured' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > [Resource Group or Application]. Create an Application Insights resource: Azure Portal > Application Insights > Create. Instrument the application with the Application Insights SDK or enable auto-instrumentation for supported runtimes."
   },
   {
     "checkId": "AZ-NETWORK-004",
@@ -2535,7 +2643,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that RDP access from the Internet is evaluated and restric' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Remove or restrict RDP (TCP 3389) access from Internet. Restrict source to specific IP ranges or use Azure Bastion."
   },
   {
     "checkId": "AZ-NETWORK-005",
@@ -2557,7 +2666,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that SSH access from the Internet is evaluated and restric' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Remove or restrict SSH (TCP 22) access from Internet. Restrict source to specific IP ranges or use Azure Bastion."
   },
   {
     "checkId": "AZ-NETWORK-006",
@@ -2579,7 +2689,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that UDP access from the Internet is evaluated and restric' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Remove or restrict UDP access from Internet. Limit any UDP rules to specific source IPs and required ports."
   },
   {
     "checkId": "AZ-NETWORK-007",
@@ -2601,7 +2712,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that HTTP(S) access from the Internet is evaluated and res' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Review HTTP (80) and HTTPS (443) rules. Route internet-facing traffic through Azure Application Gateway or Azure Front Door with WAF instead of direct NSG allow rules."
   },
   {
     "checkId": "AZ-NETWORK-008",
@@ -2623,7 +2735,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that network security group flow log retention days is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Network security groups > [NSG] > Monitoring > NSG flow logs > [flow log]. Set retention period to 90 days or greater. Or: az network watcher flow-log update --resource-group <RG> --name <LOG> --retention 90"
   },
   {
     "checkId": "AZ-NETWORK-009",
@@ -2645,7 +2758,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Network Watcher is 'Enabled' for Azure Regions that a' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Network Watcher > Overview > Region list. Enable Network Watcher for each Azure region in use. Or: az network watcher configure --resource-group NetworkWatcherRG --locations <REGION> --enabled true"
   },
   {
     "checkId": "AZ-NETWORK-010",
@@ -2667,7 +2781,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Public IP addresses are Evaluated on a Periodic Basis' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Public IP addresses. Review all public IP resources. Remove IPs not associated with active resources. Document and periodically review remaining IPs and their purpose."
   },
   {
     "checkId": "AZ-NETWORK-011",
@@ -2689,7 +2804,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that virtual network flow log retention days is set to gre' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Virtual networks > [VNet] > Monitoring > Flow logs. Set retention period to 90 days or greater. Or: az network watcher flow-log update --resource-group <RG> --name <LOG> --retention 90"
   },
   {
     "checkId": "AZ-NETWORK-012",
@@ -2711,7 +2827,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Authentication type' is set to 'Azure Active Directory' o' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Virtual network gateways > [gateway] > Settings > Point-to-site configuration > Tunnel type. Set to IKEv2 or OpenVPN. Authentication type: Microsoft Entra ID. Remove certificate-based authentication if not required."
   },
   {
     "checkId": "AZ-NETWORK-013",
@@ -2733,7 +2850,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure Web Application Firewall (WAF) is enabled on Azure A' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Application gateways > [gateway] > Web application firewall. Set WAF mode to Prevention. Or create a WAF policy: Azure Portal > Web Application Firewall policies > Create, then associate with the Application Gateway."
   },
   {
     "checkId": "AZ-NETWORK-014",
@@ -2755,7 +2873,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Missing network access controls leave Azure resources exposed to unrestricted lateral traffic, enabling pivoting and data exfiltration."
-    }
+    },
+    "remediation": "Azure Portal > Virtual networks > [VNet] > Subnets > [subnet] > Network security group. Assign an NSG to each subnet that does not have one. Ensure all subnets except AzureBastionSubnet and GatewaySubnet are NSG-protected."
   },
   {
     "checkId": "AZ-NETWORK-015",
@@ -2777,7 +2896,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure the SSL policy's 'Min protocol version' is set to 'TLSv1_2' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Application gateways > [gateway] > Settings > SSL policy. Set 'Policy type' to Custom and 'Min protocol version' to TLS 1.2. Remove TLS 1.0 and 1.1 cipher suites."
   },
   {
     "checkId": "AZ-NETWORK-016",
@@ -2799,7 +2919,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'HTTP2' is set to 'Enabled' on Azure Application Gateway' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Application gateways > [gateway] > Settings > Configuration. Set 'HTTP2': Enabled."
   },
   {
     "checkId": "AZ-NETWORK-017",
@@ -2821,7 +2942,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure request body inspection is enabled in Azure Web Applicatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Web Application Firewall policies > [policy] > Policy settings. Enable 'Inspect request body' and set 'Max request body size' to an appropriate limit. Save."
   },
   {
     "checkId": "AZ-NETWORK-018",
@@ -2843,7 +2965,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure bot protection is enabled in Azure Web Application Firewal' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Web Application Firewall policies > [policy] > Policy settings. Enable 'Bot protection'. Set 'Bot protection ruleset version' to current. Save."
   },
   {
     "checkId": "AZ-NETWORK-019",
@@ -2865,7 +2988,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Missing network access controls leave Azure resources exposed to unrestricted lateral traffic, enabling pivoting and data exfiltration."
-    }
+    },
+    "remediation": "Azure Portal > Network security perimeters > Create. Configure the perimeter to protect target PaaS resources (Key Vault, Storage, etc.). This feature requires registration: az feature register --namespace Microsoft.Network --name AllowNetworkSecurityPerimeter"
   },
   {
     "checkId": "AZ-DEFENDER-004",
@@ -2887,7 +3011,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure DDoS Network Protection is enabled on virtual networ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Virtual networks > [VNet] > DDoS protection > Standard: Enable. Or: az network ddos-protection create --resource-group <RG> --name <PLAN>; az network vnet update --resource-group <RG> --name <VNET> --ddos-protection-plan <PLAN>"
   },
   {
     "checkId": "AZ-DEFENDER-005",
@@ -2909,7 +3034,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Microsoft Defender for Cloud is configured to check V' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings. Enable 'System updates should be installed on your machines' recommendation in the Defender for Servers configuration."
   },
   {
     "checkId": "AZ-DEFENDER-006",
@@ -2931,7 +3057,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Microsoft Cloud Security Benchmark policies are not s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Security policies. Find Microsoft Cloud Security Benchmark initiative and set any 'Disabled' effects to 'Audit' or 'Deny'."
   },
   {
     "checkId": "AZ-DEFENDER-007",
@@ -2953,7 +3080,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure That 'All users with the following roles' is set to 'Owner' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Email notifications. Set 'All users with the following roles' to include Owner. Save."
   },
   {
     "checkId": "AZ-DEFENDER-008",
@@ -2975,7 +3103,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'Additional email addresses' is Configured with a Security' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Email notifications > Additional email addresses. Add at least one security contact email address. Save."
   },
   {
     "checkId": "AZ-DEFENDER-009",
@@ -2997,7 +3126,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that 'Notify about alerts with the following severity (or ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Email notifications > Notify about alerts with the following severity: High or above. Save."
   },
   {
     "checkId": "AZ-DEFENDER-010",
@@ -3019,7 +3149,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Notify about attack paths with the following risk le' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Email notifications > Notify about attack paths: High or above. Save."
   },
   {
     "checkId": "AZ-DEFENDER-011",
@@ -3041,7 +3172,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Microsoft Defender External Attack Surface Monitoring' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > External Attack Surface Management: Enable (requires EASM workspace)."
   },
   {
     "checkId": "AZ-DEFENDER-012",
@@ -3063,7 +3195,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure Microsoft Defender CSPM is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender CSPM: On. Save. CSPM provides advanced posture management capabilities beyond the free tier."
   },
   {
     "checkId": "AZ-DEFENDER-013",
@@ -3085,7 +3218,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Microsoft Defender for APIs is set to 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > APIs: On. Save. Defender for APIs protects Azure API Management endpoints."
   },
   {
     "checkId": "AZ-DEFENDER-014",
@@ -3107,7 +3241,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Defender for Servers is set to 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Servers: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-015",
@@ -3129,7 +3264,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Vulnerability assessment for machines' component sta' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings > Vulnerability assessment for machines: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-016",
@@ -3151,7 +3287,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Endpoint protection' component status is set to 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings > Endpoint protection: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-017",
@@ -3173,7 +3310,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Agentless scanning for machines' component status is' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings > Agentless scanning for machines: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-018",
@@ -3195,7 +3333,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'File Integrity Monitoring' component status is set t' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings > File Integrity Monitoring: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-019",
@@ -3217,7 +3356,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for Containers Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Containers: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-020",
@@ -3239,7 +3379,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for Storage Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Storage: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-021",
@@ -3261,7 +3402,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Advanced Threat Protection Alerts for Storage Accounts Are' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Microsoft Defender for Cloud > Advanced threat protection: On. Or enable at subscription level via Defender for Storage plan."
   },
   {
     "checkId": "AZ-DEFENDER-022",
@@ -3283,7 +3425,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for App Services Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > App Service: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-023",
@@ -3305,7 +3448,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for Azure Cosmos DB Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Azure Cosmos DB: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-024",
@@ -3327,7 +3471,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for Open-Source Relational Databas' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Open-source relational databases: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-025",
@@ -3349,7 +3494,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for (Managed Instance) Azure SQL D' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Azure SQL Databases (Managed Instances): On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-026",
@@ -3371,7 +3517,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for SQL Servers on Machines Is Set' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > SQL servers on machines: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-027",
@@ -3393,7 +3540,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for Key Vault Is Set To 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Key Vault: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-028",
@@ -3415,7 +3563,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for Resource Manager Is Set To 'On' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Resource Manager: On. Save."
   },
   {
     "checkId": "AZ-DEFENDER-029",
@@ -3437,7 +3586,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That Microsoft Defender for IoT Hub Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > IoT: On. Save. Requires Azure IoT Hub."
   },
   {
     "checkId": "AZ-DEFENDER-030",
@@ -3459,7 +3609,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the Expiration Date is set for all Keys in RBAC Key V' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Objects > Keys > [key]. Set expiration date. Or: az keyvault key set-attributes --vault-name <VAULT> --name <KEY> --expires <YYYY-MM-DDTHH:MM:SSZ>"
   },
   {
     "checkId": "AZ-DEFENDER-031",
@@ -3481,7 +3632,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the Expiration Date is set for all Keys in Non-RBAC K' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Objects > Keys > [key]. Set expiration date. Or: az keyvault key set-attributes --vault-name <VAULT> --name <KEY> --expires <YYYY-MM-DDTHH:MM:SSZ>"
   },
   {
     "checkId": "AZ-DEFENDER-032",
@@ -3503,7 +3655,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the Expiration Date is set for all Secrets in RBAC Ke' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Objects > Secrets > [secret]. Set expiration date. Or: az keyvault secret set-attributes --vault-name <VAULT> --name <SECRET> --expires <YYYY-MM-DDTHH:MM:SSZ>"
   },
   {
     "checkId": "AZ-DEFENDER-033",
@@ -3525,7 +3678,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the Expiration Date is set for all Secrets in Non-RBA' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Objects > Secrets > [secret]. Set expiration date. Or: az keyvault secret set-attributes --vault-name <VAULT> --name <SECRET> --expires <YYYY-MM-DDTHH:MM:SSZ>"
   },
   {
     "checkId": "AZ-DEFENDER-034",
@@ -3547,7 +3701,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Purge protection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Settings > Properties > Purge protection: Enable. Or: az keyvault update --resource-group <RG> --name <VAULT> --enable-purge-protection true"
   },
   {
     "checkId": "AZ-DEFENDER-035",
@@ -3569,7 +3724,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Role Based Access Control for Azure Key Vault is enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Settings > Access policies > Permission model: Azure role-based access control. Or: az keyvault update --resource-group <RG> --name <VAULT> --enable-rbac-authorization true"
   },
   {
     "checkId": "AZ-DEFENDER-036",
@@ -3591,7 +3747,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Public Network Access is Disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Settings > Networking > Public network access: Disable. Or: az keyvault update --resource-group <RG> --name <VAULT> --public-network-access Disabled"
   },
   {
     "checkId": "AZ-DEFENDER-037",
@@ -3613,7 +3770,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Private Endpoints are used to access Azure Key Vault' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Settings > Networking > Private endpoint connections > Add. Create a private endpoint in the VNet and configure private DNS zone 'privatelink.vaultcore.azure.net'."
   },
   {
     "checkId": "AZ-DEFENDER-038",
@@ -3635,7 +3793,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure automatic key rotation is enabled within Azure Key Vault' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Objects > Keys > [key] > Rotation policy. Set a rotation period (e.g., 90 days) and enable automatic rotation. Or: az keyvault key rotation-policy update --vault-name <VAULT> --name <KEY> --value @policy.json"
   },
   {
     "checkId": "AZ-DEFENDER-039",
@@ -3657,7 +3816,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Azure Key Vault Managed HSM is used when required' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Settings > Managed HSM. Assess whether cryptographic operations require FIPS 140-2 Level 3 compliance. If required, create a Managed HSM and migrate key material."
   },
   {
     "checkId": "AZ-DEFENDER-040",
@@ -3679,7 +3839,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure certificate 'Validity Period (in months)' is less than or ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Key vaults > [vault] > Certificates > [certificate] > Current version. Review 'Valid from' and 'Expires' to ensure validity period is 12 months or less. Create new certificates with a shorter validity period as existing ones expire."
   },
   {
     "checkId": "AZ-DEFENDER-041",
@@ -3701,7 +3862,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure an Azure Bastion Host Exists' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Create a resource > Azure Bastion. Deploy Azure Bastion in a subnet named 'AzureBastionSubnet' (/27 or larger) within the VNet. Once deployed, use Bastion for all RDP/SSH to VMs instead of public IPs."
   },
   {
     "checkId": "AZ-STORAGE-004",
@@ -3723,7 +3885,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure soft delete for Azure File Shares is Enabled' leaves the environment exposed, reducing the ability to recover from security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Data storage > File shares > [share] > Properties. Enable Soft delete with a retention period (e.g., 14 days). Or: az storage account file-service-properties update --account-name <ACCOUNT> --resource-group <RG> --enable-delete-retention true --delete-retention-days 14"
   },
   {
     "checkId": "AZ-STORAGE-005",
@@ -3745,7 +3908,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "SMB versions below 3.1.1 lack mandatory encryption and integrity validation, exposing file shares to eavesdropping and MITM attacks."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Data storage > File shares > [share] > Properties > Protocol settings > SMB protocol version. Set to SMB 3.1.1 (disable 2.1 and 3.0). Or configure via az storage share-rm."
   },
   {
     "checkId": "AZ-STORAGE-006",
@@ -3767,7 +3931,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'SMB channel encryption' is set to 'AES-256-GCM' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Data storage > File shares > [share] > Properties > Protocol settings > SMB channel encryption. Set to AES-256-GCM. Or configure via az storage share-rm protocol."
   },
   {
     "checkId": "AZ-STORAGE-007",
@@ -3789,7 +3954,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Without soft delete, accidentally or maliciously deleted blobs/containers are unrecoverable, causing permanent data loss."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Data storage > Containers > [container] > Properties > Soft delete: Enabled with retention period >= 7 days. Or: az storage account blob-service-properties update --account-name <ACCOUNT> --enable-delete-retention true --delete-retention-days 7"
   },
   {
     "checkId": "AZ-STORAGE-008",
@@ -3811,7 +3977,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Without soft delete, accidentally or maliciously deleted blobs/containers are unrecoverable, causing permanent data loss."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Data management > Data protection > Container soft delete: Enabled with retention >= 7 days. Or: az storage account blob-service-properties update --account-name <ACCOUNT> --enable-container-delete-retention true --container-delete-retention-days 7"
   },
   {
     "checkId": "AZ-STORAGE-009",
@@ -3833,7 +4000,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Versioning' is set to 'Enabled' on Azure Blob Storage sto' leaves the environment exposed, reducing the ability to recover from security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Data management > Data protection > Blob versioning: Enabled. Or: az storage account blob-service-properties update --account-name <ACCOUNT> --enable-versioning true"
   },
   {
     "checkId": "AZ-STORAGE-010",
@@ -3855,7 +4023,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Secure transfer required' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Secure transfer required: Enabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --https-only true"
   },
   {
     "checkId": "AZ-STORAGE-011",
@@ -3877,7 +4046,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow Azure services on the trusted services list to acce' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Networking > Exceptions > Allow Azure services on the trusted services list to access this storage account: Enabled."
   },
   {
     "checkId": "AZ-STORAGE-012",
@@ -3899,7 +4069,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure the 'Minimum TLS version' for storage accounts is set to '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Minimum TLS version: Version 1.2. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --min-tls-version TLS1_2"
   },
   {
     "checkId": "AZ-STORAGE-013",
@@ -3921,7 +4092,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Cross Tenant Replication' is not enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Data management > Object replication. Disable cross-tenant replication: in Object replication rules, ensure no rules allow replication to accounts in different tenants. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --allow-cross-tenant-replication false"
   },
   {
     "checkId": "AZ-STORAGE-014",
@@ -3943,7 +4115,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Allow Blob Anonymous Access' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Allow Blob anonymous access: Disabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --allow-blob-public-access false"
   },
   {
     "checkId": "AZ-STORAGE-015",
@@ -3965,7 +4138,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure Resource Manager Delete locks are applied to Azure S' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Locks > Add lock. Apply CanNotDelete lock. Or: az lock create --name <LOCK> --resource-group <RG> --resource-type Microsoft.Storage/storageAccounts --resource <ACCOUNT> --lock-type CanNotDelete"
   },
   {
     "checkId": "AZ-STORAGE-016",
@@ -3987,7 +4161,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure Resource Manager ReadOnly locks are considered for A' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Locks > Add lock. Evaluate applying ReadOnly lock to critical storage accounts. Ensure that applications can still function with read-only access before applying."
   },
   {
     "checkId": "AZ-STORAGE-017",
@@ -4009,7 +4184,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Redundancy is set to 'geo-redundant storage (GRS)' on crit' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Replication. Set to Geo-redundant storage (GRS) or Read-access geo-redundant storage (RA-GRS) for critical accounts. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --sku Standard_GRS"
   },
   {
     "checkId": "AZ-STORAGE-018",
@@ -4031,7 +4207,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Enable key rotation reminders' is enabled for each S' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Access keys > Key rotation reminder: Enabled. Set the reminder period. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --key-expiration-period-in-days 90"
   },
   {
     "checkId": "AZ-STORAGE-019",
@@ -4053,7 +4230,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Storage Account access keys are periodically regenera' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Access keys > Rotate key1 and key2. Ensure consuming applications are updated before rotating. Automate with Azure Key Vault rotation policy."
   },
   {
     "checkId": "AZ-STORAGE-020",
@@ -4075,7 +4253,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Allow storage account key access' for Azure Storage Accou' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Allow storage account key access: Disabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --allow-shared-key-access false"
   },
   {
     "checkId": "AZ-STORAGE-021",
@@ -4097,7 +4276,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Private Endpoints are used to access Storage Accounts' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Networking > Private endpoint connections > Add. Create a private endpoint and configure DNS zone 'privatelink.blob.core.windows.net'."
   },
   {
     "checkId": "AZ-STORAGE-022",
@@ -4119,7 +4299,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Public Network Access' is 'Disabled' for storage acc' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Networking > Public network access: Disabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --public-network-access Disabled"
   },
   {
     "checkId": "AZ-STORAGE-023",
@@ -4141,7 +4322,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure default network access rule for storage accounts is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Networking > Firewalls and virtual networks > Default network access rule: Deny. Add required VNet service endpoints or IP rules."
   },
   {
     "checkId": "AZ-STORAGE-024",
@@ -4163,7 +4345,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Default to Microsoft Entra authorization in the Azur' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Default to Microsoft Entra authorization in the Azure portal: Enabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --default-to-oauth-authentication true"
   },
   {
     "checkId": "AZ-APPSVC-001",
@@ -4185,7 +4368,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure Key Vaults are Used to Store Secrets' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Store application secrets in Azure Key Vault. Azure Portal > App Services > [app] > Settings > Configuration > Application settings. Replace plaintext secret values with Key Vault references: @Microsoft.KeyVault(SecretUri=https://<VAULT>.vault.azure.net/secrets/<SECRET>/)"
   },
   {
     "checkId": "AZ-APPSVC-002",
@@ -4207,7 +4391,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure App Service Environment is deployed with an internal load ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "App Service Environment v3 must be deployed with an internal load balancer at creation time. To migrate: create a new internal ASE v3 and redeploy applications. Azure Portal > App Service Environments > Create > Virtual IP: Internal."
   },
   {
     "checkId": "AZ-APPSVC-003",
@@ -4229,7 +4414,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure App Service Environment is provisioned with v3 or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Migrate from ASE v1/v2 to ASE v3: create a new ASE v3 and redeploy applications. Azure Portal > App Service Environments > Create. ASE v1 and v2 cannot be in-place upgraded to v3."
   },
   {
     "checkId": "AZ-APPSVC-004",
@@ -4251,7 +4437,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure App Service Environment has internal encryption enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Service Environments > [ASE] > Settings > Configuration > Internal encryption: Enabled. This encrypts traffic between the ASE front end and workers."
   },
   {
     "checkId": "AZ-APPSVC-005",
@@ -4273,7 +4460,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure App Service Environment has TLS 1.0 and 1.1 disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Service Environments > [ASE] > Settings > Configuration > TLS 1.0/1.1: Disabled. Set minimum TLS version to 1.2."
   },
   {
     "checkId": "AZ-APPSVC-006",
@@ -4295,7 +4483,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure App Service Environment has TLS cipher suite ordering conf' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Configure TLS cipher suite ordering via ASE PowerShell or CLI. The ordering must be set per Microsoft's recommended cipher suite list. See: az appservice ase update --resource-group <RG> --name <ASE> with custom cipher ordering."
   },
   {
     "checkId": "AZ-APPSVC-007",
@@ -4317,7 +4506,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Java version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Java version. Select the current supported LTS version. Or: az webapp config set --resource-group <RG> --name <APP> --java-version <VERSION>"
   },
   {
     "checkId": "AZ-APPSVC-008",
@@ -4339,7 +4529,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Python version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Python version. Select the current supported version. Or: az webapp config set --resource-group <RG> --name <APP> --python-version <VERSION>"
   },
   {
     "checkId": "AZ-APPSVC-009",
@@ -4361,7 +4552,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'PHP version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > PHP version. Select the current supported version. Or: az webapp config set --resource-group <RG> --name <APP> --php-version <VERSION>"
   },
   {
     "checkId": "AZ-APPSVC-010",
@@ -4383,7 +4575,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Basic Authentication Publishing Credentials' are 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Basic Auth Publishing Credentials: Off. Or: az resource update --resource-type Microsoft.Web/sites/basicPublishingCredentialsPolicies --name scm --set properties.allow=false"
   },
   {
     "checkId": "AZ-APPSVC-011",
@@ -4405,7 +4598,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'FTP State' is set to 'FTPS only' or 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > FTP state: Disabled or FTPS only. Or: az webapp config set --resource-group <RG> --name <APP> --ftps-state Disabled"
   },
   {
     "checkId": "AZ-APPSVC-012",
@@ -4427,7 +4621,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'HTTP version' is set to '2.0' (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > HTTP version: 2.0. Or: az webapp config set --resource-group <RG> --name <APP> --http20-enabled true"
   },
   {
     "checkId": "AZ-APPSVC-013",
@@ -4449,7 +4644,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'HTTPS Only' is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > HTTPS Only: On. Or: az webapp update --resource-group <RG> --name <APP> --https-only true"
   },
   {
     "checkId": "AZ-APPSVC-014",
@@ -4471,7 +4667,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Minimum Inbound TLS Version' is set to '1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Minimum Inbound TLS Version: 1.2. Or: az webapp config set --resource-group <RG> --name <APP> --min-tls-version 1.2"
   },
   {
     "checkId": "AZ-APPSVC-015",
@@ -4493,7 +4690,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure end-to-end TLS encryption is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > End-to-end TLS encryption: Enabled. This requires the App Service plan to support this feature (Standard or higher)."
   },
   {
     "checkId": "AZ-APPSVC-016",
@@ -4515,7 +4713,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Remote debugging' is set to 'Off'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Remote debugging: Off. Or: az webapp config set --resource-group <RG> --name <APP> --remote-debugging-enabled false"
   },
   {
     "checkId": "AZ-APPSVC-017",
@@ -4537,7 +4736,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure incoming client certificates are enabled and required (if ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Incoming client certificates: Required. Or: az webapp update --resource-group <RG> --name <APP> --set clientCertEnabled=true clientCertMode=Required"
   },
   {
     "checkId": "AZ-APPSVC-018",
@@ -4559,7 +4759,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'App Service authentication' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Authentication > Add identity provider. Configure Entra ID (or another provider). Ensure 'Unauthenticated requests: 401 Unauthorized' is selected."
   },
   {
     "checkId": "AZ-APPSVC-019",
@@ -4581,7 +4782,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure managed identities are configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Identity > System assigned: On. Or: az webapp identity assign --resource-group <RG> --name <APP>. Grant the managed identity access to required resources via IAM."
   },
   {
     "checkId": "AZ-APPSVC-020",
@@ -4603,7 +4805,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure public network access is disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Networking > Public network access: Disabled. Or: az webapp update --resource-group <RG> --name <APP> --public-network-access Disabled"
   },
   {
     "checkId": "AZ-APPSVC-021",
@@ -4625,7 +4828,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure App Service plan SKU supports private endpoints' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Upgrade the App Service plan from Free/Shared/Basic to Standard or Premium to support private endpoints. Azure Portal > App Service plans > [plan] > Scale up (App Service plan)."
   },
   {
     "checkId": "AZ-APPSVC-022",
@@ -4647,7 +4851,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure private endpoints are used to access App Service apps' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Networking > Private endpoints > Add. Select the VNet and subnet for the private endpoint. Configure private DNS zone integration."
   },
   {
     "checkId": "AZ-APPSVC-023",
@@ -4669,7 +4874,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure private endpoints used to access App Service apps use priv' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "When creating the private endpoint for App Service, enable private DNS zone integration: select the zone 'privatelink.azurewebsites.net'. Azure Portal > App Services > [app] > Networking > Private endpoints > Add > integrate with private DNS zone: Yes."
   },
   {
     "checkId": "AZ-APPSVC-024",
@@ -4691,7 +4897,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure app is integrated with a virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > Networking > VNet integration > Add VNet integration. Select the VNet and a delegated subnet. Or: az webapp vnet-integration add --resource-group <RG> --name <APP> --vnet <VNET> --subnet <SUBNET>"
   },
   {
     "checkId": "AZ-APPSVC-025",
@@ -4713,7 +4920,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure configuration is routed through the virtual network integr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "After enabling VNet integration, enable route-all traffic: Azure Portal > App Services > [app] > Networking > VNet integration > Route All: Enabled. Or: az webapp config set --resource-group <RG> --name <APP> --vnet-route-all-enabled true"
   },
   {
     "checkId": "AZ-APPSVC-026",
@@ -4735,7 +4943,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure all traffic is routed through the virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Ensure all outbound traffic routes through the VNet by enabling route-all: Azure Portal > App Services > [app] > Networking > VNet integration > Route All: Enabled."
   },
   {
     "checkId": "AZ-APPSVC-027",
@@ -4757,7 +4966,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure cross-origin resource sharing does not allow all origins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Settings > CORS. Remove '*' from allowed origins. Add only specific allowed origins. Or: az webapp cors remove --resource-group <RG> --name <APP> --allowed-origins '*'"
   },
   {
     "checkId": "AZ-APPSVC-028",
@@ -4779,7 +4989,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Java version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Java version. Select the current supported LTS version."
   },
   {
     "checkId": "AZ-APPSVC-029",
@@ -4801,7 +5012,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Python version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Python version. Select the current supported version."
   },
   {
     "checkId": "AZ-APPSVC-030",
@@ -4823,7 +5035,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'PHP version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > PHP version. Select the current supported version."
   },
   {
     "checkId": "AZ-APPSVC-031",
@@ -4845,7 +5058,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Basic Authentication Publishing Credentials' are 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Basic Auth Publishing Credentials: Off."
   },
   {
     "checkId": "AZ-APPSVC-032",
@@ -4867,7 +5081,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'FTP state' is set to 'FTPS only' or 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > FTP state: Disabled."
   },
   {
     "checkId": "AZ-APPSVC-033",
@@ -4889,7 +5104,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'HTTP version' is set to '2.0' (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > HTTP version: 2.0."
   },
   {
     "checkId": "AZ-APPSVC-034",
@@ -4911,7 +5127,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'HTTPS Only' is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > HTTPS Only: On."
   },
   {
     "checkId": "AZ-APPSVC-035",
@@ -4933,7 +5150,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Minimum Inbound TLS Version' is set to '1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Minimum Inbound TLS Version: 1.2."
   },
   {
     "checkId": "AZ-APPSVC-036",
@@ -4955,7 +5173,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure end-to-end TLS encryption is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > End-to-end TLS encryption: Enabled."
   },
   {
     "checkId": "AZ-APPSVC-037",
@@ -4977,7 +5196,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Remote debugging' is set to 'Off'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Remote debugging: Off."
   },
   {
     "checkId": "AZ-APPSVC-038",
@@ -4999,7 +5219,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure incoming client certificates are enabled and required (if ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Incoming client certificates: Required."
   },
   {
     "checkId": "AZ-APPSVC-039",
@@ -5021,7 +5242,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure managed identities are configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Identity > System assigned: On."
   },
   {
     "checkId": "AZ-APPSVC-040",
@@ -5043,7 +5265,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure public network access is disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Networking > Public network access: Disabled."
   },
   {
     "checkId": "AZ-APPSVC-041",
@@ -5065,7 +5288,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure deployment slot is integrated with a virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Add VNet integration. Select the VNet and delegated subnet."
   },
   {
     "checkId": "AZ-APPSVC-042",
@@ -5087,7 +5311,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure configuration is routed through the virtual network integr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Route All: Enabled."
   },
   {
     "checkId": "AZ-APPSVC-043",
@@ -5109,7 +5334,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure all traffic is routed through the virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Route All: Enabled to route all outbound traffic through the VNet."
   },
   {
     "checkId": "AZ-APPSVC-044",
@@ -5131,7 +5357,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure cross-origin resource sharing does not allow all origins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > CORS. Remove '*' from allowed origins and specify only required origins."
   },
   {
     "checkId": "AZ-APPSVC-045",
@@ -5153,7 +5380,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Java version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Java version. Select the current supported LTS version."
   },
   {
     "checkId": "AZ-APPSVC-046",
@@ -5175,7 +5403,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Python version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Python version. Select the current supported version."
   },
   {
     "checkId": "AZ-APPSVC-047",
@@ -5197,7 +5426,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Basic Authentication Publishing Credentials' are 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Basic Auth Publishing Credentials: Off."
   },
   {
     "checkId": "AZ-APPSVC-048",
@@ -5219,7 +5449,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'FTP state' is set to 'FTPS only' or 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > FTP state: Disabled."
   },
   {
     "checkId": "AZ-APPSVC-049",
@@ -5241,7 +5472,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'HTTP version' is set to '2.0' (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > HTTP version: 2.0."
   },
   {
     "checkId": "AZ-APPSVC-050",
@@ -5263,7 +5495,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'HTTPS Only' is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > HTTPS Only: On. Or: az functionapp update --resource-group <RG> --name <APP> --set httpsOnly=true"
   },
   {
     "checkId": "AZ-APPSVC-051",
@@ -5285,7 +5518,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Minimum Inbound TLS Version' is set to '1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Minimum Inbound TLS Version: 1.2."
   },
   {
     "checkId": "AZ-APPSVC-052",
@@ -5307,7 +5541,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure end-to-end TLS encryption is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > End-to-end TLS encryption: Enabled."
   },
   {
     "checkId": "AZ-APPSVC-053",
@@ -5329,7 +5564,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Remote debugging' is set to 'Off'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Remote debugging: Off."
   },
   {
     "checkId": "AZ-APPSVC-054",
@@ -5351,7 +5587,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure incoming client certificates are enabled and required (if ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Incoming client certificates: Required."
   },
   {
     "checkId": "AZ-APPSVC-055",
@@ -5373,7 +5610,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'App Service authentication' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Authentication > Add identity provider. Configure Entra ID. Set 'Unauthenticated requests: 401 Unauthorized'."
   },
   {
     "checkId": "AZ-APPSVC-056",
@@ -5395,7 +5633,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure managed identities are configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Identity > System assigned: On. Or: az functionapp identity assign --resource-group <RG> --name <APP>"
   },
   {
     "checkId": "AZ-APPSVC-057",
@@ -5417,7 +5656,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure public network access is disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Networking > Public network access: Disabled."
   },
   {
     "checkId": "AZ-APPSVC-058",
@@ -5439,7 +5679,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure function app is integrated with a virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Networking > VNet integration > Add VNet integration. Select the VNet and delegated subnet."
   },
   {
     "checkId": "AZ-APPSVC-059",
@@ -5461,7 +5702,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure configuration is routed through the virtual network integr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Networking > VNet integration > Route All: Enabled."
   },
   {
     "checkId": "AZ-APPSVC-060",
@@ -5483,7 +5725,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure all traffic is routed through the virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > Networking > VNet integration > Route All: Enabled to route all outbound traffic through the VNet."
   },
   {
     "checkId": "AZ-APPSVC-061",
@@ -5505,7 +5748,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure cross-origin resource sharing does not allow all origins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Settings > CORS. Remove '*' from allowed origins and add only required origins."
   },
   {
     "checkId": "AZ-APPSVC-062",
@@ -5527,7 +5771,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Java version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Java version. Select the current supported version."
   },
   {
     "checkId": "AZ-APPSVC-063",
@@ -5549,7 +5794,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Python version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Python version. Select the current supported version."
   },
   {
     "checkId": "AZ-APPSVC-064",
@@ -5571,7 +5817,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Basic Authentication Publishing Credentials' are 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Basic Auth Publishing Credentials: Off."
   },
   {
     "checkId": "AZ-APPSVC-065",
@@ -5593,7 +5840,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'FTP state' is set to 'FTPS only' or 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > FTP state: Disabled."
   },
   {
     "checkId": "AZ-APPSVC-066",
@@ -5615,7 +5863,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure 'HTTP version' is set to '2.0' (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > HTTP version: 2.0."
   },
   {
     "checkId": "AZ-APPSVC-067",
@@ -5637,7 +5886,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'HTTPS Only' is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > HTTPS Only: On."
   },
   {
     "checkId": "AZ-APPSVC-068",
@@ -5659,7 +5909,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Minimum Inbound TLS Version' is set to '1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Minimum Inbound TLS Version: 1.2."
   },
   {
     "checkId": "AZ-APPSVC-069",
@@ -5681,7 +5932,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure end-to-end TLS encryption is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > End-to-end TLS encryption: Enabled."
   },
   {
     "checkId": "AZ-APPSVC-070",
@@ -5703,7 +5955,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Remote debugging' is set to 'Off'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Remote debugging: Off."
   },
   {
     "checkId": "AZ-APPSVC-071",
@@ -5725,7 +5978,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure incoming client certificates are enabled and required (if ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Incoming client certificates: Required."
   },
   {
     "checkId": "AZ-APPSVC-072",
@@ -5747,7 +6001,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure managed identities are configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Identity > System assigned: On."
   },
   {
     "checkId": "AZ-APPSVC-073",
@@ -5769,7 +6024,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure public network access is disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Networking > Public network access: Disabled."
   },
   {
     "checkId": "AZ-APPSVC-074",
@@ -5791,7 +6047,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure deployment slot is integrated with a virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Add VNet integration."
   },
   {
     "checkId": "AZ-APPSVC-075",
@@ -5813,7 +6070,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure configuration is routed through the virtual network integr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Route All: Enabled."
   },
   {
     "checkId": "AZ-APPSVC-076",
@@ -5835,7 +6093,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure all traffic is routed through the virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Route All: Enabled."
   },
   {
     "checkId": "AZ-APPSVC-077",
@@ -5857,7 +6116,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure cross-origin resource sharing does not allow all origins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > CORS. Remove '*' and add only required origins."
   },
   {
     "checkId": "AZ-CONTAINER-001",
@@ -5879,7 +6139,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Private Virtual Networks are used for Container Instances' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "At creation time, configure the Container Instance with a VNet: az container create --resource-group <RG> --name <CONTAINER> --vnet <VNET-ID> --subnet <SUBNET>. Existing container instances without VNet integration must be recreated."
   },
   {
     "checkId": "AZ-CONTAINER-002",
@@ -5901,7 +6162,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure a Managed Identity is used for interactions with other Azu' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Assign a managed identity to the container group: az container create --resource-group <RG> --name <CONTAINER> --assign-identity [system or user-assigned]. Grant the identity only the required permissions via IAM role assignments."
   },
   {
     "checkId": "AZ-CONTAINER-003",
@@ -5923,7 +6185,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure the principle of least privilege is used when assigning ro' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Container instances > [instance] > Access control (IAM). Review role assignments on the container instance's managed identity and remove any roles broader than needed. Follow least-privilege principles."
   },
   {
     "checkId": "AZ-VM-003",
@@ -5945,7 +6208,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Virtual Machines are utilizing Managed Disks' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Disks. If any disk shows 'Unmanaged', the VM must be migrated to managed disks. Or: az vm convert --resource-group <RG> --name <VM>"
   },
   {
     "checkId": "AZ-VM-004",
@@ -5967,7 +6231,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'OS and Data' disks are encrypted with Customer Manag' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Disks > [disk] > Encryption. Set encryption type to Customer-managed keys. Link to an Azure Key Vault key. Or via disk update: az disk update --resource-group <RG> --name <DISK> --encryption-type EncryptionAtRestWithCustomerKey --disk-encryption-set <DES-ID>"
   },
   {
     "checkId": "AZ-VM-005",
@@ -5989,7 +6254,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Unattached disks' are encrypted with 'Customer Manag' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Disks (standalone, unattached). Filter by 'Unattached'. For each disk: Encryption > Encryption type: Customer-managed keys. Or: az disk update --resource-group <RG> --name <DISK> --encryption-type EncryptionAtRestWithCustomerKey"
   },
   {
     "checkId": "AZ-VM-006",
@@ -6011,7 +6277,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Disk Network Access' is NOT set to 'Enable public ac' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Disks > [disk] > Settings > Networking. Set 'Disk network access' to 'Disable public access and enable private access' or 'Disable public access'. Or: az disk update --resource-group <RG> --name <DISK> --network-access-policy DenyAll"
   },
   {
     "checkId": "AZ-VM-007",
@@ -6033,7 +6300,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Enable Data Access Authentication Mode' is 'Checked'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Disks > [disk] > Settings > Networking > Enable data access authentication mode: Checked. This requires SAS token or Entra authentication to export or import disk content."
   },
   {
     "checkId": "AZ-VM-008",
@@ -6055,7 +6323,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Only Approved Extensions Are Installed' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Extensions + applications. Review installed extensions. Remove any extensions not on the approved list. Allowed extensions must be documented and reviewed periodically."
   },
   {
     "checkId": "AZ-VM-009",
@@ -6077,7 +6346,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Endpoint Protection for all Virtual Machines is insta' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Extensions + applications. Install Microsoft Antimalware or Defender for Endpoint extension. Or enable Defender for Servers in Defender for Cloud, which provisions endpoint protection automatically."
   },
   {
     "checkId": "AZ-VM-010",
@@ -6099,7 +6369,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure '[Legacy] Ensure that VHDs are Encrypted' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Disks. Ensure all disks use managed disks (not VHDs in storage accounts). Migrate from VHDs using: az vm convert --resource-group <RG> --name <VM>"
   },
   {
     "checkId": "AZ-VM-011",
@@ -6121,7 +6392,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure only MFA enabled identities can access privileged Virtual ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Defender for Cloud > Workload protections > Just-in-time VM access. Enable JIT on the VM and configure Conditional Access policies requiring MFA for accounts with VM administrator rights."
   },
   {
     "checkId": "AZ-VM-012",
@@ -6143,7 +6415,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Trusted Launch is enabled on Virtual Machines' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Configuration > Trusted launch: Enabled. Note: Trusted Launch must be enabled at VM creation time (Generation 2 VMs only). Existing VMs without Trusted Launch must be redeployed."
   },
   {
     "checkId": "AZ-VM-013",
@@ -6165,7 +6438,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that encryption at host is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Configuration > Encryption at host: Enabled. Or: az vm update --resource-group <RG> --name <VM> --set storageProfile.osDisk.encryptionSettings.encryptionAtHost=true. Requires the feature to be registered: az feature register --namespace Microsoft.Compute --name EncryptionAtHost"
   },
   {
     "checkId": "AZ-COSMOS-001",
@@ -6187,7 +6461,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure That 'Firewalls & Networks' Is Limited to Use Selected Net' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Cosmos DB > [account] > Networking > Firewalls and virtual networks > Selected networks. Add allowed VNet/subnet rules and IP ranges. Remove 'Allow access from all networks'."
   },
   {
     "checkId": "AZ-COSMOS-002",
@@ -6209,7 +6484,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Cosmos DB uses Private Endpoints where possible' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Cosmos DB > [account] > Networking > Private endpoint connections > Add. Create a private endpoint and configure DNS to resolve the Cosmos DB endpoint to the private IP."
   },
   {
     "checkId": "AZ-COSMOS-003",
@@ -6231,7 +6507,8 @@
     "impactRating": {
       "severity": "Critical",
       "rationale": "Failure to configure 'Ensure that 'disableLocalAuth' is set to 'true'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Cosmos DB > [account] > Settings > Keys > Disable local authentication: Enabled. Or: az cosmosdb update --resource-group <RG> --name <ACCOUNT> --disable-local-auth true"
   },
   {
     "checkId": "AZ-COSMOS-004",
@@ -6253,7 +6530,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure `Public Network Access` is `Disabled`' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Cosmos DB > [account] > Networking > Public network access: Disabled. Or: az cosmosdb update --resource-group <RG> --name <ACCOUNT> --public-network-access Disabled"
   },
   {
     "checkId": "AZ-COSMOS-005",
@@ -6275,7 +6553,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure critical data is encrypted with customer-managed keys (CMK' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Cosmos DB > [account] > Settings > Encryption. Select 'Customer-managed key' and provide the Azure Key Vault key URI. CMK must be configured at account creation or via update before data is written."
   },
   {
     "checkId": "AZ-COSMOS-006",
@@ -6297,7 +6576,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure the firewall does not allow all network traffic' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Cosmos DB > [account] > Networking > Firewalls and virtual networks. Remove the 'Allow access from all networks' rule and add explicit IP or VNet allow rules."
   },
   {
     "checkId": "AZ-COSMOS-007",
@@ -6319,7 +6599,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure that Cosmos DB Logging is Enabled' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Azure Cosmos DB > [account] > Monitoring > Diagnostic settings > Add diagnostic setting. Enable 'DataPlaneRequests' and 'QueryRuntimeStatistics' logs. Send to Log Analytics Workspace."
   },
   {
     "checkId": "AZ-MYSQL-001",
@@ -6341,7 +6622,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure Database for MySQL uses Customer Managed Keys for En' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL > [server] > Settings > Encryption. Set 'Data encryption' to Customer-managed key. Link to an Azure Key Vault key with appropriate permissions."
   },
   {
     "checkId": "AZ-MYSQL-002",
@@ -6363,7 +6645,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure Database for MySQL uses only Microsoft Entra Authent' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Authentication. Set 'Authentication method' to Microsoft Entra authentication only. Add an Entra user or group as admin."
   },
   {
     "checkId": "AZ-MYSQL-003",
@@ -6385,7 +6668,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure `Public Network Access` is `Disabled` for Azure Database f' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Networking > Public network access: Disabled. Or: az mysql flexible-server update --resource-group <RG> --name <SERVER> --public-access Disabled"
   },
   {
     "checkId": "AZ-MYSQL-004",
@@ -6407,7 +6691,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Private Endpoints Are Used for Azure MySQL Databases' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Networking > Private endpoint connections > Add. Configure private DNS zone 'privatelink.mysql.database.azure.com'."
   },
   {
     "checkId": "AZ-MYSQL-005",
@@ -6429,7 +6714,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure server parameter 'audit_log_enabled' is set to 'ON' for My' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'audit_log_enabled'. Set value to ON. Save."
   },
   {
     "checkId": "AZ-MYSQL-006",
@@ -6451,7 +6737,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure server parameter 'audit_log_events' has 'CONNECTION' set f' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'audit_log_events'. Set value to include 'CONNECTION'. Save."
   },
   {
     "checkId": "AZ-MYSQL-007",
@@ -6473,7 +6760,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure server parameter 'error_server_log_file' is Enabled for My' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'error_server_log_file'. Set to enabled. Save."
   },
   {
     "checkId": "AZ-MYSQL-008",
@@ -6495,7 +6783,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure server parameter 'require_secure_transport' is set to 'ON'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'require_secure_transport'. Set value to ON. Save."
   },
   {
     "checkId": "AZ-MYSQL-009",
@@ -6517,7 +6806,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure server parameter 'tls_version' is set to 'TLSv1.2' (or hig' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'tls_version'. Set to TLSv1.2 (remove TLSv1 and TLSv1.1). Save."
   },
   {
     "checkId": "AZ-POSTGRES-001",
@@ -6539,7 +6829,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure Database for PostgreSQL uses Customer Managed Keys f' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Encryption. Set 'Data encryption' to Customer-managed key. Link to an Azure Key Vault key."
   },
   {
     "checkId": "AZ-POSTGRES-002",
@@ -6561,7 +6852,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Azure Database for PostgreSQL uses only Microsoft Entra Au' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Authentication. Set 'Authentication method' to Microsoft Entra authentication only. Add an Entra admin."
   },
   {
     "checkId": "AZ-POSTGRES-003",
@@ -6583,7 +6875,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure `Public Network Access` is `Disabled` for Azure Database f' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Networking > Public network access: Disabled. Or: az postgres flexible-server update --resource-group <RG> --name <SERVER> --public-access Disabled"
   },
   {
     "checkId": "AZ-POSTGRES-004",
@@ -6605,7 +6898,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Private Endpoints Are Used for Azure Database for PostgreS' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Networking > Private endpoint connections > Add. Configure private DNS zone 'privatelink.postgres.database.azure.com'."
   },
   {
     "checkId": "AZ-POSTGRES-005",
@@ -6627,7 +6921,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure server parameter 'connection_throttle.enable' is set to 'O' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'connection_throttle.enable'. Set to ON. Save."
   },
   {
     "checkId": "AZ-POSTGRES-006",
@@ -6649,7 +6944,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure server parameter 'logfiles.retention_days' is greater than' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'logfiles.retention_days'. Set to a value greater than 3. Save."
   },
   {
     "checkId": "AZ-POSTGRES-007",
@@ -6671,7 +6967,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure server parameter 'log_checkpoints' is set to 'ON' for Post' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'log_checkpoints'. Set to ON. Save."
   },
   {
     "checkId": "AZ-POSTGRES-008",
@@ -6693,7 +6990,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure server parameter 'log_disconnections' is set to 'ON' for P' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'log_disconnections'. Set to ON. Save."
   },
   {
     "checkId": "AZ-POSTGRES-009",
@@ -6715,7 +7013,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Ensure server parameter 'log_connections' is set to 'ON' for Post' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'log_connections'. Set to ON. Save."
   },
   {
     "checkId": "AZ-POSTGRES-010",
@@ -6737,7 +7036,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure server parameter 'require_secure_transport' is set to 'ON'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'require_secure_transport'. Set to ON. Save."
   },
   {
     "checkId": "AZ-POSTGRES-011",
@@ -6759,7 +7059,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure server parameter 'ssl_min_protocol_version' is set to 'TLS' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'ssl_min_protocol_version'. Set to TLSv1.2. Save."
   },
   {
     "checkId": "AZ-SQL-004",
@@ -6781,7 +7082,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Auditing' is set to 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Security > Auditing > Enable Azure SQL Auditing: On. Or: az sql server audit-policy update --resource-group <RG> --name <SERVER> --state Enabled --blob-storage-target-state Enabled"
   },
   {
     "checkId": "AZ-SQL-005",
@@ -6803,7 +7105,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Public Network Access' is set to 'Disable'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Security > Networking > Public network access: Disable. Or: az sql server update --resource-group <RG> --name <SERVER> --set publicNetworkAccess=Disabled"
   },
   {
     "checkId": "AZ-SQL-006",
@@ -6825,7 +7128,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure no Azure SQL Database firewall rule is overly permissive' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Security > Networking > Firewall rules. Remove any rule allowing 0.0.0.0 to 255.255.255.255. Add specific IP ranges or configure VNet service endpoints."
   },
   {
     "checkId": "AZ-SQL-007",
@@ -6847,7 +7151,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure SQL server's Transparent Data Encryption (TDE) protector i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Security > Transparent data encryption > TDE protector. Select 'Customer-managed key'. Choose or import a key from Azure Key Vault. Or: az sql server tde-key set --resource-group <RG> --server <SERVER> --server-key-type AzureKeyVault --kid <KEY-URL>"
   },
   {
     "checkId": "AZ-SQL-008",
@@ -6869,7 +7174,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Microsoft Entra authentication is Configured for SQL ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Settings > Microsoft Entra ID > Set admin. Select an Entra user or group as the SQL Server Microsoft Entra administrator. Or: az sql server ad-admin create --resource-group <RG> --server <SERVER> --display-name <ADMIN> --object-id <OID>"
   },
   {
     "checkId": "AZ-SQL-009",
@@ -6891,7 +7197,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Data encryption' is set to 'On' on a SQL Database' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > SQL databases > [database] > Security > Transparent data encryption: On. Or: az sql db tde set --resource-group <RG> --server <SERVER> --database <DB> --status Enabled"
   },
   {
     "checkId": "AZ-SQL-010",
@@ -6913,7 +7220,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that 'Auditing' Retention is 'greater than 90 days'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Security > Auditing > Retention. Set log retention to 90 days or greater. Or: az sql server audit-policy update --resource-group <RG> --name <SERVER> --retention-days 90"
   },
   {
     "checkId": "AZ-SQL-011",
@@ -6935,7 +7243,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure 'Minimum TLS Version' is set to 'TLS 1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > SQL servers > [server] > Security > Networking > Minimum TLS version: 1.2. Or: az sql server update --resource-group <RG> --name <SERVER> --minimal-tls-version 1.2"
   },
   {
     "checkId": "AZ-AKS-004",
@@ -6957,7 +7266,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Enable audit Logs' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Kubernetes services > [cluster] > Monitoring > Diagnostic settings > Add diagnostic setting. Enable kube-audit and kube-audit-admin logs. Or: az aks enable-addons --addons monitoring --resource-group <RG> --name <CLUSTER>"
   },
   {
     "checkId": "AZ-AKS-005",
@@ -6979,7 +7289,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the kubeconfig file permissions are set to 644 or mor' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "AKS-managed nodes: upgrade node pool to the latest node image. Azure Portal > Kubernetes services > [cluster] > Node pools > [pool] > Upgrade node image. File permissions on kubeconfig are managed by the node OS image."
   },
   {
     "checkId": "AZ-AKS-006",
@@ -7001,7 +7312,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the kubelet kubeconfig file ownership is set to root:' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "AKS-managed nodes: upgrade node pool to the latest node image. Ownership of kubelet kubeconfig is managed by the AKS node OS image. Azure Portal > Kubernetes services > [cluster] > Node pools > Upgrade node image."
   },
   {
     "checkId": "AZ-AKS-007",
@@ -7023,7 +7335,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the azure.json file has permissions set to 644 or mor' leaves the environment exposed, weakening the security governance posture of the environment."
-    }
+    },
+    "remediation": "AKS-managed nodes: upgrade node pool to the latest node image. Permissions on azure.json are managed by the AKS node OS image. Azure Portal > Kubernetes services > [cluster] > Node pools > Upgrade node image."
   },
   {
     "checkId": "AZ-AKS-008",
@@ -7045,7 +7358,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the azure.json file ownership is set to root:root' leaves the environment exposed, weakening the security governance posture of the environment."
-    }
+    },
+    "remediation": "AKS-managed nodes: upgrade node pool to the latest node image. Ownership of azure.json is managed by the AKS node OS image. Azure Portal > Kubernetes services > [cluster] > Node pools > Upgrade node image."
   },
   {
     "checkId": "AZ-AKS-009",
@@ -7067,7 +7381,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the --anonymous-auth argument is set to false' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply a custom kubelet configuration disabling anonymous auth. Create a kubelet config file with anonymousAuth: false and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json"
   },
   {
     "checkId": "AZ-AKS-010",
@@ -7089,7 +7404,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the --authorization-mode argument is not set to Alway' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply a custom kubelet configuration setting authorization mode to Webhook. Create a kubelet config file with authorizationMode: Webhook and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json"
   },
   {
     "checkId": "AZ-AKS-011",
@@ -7111,7 +7427,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the --client-ca-file argument is set as appropriate' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "AKS manages TLS certificates for the API server automatically. Ensure the cluster uses the AKS-managed CA by not overriding with --api-server-authorized-ip-ranges or custom CA unless required. Verify with: az aks show --resource-group <RG> --name <CLUSTER> --query 'networkProfile'"
   },
   {
     "checkId": "AZ-AKS-012",
@@ -7133,7 +7450,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the --read-only-port is secured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply a custom kubelet configuration setting readOnlyPort: 0 to disable the read-only port. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json"
   },
   {
     "checkId": "AZ-AKS-013",
@@ -7155,7 +7473,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the --streaming-connection-idle-timeout argument is n' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply a custom kubelet configuration setting streamingConnectionIdleTimeout to a non-zero value (e.g., 4h). Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json"
   },
   {
     "checkId": "AZ-AKS-014",
@@ -7177,7 +7496,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the --make-iptables-util-chains argument is set to tr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply a custom kubelet configuration setting makeIPTablesUtilChains: true. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json"
   },
   {
     "checkId": "AZ-AKS-015",
@@ -7199,7 +7519,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the --eventRecordQPS argument is set to 0 or a level ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Apply a custom kubelet configuration setting eventRecordQPS to 0 or an appropriate rate limit. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json"
   },
   {
     "checkId": "AZ-AKS-016",
@@ -7221,7 +7542,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the --rotate-certificates argument is not set to fals' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply a custom kubelet configuration with rotateCertificates: true. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json"
   },
   {
     "checkId": "AZ-AKS-017",
@@ -7243,7 +7565,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the RotateKubeletServerCertificate argument is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply a custom kubelet configuration with RotateKubeletServerCertificate: true. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json"
   },
   {
     "checkId": "AZ-AKS-018",
@@ -7265,7 +7588,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that the cluster-admin role is only used where required' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Review ClusterRoleBindings for cluster-admin: kubectl get clusterrolebindings -o wide | grep cluster-admin. Remove unnecessary bindings: kubectl delete clusterrolebinding <NAME>. Grant scoped roles instead."
   },
   {
     "checkId": "AZ-AKS-019",
@@ -7287,7 +7611,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize access to secrets' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Review RBAC Role/ClusterRole definitions granting 'get','list','watch' on 'secrets'. Use: kubectl get roles,clusterroles -A -o yaml | grep -A5 'secrets'. Replace with least-privilege roles scoped to specific namespaces."
   },
   {
     "checkId": "AZ-AKS-020",
@@ -7309,7 +7634,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize wildcard use in Roles and ClusterRoles' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Review RBAC roles using wildcard (*) verbs or resources: kubectl get roles,clusterroles -A -o yaml | grep '\\*'. Replace wildcards with explicit resource and verb lists in role definitions."
   },
   {
     "checkId": "AZ-AKS-021",
@@ -7331,7 +7657,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Unrestricted pod creation rights allow workloads to deploy privileged containers, enabling host escape and cluster-wide compromise."
-    }
+    },
+    "remediation": "Review RBAC roles granting 'create' on 'pods': kubectl get roles,clusterroles -A -o yaml | grep -B5 'pods'. Restrict pod creation to deployment controllers rather than direct user access."
   },
   {
     "checkId": "AZ-AKS-022",
@@ -7353,7 +7680,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that default service accounts are not actively used' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Disable automounting of service account tokens for default service accounts in each namespace: kubectl patch serviceaccount default -n <NAMESPACE> -p '{\"automountServiceAccountToken\": false}'"
   },
   {
     "checkId": "AZ-AKS-023",
@@ -7375,7 +7703,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that Service Account Tokens are only mounted where necessa' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Set automountServiceAccountToken: false in pod specs that do not require API server access: spec: automountServiceAccountToken: false. Apply to all workloads that do not call the Kubernetes API."
   },
   {
     "checkId": "AZ-AKS-024",
@@ -7397,7 +7726,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Limit use of the Bind, Impersonate and Escalate permissions in th' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Review ClusterRoles granting bind, impersonate, or escalate verbs: kubectl get clusterroles -o yaml | grep -E 'bind|impersonate|escalate'. Remove these permissions and reassign to cluster-admin or dedicated service accounts only."
   },
   {
     "checkId": "AZ-AKS-025",
@@ -7419,7 +7749,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize access to create persistent volumes' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Review ClusterRoles granting 'create' on 'persistentvolumes': kubectl get clusterroles -o yaml | grep -B5 'persistentvolumes'. Restrict persistent volume creation to storage administrators only."
   },
   {
     "checkId": "AZ-AKS-026",
@@ -7441,7 +7772,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Minimize access to the proxy sub-resource of nodes' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Review ClusterRoles granting access to the 'nodes/proxy' sub-resource. Remove this permission from all roles unless required for specific monitoring or debugging tooling."
   },
   {
     "checkId": "AZ-AKS-027",
@@ -7463,7 +7795,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize access to the approval sub-resource of certificatesignin' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Review ClusterRoles granting access to 'certificatesigningrequests/approval': kubectl get clusterroles -o yaml | grep approval. Restrict this permission to the controller manager service account only."
   },
   {
     "checkId": "AZ-AKS-028",
@@ -7485,7 +7818,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize access to webhook configuration objects' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Review ClusterRoles granting access to 'mutatingwebhookconfigurations' or 'validatingwebhookconfigurations'. Restrict webhook configuration access to cluster-admin and designated operators."
   },
   {
     "checkId": "AZ-AKS-029",
@@ -7507,7 +7841,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize access to the service account token creation' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Review ClusterRoles granting 'create' on 'serviceaccounts/token': kubectl get clusterroles -o yaml | grep token. Restrict token creation to specific controllers or service accounts that require it."
   },
   {
     "checkId": "AZ-AKS-030",
@@ -7529,7 +7864,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize the admission of privileged containers' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply an Azure Policy to deny privileged containers: Azure Portal > Policy > Definitions > search 'Kubernetes cluster should not allow privileged containers'. Assign to the cluster's resource group or subscription."
   },
   {
     "checkId": "AZ-AKS-031",
@@ -7551,7 +7887,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize the admission of containers wishing to share the host pr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply an Azure Policy to deny hostPID containers: Azure Portal > Policy > Definitions > search 'Kubernetes clusters should not use the host process ID or host IPC namespace'. Assign to the subscription."
   },
   {
     "checkId": "AZ-AKS-032",
@@ -7573,7 +7910,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize the admission of containers wishing to share the host IP' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply an Azure Policy to deny hostIPC containers: Azure Portal > Policy > Definitions > search 'Kubernetes clusters should not use the host process ID or host IPC namespace'. Assign to the subscription."
   },
   {
     "checkId": "AZ-AKS-033",
@@ -7595,7 +7933,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize the admission of containers wishing to share the host ne' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply an Azure Policy to deny hostNetwork containers: Azure Portal > Policy > Definitions > search 'Kubernetes cluster pods should only use approved host network and port range'. Assign to the subscription."
   },
   {
     "checkId": "AZ-AKS-034",
@@ -7617,7 +7956,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize the admission of containers with allowPrivilegeEscalatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply an Azure Policy to deny allowPrivilegeEscalation: Azure Portal > Policy > Definitions > search 'Kubernetes clusters should not allow container privilege escalation'. Assign to the subscription."
   },
   {
     "checkId": "AZ-AKS-035",
@@ -7639,7 +7979,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure latest CNI version is used' leaves the environment exposed, weakening the security governance posture of the environment."
-    }
+    },
+    "remediation": "Azure Portal > Kubernetes services > [cluster] > Node pools > [pool] > Upgrade node image. Ensure the node pool is running the latest AKS node image, which bundles the current CNI version."
   },
   {
     "checkId": "AZ-AKS-036",
@@ -7661,7 +8002,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure that all Namespaces have Network Policies defined' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply a NetworkPolicy to each namespace that restricts pod-to-pod traffic: kubectl apply -f network-policy.yaml. At minimum, a default-deny-ingress policy should exist in each namespace with explicit allow rules for required traffic."
   },
   {
     "checkId": "AZ-AKS-037",
@@ -7683,7 +8025,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Prefer using secrets as files over secrets as environment variabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Update application workload manifests to mount secrets as files (volumeMounts) rather than injecting them as environment variables (env.valueFrom.secretKeyRef). This prevents secrets from appearing in process listings."
   },
   {
     "checkId": "AZ-AKS-038",
@@ -7705,7 +8048,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Consider external secret storage' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Integrate the cluster with Azure Key Vault using the Secrets Store CSI driver: az aks enable-addons --addons azure-keyvault-secrets-provider --resource-group <RG> --name <CLUSTER>. Reference Key Vault secrets in pod specs via SecretProviderClass."
   },
   {
     "checkId": "AZ-AKS-039",
@@ -7727,7 +8071,8 @@
     "impactRating": {
       "severity": "Medium",
       "rationale": "Failure to configure 'Create administrative boundaries between resources using namespac' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Use Kubernetes namespaces to isolate workloads: kubectl create namespace <NAME>. Apply ResourceQuota and LimitRange to each namespace. Do not deploy unrelated workloads into the default namespace."
   },
   {
     "checkId": "AZ-AKS-040",
@@ -7749,7 +8094,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Apply Security Context to Your Pods and Containers' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Add a securityContext block to each pod and container spec defining: runAsNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, and appropriate capabilities (drop: [ALL])."
   },
   {
     "checkId": "AZ-AKS-041",
@@ -7771,7 +8117,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'The default namespace should not be used' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Move all workloads out of the default namespace. Create application-specific namespaces: kubectl create namespace <APP>. Update deployment manifests with namespace: <APP>."
   },
   {
     "checkId": "AZ-AKS-042",
@@ -7793,7 +8140,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Image Vulnerability Scanning using Microsoft Defender for ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
-    }
+    },
+    "remediation": "Azure Portal > Defender for Cloud > Environment settings > [subscription] > Containers plan > Enable. This enables vulnerability scanning for images in Azure Container Registry via Microsoft Defender for Containers."
   },
   {
     "checkId": "AZ-AKS-043",
@@ -7815,7 +8163,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize user access to Azure Container Registry (ACR)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Container registries > [registry] > Access control (IAM). Remove broad roles (Contributor, Owner) from non-administrative users. Grant AcrPull to service principals that only need to pull images."
   },
   {
     "checkId": "AZ-AKS-044",
@@ -7837,7 +8186,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize cluster access to read-only for Azure Container Registry' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Grant only AcrPull to the AKS cluster's managed identity on the container registry: az role assignment create --assignee <CLUSTER-IDENTITY> --role AcrPull --scope /subscriptions/<SUB>/resourceGroups/<RG>/providers/Microsoft.ContainerRegistry/registries/<REGISTRY>"
   },
   {
     "checkId": "AZ-AKS-045",
@@ -7859,7 +8209,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Minimize Container Registries to only those approved' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Apply an Azure Policy to restrict registries: Azure Portal > Policy > Definitions > search 'Kubernetes cluster containers should only use allowed images'. Specify the allowed registry list (e.g., <REGISTRY>.azurecr.io/*) in the policy parameters."
   },
   {
     "checkId": "AZ-AKS-046",
@@ -7881,7 +8232,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Prefer using dedicated AKS Service Accounts' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Create dedicated Kubernetes service accounts for each workload instead of using the default service account: kubectl create serviceaccount <NAME> -n <NAMESPACE>. Reference in pod spec: serviceAccountName: <NAME>."
   },
   {
     "checkId": "AZ-AKS-047",
@@ -7903,7 +8255,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Kubernetes Secrets are encrypted' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Enable encryption at rest for Kubernetes Secrets using an Azure Key Vault key: Azure Portal > Kubernetes services > [cluster] > Settings > Encryption (preview). Or use a KMS plugin via az aks create/update with --enable-azure-keyvault-kms."
   },
   {
     "checkId": "AZ-AKS-048",
@@ -7925,7 +8278,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Restrict Access to the Control Plane Endpoint' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Networking > Authorized IP ranges. Add the CIDR ranges of authorized management networks. Or: az aks update --resource-group <RG> --name <CLUSTER> --api-server-authorized-ip-ranges <CIDR>"
   },
   {
     "checkId": "AZ-AKS-049",
@@ -7947,7 +8301,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure clusters are created with Private Endpoint Enabled and Pub' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Create or update the cluster with a private endpoint: az aks update --resource-group <RG> --name <CLUSTER> --enable-private-cluster. Public API server access must be disabled in the cluster networking settings."
   },
   {
     "checkId": "AZ-AKS-050",
@@ -7969,7 +8324,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure clusters are created with Private Nodes' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Create a new node pool with private nodes (no public IPs): az aks nodepool add --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --node-count 3 --no-public-ip-for-nodes. Existing public-IP node pools must be replaced."
   },
   {
     "checkId": "AZ-AKS-051",
@@ -7991,7 +8347,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Ensure Network Policy is Enabled and set as appropriate' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > Network policy. Select Azure or Calico and apply appropriate NetworkPolicy objects for namespace traffic control."
   },
   {
     "checkId": "AZ-AKS-052",
@@ -8013,7 +8370,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Encrypt traffic to HTTPS load balancers with TLS certificates' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Configure TLS certificates on HTTPS load balancers. Use cert-manager or Azure Application Gateway Ingress Controller (AGIC) with a certificate from Azure Key Vault. Ensure all ingress resources specify TLS secretName."
   },
   {
     "checkId": "AZ-AKS-053",
@@ -8035,7 +8393,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Manage Kubernetes RBAC users with Azure AD' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > Enable AKS-managed Microsoft Entra ID. Or: az aks update --resource-group <RG> --name <CLUSTER> --enable-aad --aad-admin-group-object-ids <GROUP-ID>"
   },
   {
     "checkId": "AZ-AKS-054",
@@ -8057,7 +8416,8 @@
     "impactRating": {
       "severity": "High",
       "rationale": "Failure to configure 'Use Azure RBAC for Kubernetes Authorization' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
-    }
+    },
+    "remediation": "Enable Azure RBAC for Kubernetes authorization: az aks update --resource-group <RG> --name <CLUSTER> --enable-azure-rbac. Assign Azure RBAC roles (e.g., Azure Kubernetes Service RBAC Cluster Admin) to Entra users and groups."
   },
   {
     "checkId": "WIN-ACCOUNT-001",

--- a/data/registry.json
+++ b/data/registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "2.2.0",
-  "dataVersion": "2026-04-19",
+  "dataVersion": "2026-04-20",
   "generatedFrom": "data/scf-check-mapping.json + SecFrame/SCF/scf.db + data/scf-framework-map.json + data/az-assess-source-checks.json",
   "checks": [
     {
@@ -2458,6 +2458,7 @@
         "severity": "High",
         "rationale": "Guest accounts are often over-privileged and rarely reviewed, creating persistent unauthorized access paths."
       },
+      "remediation": "Microsoft Entra admin center > Users > All users > Filter by 'Guest'. Review and remove guest accounts that are no longer needed. Or use Microsoft Entra access reviews: Identity Governance > Access reviews > New access review > Guests.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -2500,6 +2501,7 @@
         "severity": "Medium",
         "rationale": "Without Azure AD integration, AKS authentication relies on local credentials that bypass organizational MFA and conditional access policies."
       },
+      "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > AKS-managed Azure Active Directory: Enable. Or: az aks update --resource-group <RG> --name <CLUSTER> --enable-aad --aad-admin-group-object-ids <GROUP-ID>",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -2572,6 +2574,7 @@
         "severity": "Critical",
         "rationale": "Privileged VM access without MFA allows a single compromised credential to grant full control of a virtual machine, enabling persistent access, lateral movement, and data exfiltration."
       },
+      "remediation": "Azure Portal > Defender for Cloud > Workload protections > Just-in-time VM access. Enable JIT on VMs and configure MFA via Conditional Access for Entra ID accounts that have VM administrator access.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -2643,6 +2646,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure that 'Require Multifactor Authentication to register or jo' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Devices > Device settings > Require Multifactor Authentication to register or join devices with Microsoft Entra: Yes. Save.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -2714,6 +2718,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure that 'multifactor authentication' is 'enabled' for all use' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Require MFA for all users and all cloud apps. Or use the 'Require MFA for all users' template under Security defaults.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -2785,6 +2790,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure that 'Allow users to remember multifactor authentication o' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Multifactor authentication > Service settings. Uncheck 'Allow users to remember multi-factor authentication on devices they trust'. Save.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -2856,6 +2862,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure that a multifactor authentication policy exists for all us' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies. Verify a policy exists requiring MFA for All users accessing all cloud apps. Use the 'Require multifactor authentication for all users' template if not present.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -2927,6 +2934,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure that multifactor authentication is required for risky sign' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies. Create a policy requiring MFA when sign-in risk is Medium or above: Conditions = Sign-in risk: Medium, High. Grant = Require MFA.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -2998,6 +3006,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure that multifactor authentication is required for Windows Az' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Require MFA for Windows Azure Service Management API: Cloud apps = Windows Azure Service Management API. Grant = Require MFA.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -3069,6 +3078,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure that multifactor authentication is required to access Micr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Require MFA for Microsoft Admin Portals: Cloud apps = Microsoft Admin Portals. Grant = Require MFA.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -3140,6 +3150,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure only MFA enabled identities can access privileged Virtual ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Defender for Cloud > Workload protections > Just-in-time VM access. Enable JIT on the VM and configure Conditional Access policies requiring MFA for accounts with VM administrator rights.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -3211,6 +3222,7 @@
         "severity": "Critical",
         "rationale": "Failure to configure 'Ensure that 'disableLocalAuth' is set to 'true'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Cosmos DB > [account] > Settings > Keys > Disable local authentication: Enabled. Or: az cosmosdb update --resource-group <RG> --name <ACCOUNT> --disable-local-auth true",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -3282,6 +3294,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'security defaults' is enabled in Microsoft Entra ID' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Overview > Properties > Manage security defaults: Enable security defaults. Note: incompatible with Conditional Access policies. If CA policies are in use, disable security defaults and configure equivalent CA policies.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -3353,6 +3366,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'trusted locations' are defined' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Named locations. Define trusted IP ranges for the organization. Reference them in CA policies to restrict or allow access from known locations.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -3424,6 +3438,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that an exclusionary geographic Conditional Access policy ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Configure a policy that blocks sign-ins from countries the organization does not operate in. Use Named Locations (country-based) as the condition.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -3495,6 +3510,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that an exclusionary device code flow policy is considered' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Block device code flow: grant = Block. Conditions = Authentication flows > Device code flow. Scope to all users or privileged accounts at minimum.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -3566,6 +3582,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure a Token Protection Conditional Access policy is considered' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Conditional Access > Policies > New policy. Enable Token Protection (requires Entra ID P2). Conditions = All apps. Session = Token Protection: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -5239,6 +5256,7 @@
         "severity": "High",
         "rationale": "Expired credentials on active service principals indicate unmanaged automation that may have been compromised or abandoned."
       },
+      "remediation": "Microsoft Entra admin center > App registrations > All applications > filter for apps with expired credentials. Remove expired certificates and secrets: [app] > Certificates & secrets. Delete expired entries and rotate active credentials.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -6737,6 +6755,7 @@
         "severity": "High",
         "rationale": "Requiring only one reset method reduces the assurance that the requester is the legitimate account owner, enabling account takeover via a single compromised factor."
       },
+      "remediation": "Microsoft Entra admin center > Users > Password reset > Authentication methods. Set 'Number of methods required to reset' to 2.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -6812,6 +6831,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that a 'Custom banned password list' is set to 'Enforce'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Authentication methods > Password protection > Custom banned password list: Enforce. Add organizational terms to the banned list. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -6887,6 +6907,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that 'Number of days before users are asked to re-confirm ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Users > Password reset > Registration > Number of days before users are asked to re-confirm their authentication information. Set to a value greater than 0 (recommended: 180 days).",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -6961,6 +6982,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that 'Notify users on password resets?' is set to 'Yes'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Users > Password reset > Notifications > Notify users on password resets: Yes. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -8168,6 +8190,7 @@
         "severity": "High",
         "rationale": "A high lockout threshold permits extensive password guessing before triggering account lockout, substantially increasing the success probability of brute force attacks."
       },
+      "remediation": "Microsoft Entra admin center > Security > Authentication methods > Password protection > Lockout threshold. Set to 10 or lower. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -8243,6 +8266,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that account 'Lockout duration in seconds' is greater than' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Authentication methods > Password protection > Lockout duration in seconds. Set to 60 or higher. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -9449,6 +9473,7 @@
         "severity": "High",
         "rationale": "Excessive Owner assignments violate least privilege and expand the attack surface for subscription takeover."
       },
+      "remediation": "Azure Portal > Subscriptions > [subscription] > Access control (IAM) > Role assignments. Review Owner role assignments. Remove accounts that do not require Owner. Reduce to 2-3 maximum. Use Privileged Identity Management (PIM) for eligible assignments instead.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -9491,6 +9516,7 @@
         "severity": "High",
         "rationale": "Service principals with stored secrets are a common attack vector; managed identities eliminate secret management overhead."
       },
+      "remediation": "Microsoft Entra admin center > Enterprise applications > All applications. Review service principals using service principal credentials vs. managed identities. Where feasible, migrate app authentication to managed identities to eliminate credential management.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -9533,6 +9559,7 @@
         "severity": "High",
         "rationale": "Without RBAC, all authenticated users have unrestricted access to Kubernetes API operations including cluster-admin capabilities."
       },
+      "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > Enable Kubernetes RBAC. Or: az aks update --resource-group <RG> --name <CLUSTER> --enable-aad --enable-azure-rbac",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -12764,6 +12791,7 @@
         "severity": "Medium",
         "rationale": "Local Databricks accounts not synced from Entra ID bypass centralised lifecycle management, creating orphaned access after offboarding."
       },
+      "remediation": "Azure Portal > Azure Databricks > [workspace] > Settings > Microsoft Entra ID. Enable Entra ID sync or configure SCIM provisioning to synchronize users and groups from Entra ID to Databricks.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -14717,6 +14745,7 @@
         "severity": "High",
         "rationale": "Long-lived or unrestricted PATs provide persistent API access; a leaked token without expiry can be used indefinitely to exfiltrate data or execute jobs."
       },
+      "remediation": "In the Databricks workspace: Settings > Admin Console > Workspace settings > Personal access tokens. Set the maximum token lifetime (e.g., 90 days) and disable the ability to create tokens without expiration.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -14780,6 +14809,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow storage account key access' for Azure Storage Accou' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Allow storage account key access: Disabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --allow-shared-key-access false",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -18828,6 +18858,7 @@
         "severity": "High",
         "rationale": "Unrestricted tenant creation allows any user to establish a shadow tenant, bypassing organizational security policies and creating unmonitored administrative domains."
       },
+      "remediation": "Microsoft Entra admin center > Users > User settings > Restrict non-admin users from creating tenants: Yes. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -18912,6 +18943,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Notify all admins when other admins reset their pass' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Users > Password reset > Notifications > Notify all admins when other admins reset their password: Yes. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -18996,6 +19028,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'User consent for applications' is set to 'Do not all' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Enterprise applications > Consent and permissions > User consent settings > User consent for applications: Do not allow user consent. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19080,6 +19113,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'User consent for applications' is set to 'Allow user' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Enterprise applications > Consent and permissions > User consent settings > User consent for applications: Allow user consent for apps from verified publishers, for selected permissions. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19164,6 +19198,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Users can register applications' is set to 'No'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Users > User settings > App registrations > Users can register applications: No. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19248,6 +19283,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Guest users access restrictions' is set to 'Guest us' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > External identities > External collaboration settings > Guest user access: Guest user access is restricted to properties and memberships of their own directory objects. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19332,6 +19368,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Restrict access to Microsoft Entra admin center' is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Users > User settings > Restrict access to Microsoft Entra admin center: Yes. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19416,6 +19453,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Restrict user ability to access groups features in M' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Groups > General settings > Restrict user ability to access groups features in the My Groups portal: Yes. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19500,6 +19538,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Users can create security groups in Azure portals, A' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Groups > General settings > Users can create security groups in Azure portals, API or PowerShell: No. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19584,6 +19623,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Owners can manage group membership requests in My Gr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Groups > General settings > Owners can manage group membership requests in My Groups: No. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19668,6 +19708,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Users can create Microsoft 365 groups in Azure porta' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Groups > General settings > Users can create Microsoft 365 groups in Azure portals, API or PowerShell: No. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19752,6 +19793,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that no custom subscription administrator roles exist' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Subscriptions > [subscription] > Access control (IAM) > Roles. Review custom roles with subscription-level administrator permissions. Remove or redesign roles granting more than necessary. Prefer built-in roles.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19836,6 +19878,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure fewer than 5 users have global administrator assignment' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Roles and administrators > Global administrator. Review assignments. Ensure fewer than 5 users have this role. Use Privileged Identity Management (PIM) for eligible assignments.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -19920,6 +19963,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that guest users are reviewed on a regular basis' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Identity Governance > Access reviews > New access review. Configure a recurring access review for Guest users in all groups and applications. Set reviewer to group owners or specific users.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20004,6 +20048,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that use of the 'User Access Administrator' role is restri' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Roles and administrators > User Access Administrator. Review all assignments. Remove assignments that are not time-limited via PIM. Use PIM eligible assignments for this role.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20088,6 +20133,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that all 'privileged' role assignments are periodically re' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles. Configure access reviews for all privileged role assignments. Set review frequency to quarterly or monthly.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20172,6 +20218,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure disabled user accounts do not have read, write, or owner p' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Subscriptions > Access control (IAM) > Role assignments. Filter by disabled accounts. Remove all role assignments (read, write, owner) from disabled user accounts.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20256,6 +20303,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Tenant Creator' role assignments are periodically reviewe' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Identity Governance > Privileged Identity Management > Azure AD roles > Tenant Creator. Review active and eligible assignments. Remove unnecessary assignments and configure PIM access review.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20340,6 +20388,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure all non-privileged role assignments are periodically revie' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Identity Governance > Privileged Identity Management > Azure resources. Configure access reviews for non-privileged role assignments (Contributor, Reader) across subscriptions and resource groups. Set review frequency to quarterly.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20424,6 +20473,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Resource Locks are set for Mission-Critical Azure Res' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > [Resource] > Settings > Locks > Add lock. Apply CanNotDelete or ReadOnly locks to mission-critical resources (e.g., VNets, Key Vaults, Storage Accounts). Or: az lock create --name <LOCK> --resource-group <RG> --resource-type <TYPE> --resource <NAME> --lock-type CanNotDelete",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20508,6 +20558,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the Expiration Date is set for all Keys in RBAC Key V' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Objects > Keys > [key]. Set expiration date. Or: az keyvault key set-attributes --vault-name <VAULT> --name <KEY> --expires <YYYY-MM-DDTHH:MM:SSZ>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20592,6 +20643,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the Expiration Date is set for all Keys in Non-RBAC K' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Objects > Keys > [key]. Set expiration date. Or: az keyvault key set-attributes --vault-name <VAULT> --name <KEY> --expires <YYYY-MM-DDTHH:MM:SSZ>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20676,6 +20728,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the Expiration Date is set for all Secrets in RBAC Ke' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Objects > Secrets > [secret]. Set expiration date. Or: az keyvault secret set-attributes --vault-name <VAULT> --name <SECRET> --expires <YYYY-MM-DDTHH:MM:SSZ>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20760,6 +20813,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the Expiration Date is set for all Secrets in Non-RBA' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Objects > Secrets > [secret]. Set expiration date. Or: az keyvault secret set-attributes --vault-name <VAULT> --name <SECRET> --expires <YYYY-MM-DDTHH:MM:SSZ>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20844,6 +20898,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Purge protection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Settings > Properties > Purge protection: Enable. Or: az keyvault update --resource-group <RG> --name <VAULT> --enable-purge-protection true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -20928,6 +20983,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Role Based Access Control for Azure Key Vault is enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Settings > Access policies > Permission model: Azure role-based access control. Or: az keyvault update --resource-group <RG> --name <VAULT> --enable-rbac-authorization true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21012,6 +21068,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Enable key rotation reminders' is enabled for each S' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Access keys > Key rotation reminder: Enabled. Set the reminder period. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --key-expiration-period-in-days 90",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21096,6 +21153,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Default to Microsoft Entra authorization in the Azur' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Default to Microsoft Entra authorization in the Azure portal: Enabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --default-to-oauth-authentication true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21180,6 +21238,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure managed identities are configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Identity > System assigned: On. Or: az webapp identity assign --resource-group <RG> --name <APP>. Grant the managed identity access to required resources via IAM.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21264,6 +21323,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure managed identities are configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Identity > System assigned: On.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21348,6 +21408,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure managed identities are configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Identity > System assigned: On. Or: az functionapp identity assign --resource-group <RG> --name <APP>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21432,6 +21493,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure managed identities are configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Identity > System assigned: On.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21516,6 +21578,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure a Managed Identity is used for interactions with other Azu' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Assign a managed identity to the container group: az container create --resource-group <RG> --name <CONTAINER> --assign-identity [system or user-assigned]. Grant the identity only the required permissions via IAM role assignments.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21600,6 +21663,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure the principle of least privilege is used when assigning ro' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Container instances > [instance] > Access control (IAM). Review role assignments on the container instance's managed identity and remove any roles broader than needed. Follow least-privilege principles.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21684,6 +21748,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the kubeconfig file permissions are set to 644 or mor' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "AKS-managed nodes: upgrade node pool to the latest node image. Azure Portal > Kubernetes services > [cluster] > Node pools > [pool] > Upgrade node image. File permissions on kubeconfig are managed by the node OS image.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21768,6 +21833,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the kubelet kubeconfig file ownership is set to root:' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "AKS-managed nodes: upgrade node pool to the latest node image. Ownership of kubelet kubeconfig is managed by the AKS node OS image. Azure Portal > Kubernetes services > [cluster] > Node pools > Upgrade node image.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21852,6 +21918,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the --authorization-mode argument is not set to Alway' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply a custom kubelet configuration setting authorization mode to Webhook. Create a kubelet config file with authorizationMode: Webhook and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -21936,6 +22003,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the cluster-admin role is only used where required' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Review ClusterRoleBindings for cluster-admin: kubectl get clusterrolebindings -o wide | grep cluster-admin. Remove unnecessary bindings: kubectl delete clusterrolebinding <NAME>. Grant scoped roles instead.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22020,6 +22088,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize wildcard use in Roles and ClusterRoles' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Review RBAC roles using wildcard (*) verbs or resources: kubectl get roles,clusterroles -A -o yaml | grep '\\*'. Replace wildcards with explicit resource and verb lists in role definitions.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22104,6 +22173,7 @@
         "severity": "High",
         "rationale": "Unrestricted pod creation rights allow workloads to deploy privileged containers, enabling host escape and cluster-wide compromise."
       },
+      "remediation": "Review RBAC roles granting 'create' on 'pods': kubectl get roles,clusterroles -A -o yaml | grep -B5 'pods'. Restrict pod creation to deployment controllers rather than direct user access.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22188,6 +22258,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that default service accounts are not actively used' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Disable automounting of service account tokens for default service accounts in each namespace: kubectl patch serviceaccount default -n <NAMESPACE> -p '{\"automountServiceAccountToken\": false}'",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22272,6 +22343,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Service Account Tokens are only mounted where necessa' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Set automountServiceAccountToken: false in pod specs that do not require API server access: spec: automountServiceAccountToken: false. Apply to all workloads that do not call the Kubernetes API.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22356,6 +22428,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Limit use of the Bind, Impersonate and Escalate permissions in th' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Review ClusterRoles granting bind, impersonate, or escalate verbs: kubectl get clusterroles -o yaml | grep -E 'bind|impersonate|escalate'. Remove these permissions and reassign to cluster-admin or dedicated service accounts only.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22440,6 +22513,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize access to create persistent volumes' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Review ClusterRoles granting 'create' on 'persistentvolumes': kubectl get clusterroles -o yaml | grep -B5 'persistentvolumes'. Restrict persistent volume creation to storage administrators only.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22524,6 +22598,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize access to the approval sub-resource of certificatesignin' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Review ClusterRoles granting access to 'certificatesigningrequests/approval': kubectl get clusterroles -o yaml | grep approval. Restrict this permission to the controller manager service account only.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22608,6 +22683,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize access to webhook configuration objects' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Review ClusterRoles granting access to 'mutatingwebhookconfigurations' or 'validatingwebhookconfigurations'. Restrict webhook configuration access to cluster-admin and designated operators.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22692,6 +22768,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize access to the service account token creation' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Review ClusterRoles granting 'create' on 'serviceaccounts/token': kubectl get clusterroles -o yaml | grep token. Restrict token creation to specific controllers or service accounts that require it.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22776,6 +22853,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize the admission of privileged containers' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply an Azure Policy to deny privileged containers: Azure Portal > Policy > Definitions > search 'Kubernetes cluster should not allow privileged containers'. Assign to the cluster's resource group or subscription.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22860,6 +22938,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize the admission of containers wishing to share the host pr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply an Azure Policy to deny hostPID containers: Azure Portal > Policy > Definitions > search 'Kubernetes clusters should not use the host process ID or host IPC namespace'. Assign to the subscription.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -22944,6 +23023,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize the admission of containers wishing to share the host IP' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply an Azure Policy to deny hostIPC containers: Azure Portal > Policy > Definitions > search 'Kubernetes clusters should not use the host process ID or host IPC namespace'. Assign to the subscription.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23028,6 +23108,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize the admission of containers with allowPrivilegeEscalatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply an Azure Policy to deny allowPrivilegeEscalation: Azure Portal > Policy > Definitions > search 'Kubernetes clusters should not allow container privilege escalation'. Assign to the subscription.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23112,6 +23193,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Apply Security Context to Your Pods and Containers' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Add a securityContext block to each pod and container spec defining: runAsNonRoot: true, readOnlyRootFilesystem: true, allowPrivilegeEscalation: false, and appropriate capabilities (drop: [ALL]).",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23196,6 +23278,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'The default namespace should not be used' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Move all workloads out of the default namespace. Create application-specific namespaces: kubectl create namespace <APP>. Update deployment manifests with namespace: <APP>.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23280,6 +23363,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize user access to Azure Container Registry (ACR)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Container registries > [registry] > Access control (IAM). Remove broad roles (Contributor, Owner) from non-administrative users. Grant AcrPull to service principals that only need to pull images.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23364,6 +23448,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize cluster access to read-only for Azure Container Registry' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Grant only AcrPull to the AKS cluster's managed identity on the container registry: az role assignment create --assignee <CLUSTER-IDENTITY> --role AcrPull --scope /subscriptions/<SUB>/resourceGroups/<RG>/providers/Microsoft.ContainerRegistry/registries/<REGISTRY>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23448,6 +23533,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Prefer using dedicated AKS Service Accounts' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Create dedicated Kubernetes service accounts for each workload instead of using the default service account: kubectl create serviceaccount <NAME> -n <NAMESPACE>. Reference in pod spec: serviceAccountName: <NAME>.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23532,6 +23618,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Network Policy is Enabled and set as appropriate' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > Network policy. Select Azure or Calico and apply appropriate NetworkPolicy objects for namespace traffic control.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23616,6 +23703,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Manage Kubernetes RBAC users with Azure AD' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > Enable AKS-managed Microsoft Entra ID. Or: az aks update --resource-group <RG> --name <CLUSTER> --enable-aad --aad-admin-group-object-ids <GROUP-ID>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23700,6 +23788,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Use Azure RBAC for Kubernetes Authorization' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Enable Azure RBAC for Kubernetes authorization: az aks update --resource-group <RG> --name <CLUSTER> --enable-azure-rbac. Assign Azure RBAC roles (e.g., Azure Kubernetes Service RBAC Cluster Admin) to Entra users and groups.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -41756,6 +41845,7 @@
         "severity": "Medium",
         "rationale": "Unreviewed policy non-compliance indicates configuration drift from the security baseline."
       },
+      "remediation": "Azure Portal > Policy > Compliance. Review non-compliant resources and remediate using the provided remediation tasks. Set up automated remediation tasks for supported policies.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -42103,6 +42193,7 @@
         "severity": "Medium",
         "rationale": "Absence of locks allows accidental or malicious deletion of production resources with no rollback protection."
       },
+      "remediation": "Azure Portal > Subscriptions > [subscription] > Resource locks > Add. Create a Delete or ReadOnly lock on the subscription. Or: az lock create --name <LOCK> --resource-group <RG> --lock-type CanNotDelete",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -42192,6 +42283,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that a custom role is assigned permissions for administeri' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Subscriptions > [subscription] > Access control (IAM) > Roles > Add custom role. Create a custom role with Microsoft.Authorization/locks/* permissions and assign only to designated lock administrators.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -42280,6 +42372,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Subscription leaving Microsoft Entra tenant' and 'Su' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Billing > Properties > Subscription entering/leaving tenant policies. Set both to 'Permit no one'. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -42369,6 +42462,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that SKU Basic/Consumption is not used on artifacts that n' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > [Service]. Review the pricing tier of critical services. Upgrade from Free/Basic/Consumption to Standard or Premium tiers that support diagnostic logging and monitoring integration.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -42457,6 +42551,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Public IP addresses are Evaluated on a Periodic Basis' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Public IP addresses. Review all public IP resources. Remove IPs not associated with active resources. Document and periodically review remaining IPs and their purpose.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -42546,6 +42641,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Microsoft Cloud Security Benchmark policies are not s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Security policies. Find Microsoft Cloud Security Benchmark initiative and set any 'Disabled' effects to 'Audit' or 'Deny'.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -42634,6 +42730,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure Microsoft Defender CSPM is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender CSPM: On. Save. CSPM provides advanced posture management capabilities beyond the free tier.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -42722,6 +42819,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Cross Tenant Replication' is not enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Data management > Object replication. Disable cross-tenant replication: in Object replication rules, ensure no rules allow replication to accounts in different tenants. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --allow-cross-tenant-replication false",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -42811,6 +42909,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure App Service Environment is provisioned with v3 or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Migrate from ASE v1/v2 to ASE v3: create a new ASE v3 and redeploy applications. Azure Portal > App Service Environments > Create. ASE v1 and v2 cannot be in-place upgraded to v3.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -42900,6 +42999,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Java version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Java version. Select the current supported LTS version. Or: az webapp config set --resource-group <RG> --name <APP> --java-version <VERSION>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -42989,6 +43089,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Python version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Python version. Select the current supported version. Or: az webapp config set --resource-group <RG> --name <APP> --python-version <VERSION>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43078,6 +43179,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'PHP version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > PHP version. Select the current supported version. Or: az webapp config set --resource-group <RG> --name <APP> --php-version <VERSION>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43167,6 +43269,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Remote debugging' is set to 'Off'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Remote debugging: Off. Or: az webapp config set --resource-group <RG> --name <APP> --remote-debugging-enabled false",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43256,6 +43359,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Java version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Java version. Select the current supported LTS version.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43345,6 +43449,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Python version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Python version. Select the current supported version.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43434,6 +43539,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'PHP version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > PHP version. Select the current supported version.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43523,6 +43629,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Remote debugging' is set to 'Off'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Remote debugging: Off.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43612,6 +43719,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Java version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Java version. Select the current supported LTS version.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43701,6 +43809,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Python version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Python version. Select the current supported version.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43790,6 +43899,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Remote debugging' is set to 'Off'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Remote debugging: Off.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43879,6 +43989,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Java version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Java version. Select the current supported version.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -43968,6 +44079,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Python version' is currently supported (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Python version. Select the current supported version.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -44057,6 +44169,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Remote debugging' is set to 'Off'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Remote debugging: Off.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -44146,6 +44259,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Only Approved Extensions Are Installed' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Extensions + applications. Review installed extensions. Remove any extensions not on the approved list. Allowed extensions must be documented and reviewed periodically.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -44235,6 +44349,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Trusted Launch is enabled on Virtual Machines' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Configuration > Trusted launch: Enabled. Note: Trusted Launch must be enabled at VM creation time (Generation 2 VMs only). Existing VMs without Trusted Launch must be redeployed.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -44324,6 +44439,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize Container Registries to only those approved' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply an Azure Policy to restrict registries: Azure Portal > Policy > Definitions > search 'Kubernetes cluster containers should only use allowed images'. Specify the allowed registry list (e.g., <REGISTRY>.azurecr.io/*) in the policy parameters.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -71501,6 +71617,7 @@
         "severity": "High",
         "rationale": "VMs without monitoring agents are invisible to Defender for Cloud threat detection."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Auto provisioning. Enable auto provisioning for Log Analytics agent and other monitoring extensions.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -71543,6 +71660,7 @@
         "severity": "High",
         "rationale": "Without a Log Analytics workspace, audit log collection cannot be centralized, making incident investigation impossible."
       },
+      "remediation": "Azure Portal > Log Analytics workspaces > Create. Create a workspace in the appropriate region. Connect resources by configuring Diagnostic Settings on each resource to send logs to this workspace.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -71587,6 +71705,7 @@
         "severity": "Medium",
         "rationale": "Without auditing, SQL Server access and schema changes are untracked and cannot be investigated after a breach."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Security > Auditing > Enable Azure SQL Auditing: On. Set log destination to Log Analytics or Storage Account. Or: az sql server audit-policy update --resource-group <RG> --name <SERVER> --state Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -72894,6 +73013,7 @@
         "severity": "Medium",
         "rationale": "Without diagnostic logs, user actions and cluster events are unauditable, delaying detection and forensic investigation of suspicious activity."
       },
+      "remediation": "Azure Portal > Azure Databricks > [workspace] > Diagnostic settings > Add diagnostic setting. Enable dbfs and cluster event log categories and send to Log Analytics Workspace.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -72972,6 +73092,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that a 'Diagnostic Setting' exists for Subscription Activi' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Activity log > Export Activity Logs > Add diagnostic setting. Enable all Administrative and Security log categories and send to Log Analytics Workspace.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73050,6 +73171,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that logging for Azure AppService 'HTTP logs' is enabled' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > App Services > [app] > Monitoring > Diagnostic settings > Add diagnostic setting. Enable 'AppServiceHTTPLogs' category and send to Log Analytics Workspace.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73128,6 +73250,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that a Microsoft Entra diagnostic setting exists to send M' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Entra ID > Monitoring > Diagnostic settings > Add diagnostic setting. Enable MicrosoftGraphActivityLogs and route to Log Analytics Workspace or Storage Account.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73206,6 +73329,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that a Microsoft Entra diagnostic setting exists to send M' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Entra ID > Monitoring > Diagnostic settings > Add diagnostic setting. Enable AuditLogs, SignInLogs, and NonInteractiveUserSignInLogs categories and route to Log Analytics Workspace.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73284,6 +73408,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create Policy Assignmen' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log signal 'Create policy assignment'. Action group: notify security team. Or: az monitor activity-log alert create --resource-group <RG> --name <ALERT> --condition category=Policy and operationName=Microsoft.Authorization/policyAssignments/write",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73362,6 +73487,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete Policy Assignmen' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log signal 'Delete policy assignment'. Action group: notify security team.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73440,6 +73566,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create or Update Securi' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Create or update security solutions'. Action group: notify security team.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73518,6 +73645,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete Security Solutio' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete security solutions'. Action group: notify security team.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73596,6 +73724,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create or Update Public' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Create or update public IP address'. Action group: notify security team.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73674,6 +73803,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete Public IP Addres' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete public IP address'. Action group: notify security team.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73752,6 +73882,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that an Activity Log Alert exists for Service Health' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log signal 'Service Health'. Configure for all event types (Service Issues, Planned Maintenance, Health Advisories). Action group: notify operations team.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73830,6 +73961,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure bot protection is enabled in Azure Web Application Firewal' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Web Application Firewall policies > [policy] > Policy settings. Enable 'Bot protection'. Set 'Bot protection ruleset version' to current. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -73909,6 +74041,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for Storage Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Storage: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -73988,6 +74121,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for App Services Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > App Service: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -74067,6 +74201,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for Open-Source Relational Databas' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Open-source relational databases: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -74146,6 +74281,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for (Managed Instance) Azure SQL D' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Azure SQL Databases (Managed Instances): On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -74225,6 +74361,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for SQL Servers on Machines Is Set' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > SQL servers on machines: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -74304,6 +74441,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'App Service authentication' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Authentication > Add identity provider. Configure Entra ID (or another provider). Ensure 'Unauthenticated requests: 401 Unauthorized' is selected.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -74382,6 +74520,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'App Service authentication' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Authentication > Add identity provider. Configure Entra ID. Set 'Unauthenticated requests: 401 Unauthorized'.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -74460,6 +74599,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Cosmos DB Logging is Enabled' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Azure Cosmos DB > [account] > Monitoring > Diagnostic settings > Add diagnostic setting. Enable 'DataPlaneRequests' and 'QueryRuntimeStatistics' logs. Send to Log Analytics Workspace.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -74538,6 +74678,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure server parameter 'audit_log_enabled' is set to 'ON' for My' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'audit_log_enabled'. Set value to ON. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -74616,6 +74757,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure server parameter 'audit_log_events' has 'CONNECTION' set f' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'audit_log_events'. Set value to include 'CONNECTION'. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -74695,6 +74837,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure server parameter 'error_server_log_file' is Enabled for My' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'error_server_log_file'. Set to enabled. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -74773,6 +74916,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure server parameter 'log_checkpoints' is set to 'ON' for Post' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'log_checkpoints'. Set to ON. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -74851,6 +74995,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure server parameter 'log_disconnections' is set to 'ON' for P' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'log_disconnections'. Set to ON. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -74929,6 +75074,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure server parameter 'log_connections' is set to 'ON' for Post' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'log_connections'. Set to ON. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75007,6 +75153,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Auditing' Retention is 'greater than 90 days'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Security > Auditing > Retention. Set log retention to 90 days or greater. Or: az sql server audit-policy update --resource-group <RG> --name <SERVER> --retention-days 90",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -75086,6 +75233,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Enable audit Logs' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Kubernetes services > [cluster] > Monitoring > Diagnostic settings > Add diagnostic setting. Enable kube-audit and kube-audit-admin logs. Or: az aks enable-addons --addons monitoring --resource-group <RG> --name <CLUSTER>",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75164,6 +75312,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Minimize access to the proxy sub-resource of nodes' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Review ClusterRoles granting access to the 'nodes/proxy' sub-resource. Remove this permission from all roles unless required for specific monitoring or debugging tooling.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -80938,6 +81087,7 @@
         "severity": "Medium",
         "rationale": "Silent policy deletion can remove compliance guardrails without anyone noticing until the next audit."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete policy assignment'. Action group: notify security team. Or: az monitor activity-log alert create with operationName=Microsoft.Authorization/policyAssignments/delete",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -81019,6 +81169,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Advanced Threat Protection Alerts for Storage Accounts Are' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Microsoft Defender for Cloud > Advanced threat protection: On. Or enable at subscription level via Defender for Storage plan.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -83408,6 +83559,7 @@
         "severity": "High",
         "rationale": "Public IPs without NSGs expose the VM attack surface directly to the internet."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Networking. Review if a public IP is assigned. Remove or dissociate public IPs from VMs that do not require direct internet exposure. Use Azure Bastion or load balancers instead.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -83491,6 +83643,7 @@
         "severity": "Medium",
         "rationale": "Deploying Databricks outside a customer-managed VNet limits network isolation and increases exposure of cluster traffic to shared infrastructure."
       },
+      "remediation": "Create or migrate the Databricks workspace to a customer-managed VNet: Azure Portal > Azure Databricks > [workspace] > Networking. VNet injection must be configured at workspace creation time.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -83572,6 +83725,7 @@
         "severity": "High",
         "rationale": "Public IPs on cluster nodes expose worker traffic directly to the internet, enabling port scanning, exploitation, and data exfiltration without VNet traversal."
       },
+      "remediation": "Azure Portal > Azure Databricks > [workspace] > Networking. Enable 'No Public IP' (Secure cluster connectivity). This setting must be configured at workspace creation time. Existing workspaces require migration.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -83654,6 +83808,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the azure.json file has permissions set to 644 or mor' leaves the environment exposed, weakening the security governance posture of the environment."
       },
+      "remediation": "AKS-managed nodes: upgrade node pool to the latest node image. Permissions on azure.json are managed by the AKS node OS image. Azure Portal > Kubernetes services > [cluster] > Node pools > Upgrade node image.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -83736,6 +83891,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the azure.json file ownership is set to root:root' leaves the environment exposed, weakening the security governance posture of the environment."
       },
+      "remediation": "AKS-managed nodes: upgrade node pool to the latest node image. Ownership of azure.json is managed by the AKS node OS image. Azure Portal > Kubernetes services > [cluster] > Node pools > Upgrade node image.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -83818,6 +83974,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize the admission of containers wishing to share the host ne' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply an Azure Policy to deny hostNetwork containers: Azure Portal > Policy > Definitions > search 'Kubernetes cluster pods should only use approved host network and port range'. Assign to the subscription.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -83900,6 +84057,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure latest CNI version is used' leaves the environment exposed, weakening the security governance posture of the environment."
       },
+      "remediation": "Azure Portal > Kubernetes services > [cluster] > Node pools > [pool] > Upgrade node image. Ensure the node pool is running the latest AKS node image, which bundles the current CNI version.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -83982,6 +84140,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that all Namespaces have Network Policies defined' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply a NetworkPolicy to each namespace that restricts pod-to-pod traffic: kubectl apply -f network-policy.yaml. At minimum, a default-deny-ingress policy should exist in each namespace with explicit allow rules for required traffic.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -84064,6 +84223,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Create administrative boundaries between resources using namespac' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Use Kubernetes namespaces to isolate workloads: kubectl create namespace <NAME>. Apply ResourceQuota and LimitRange to each namespace. Do not deploy unrelated workloads into the default namespace.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -84301,6 +84461,7 @@
         "severity": "Critical",
         "rationale": "Internet-exposed RDP is consistently exploited for ransomware deployment and lateral movement."
       },
+      "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Find and modify or delete any rule allowing RDP (TCP 3389) from source 'Any' or 'Internet'. Use Azure Bastion for RDP access instead.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -84344,6 +84505,7 @@
         "severity": "Critical",
         "rationale": "Internet-exposed SSH is a top attack vector for Linux VM compromise and cryptomining deployments."
       },
+      "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Find and modify or delete any rule allowing SSH (TCP 22) from source 'Any' or 'Internet'. Use Azure Bastion for SSH access instead.",
       "effort": {
         "complexity": 4,
         "isPhased": true,
@@ -84387,6 +84549,7 @@
         "severity": "Medium",
         "rationale": "Overly broad SQL firewall rules expose the database server to unauthorized connection attempts from anywhere in Azure or the internet."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Security > Firewalls and virtual networks. Review firewall rules. Remove rules with start IP 0.0.0.0 and end IP 255.255.255.255. Replace with specific IP ranges or VNet rules.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -84429,6 +84592,7 @@
         "severity": "Medium",
         "rationale": "Without network policies, a compromised pod can communicate freely with all other pods, enabling lateral movement."
       },
+      "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Cluster configuration > Network policy. Select Azure or Calico. Or: az aks update --resource-group <RG> --name <CLUSTER> --network-policy azure",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -88089,6 +88253,7 @@
         "severity": "High",
         "rationale": "Missing NSG rules on Databricks subnets allow unrestricted lateral movement between subnets, enabling exfiltration or pivot from a compromised cluster node."
       },
+      "remediation": "Associate NSGs with the Databricks public and private subnets: Azure Portal > Virtual networks > [VNet] > Subnets > [subnet] > Network security group. Attach NSGs restricting inbound and outbound access per Databricks network requirements.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88164,6 +88329,7 @@
         "severity": "High",
         "rationale": "Public network access to the workspace control plane exposes authentication endpoints to brute force and credential stuffing attacks from the internet."
       },
+      "remediation": "Azure Portal > Azure Databricks > [workspace] > Networking > Public network access: Disabled. This restricts the Databricks control plane endpoint to private network access only.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88239,6 +88405,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Azure Monitor Resource Logging is Enabled for All Ser' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > [Resource] > Diagnostic settings > Add diagnostic setting. Enable all appropriate log categories and route to Log Analytics Workspace, Storage Account, or Event Hub. Repeat for each Azure resource type in use.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88314,6 +88481,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Network Security Group Flow logs are captured and sen' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Network security groups > [NSG] > Monitoring > NSG flow logs > Create. Select the NSG, a storage account, and a Log Analytics Workspace. Enable Flow Logs v2 and set retention to 90 days.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88389,6 +88557,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create or Update Networ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Create or update network security group'. Action group: notify security team.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88464,6 +88633,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete Network Security' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete network security group'. Action group: notify security team.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88539,6 +88709,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Create or Update SQL Se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Create or update SQL server firewall rule'. Action group: notify security team.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88614,6 +88785,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Activity Log Alert exists for Delete SQL Server Firew' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Monitor > Alerts > Create > Alert rule. Scope: [subscription]. Condition: Activity log 'Delete SQL server firewall rule'. Action group: notify security team.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88689,6 +88861,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that RDP access from the Internet is evaluated and restric' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Remove or restrict RDP (TCP 3389) access from Internet. Restrict source to specific IP ranges or use Azure Bastion.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88765,6 +88938,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that SSH access from the Internet is evaluated and restric' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Remove or restrict SSH (TCP 22) access from Internet. Restrict source to specific IP ranges or use Azure Bastion.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88841,6 +89015,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that UDP access from the Internet is evaluated and restric' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Remove or restrict UDP access from Internet. Limit any UDP rules to specific source IPs and required ports.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88917,6 +89092,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that HTTP(S) access from the Internet is evaluated and res' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Network security groups > [NSG] > Inbound security rules. Review HTTP (80) and HTTPS (443) rules. Route internet-facing traffic through Azure Application Gateway or Azure Front Door with WAF instead of direct NSG allow rules.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -88993,6 +89169,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that network security group flow log retention days is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Network security groups > [NSG] > Monitoring > NSG flow logs > [flow log]. Set retention period to 90 days or greater. Or: az network watcher flow-log update --resource-group <RG> --name <LOG> --retention 90",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89069,6 +89246,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure Web Application Firewall (WAF) is enabled on Azure A' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Application gateways > [gateway] > Web application firewall. Set WAF mode to Prevention. Or create a WAF policy: Azure Portal > Web Application Firewall policies > Create, then associate with the Application Gateway.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89145,6 +89323,7 @@
         "severity": "High",
         "rationale": "Missing network access controls leave Azure resources exposed to unrestricted lateral traffic, enabling pivoting and data exfiltration."
       },
+      "remediation": "Azure Portal > Virtual networks > [VNet] > Subnets > [subnet] > Network security group. Assign an NSG to each subnet that does not have one. Ensure all subnets except AzureBastionSubnet and GatewaySubnet are NSG-protected.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89221,6 +89400,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure request body inspection is enabled in Azure Web Applicatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Web Application Firewall policies > [policy] > Policy settings. Enable 'Inspect request body' and set 'Max request body size' to an appropriate limit. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89297,6 +89477,7 @@
         "severity": "High",
         "rationale": "Missing network access controls leave Azure resources exposed to unrestricted lateral traffic, enabling pivoting and data exfiltration."
       },
+      "remediation": "Azure Portal > Network security perimeters > Create. Configure the perimeter to protect target PaaS resources (Key Vault, Storage, etc.). This feature requires registration: az feature register --namespace Microsoft.Network --name AllowNetworkSecurityPerimeter",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89373,6 +89554,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow Azure services on the trusted services list to acce' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Networking > Exceptions > Allow Azure services on the trusted services list to access this storage account: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89448,6 +89630,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Allow Blob Anonymous Access' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Allow Blob anonymous access: Disabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --allow-blob-public-access false",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89523,6 +89706,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure default network access rule for storage accounts is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Networking > Firewalls and virtual networks > Default network access rule: Deny. Add required VNet service endpoints or IP rules.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89598,6 +89782,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure cross-origin resource sharing does not allow all origins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > CORS. Remove '*' from allowed origins. Add only specific allowed origins. Or: az webapp cors remove --resource-group <RG> --name <APP> --allowed-origins '*'",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89673,6 +89858,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure cross-origin resource sharing does not allow all origins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > CORS. Remove '*' from allowed origins and specify only required origins.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89748,6 +89934,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure cross-origin resource sharing does not allow all origins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > CORS. Remove '*' from allowed origins and add only required origins.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89823,6 +90010,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure cross-origin resource sharing does not allow all origins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > CORS. Remove '*' and add only required origins.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89898,6 +90086,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Private Virtual Networks are used for Container Instances' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "At creation time, configure the Container Instance with a VNet: az container create --resource-group <RG> --name <CONTAINER> --vnet <VNET-ID> --subnet <SUBNET>. Existing container instances without VNet integration must be recreated.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -89973,6 +90162,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Disk Network Access' is NOT set to 'Enable public ac' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Disks > [disk] > Settings > Networking. Set 'Disk network access' to 'Disable public access and enable private access' or 'Disable public access'. Or: az disk update --resource-group <RG> --name <DISK> --network-access-policy DenyAll",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90048,6 +90238,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That 'Firewalls & Networks' Is Limited to Use Selected Net' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Cosmos DB > [account] > Networking > Firewalls and virtual networks > Selected networks. Add allowed VNet/subnet rules and IP ranges. Remove 'Allow access from all networks'.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90123,6 +90314,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure `Public Network Access` is `Disabled`' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Cosmos DB > [account] > Networking > Public network access: Disabled. Or: az cosmosdb update --resource-group <RG> --name <ACCOUNT> --public-network-access Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90198,6 +90390,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure the firewall does not allow all network traffic' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Cosmos DB > [account] > Networking > Firewalls and virtual networks. Remove the 'Allow access from all networks' rule and add explicit IP or VNet allow rules.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90273,6 +90466,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure `Public Network Access` is `Disabled` for Azure Database f' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Networking > Public network access: Disabled. Or: az mysql flexible-server update --resource-group <RG> --name <SERVER> --public-access Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90348,6 +90542,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure `Public Network Access` is `Disabled` for Azure Database f' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Networking > Public network access: Disabled. Or: az postgres flexible-server update --resource-group <RG> --name <SERVER> --public-access Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90423,6 +90618,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Public Network Access' is set to 'Disable'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Security > Networking > Public network access: Disable. Or: az sql server update --resource-group <RG> --name <SERVER> --set publicNetworkAccess=Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90498,6 +90694,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure no Azure SQL Database firewall rule is overly permissive' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Security > Networking > Firewall rules. Remove any rule allowing 0.0.0.0 to 255.255.255.255. Add specific IP ranges or configure VNet service endpoints.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90573,6 +90770,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the --read-only-port is secured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply a custom kubelet configuration setting readOnlyPort: 0 to disable the read-only port. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90648,6 +90846,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the --make-iptables-util-chains argument is set to tr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply a custom kubelet configuration setting makeIPTablesUtilChains: true. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90723,6 +90922,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Restrict Access to the Control Plane Endpoint' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Kubernetes services > [cluster] > Settings > Networking > Authorized IP ranges. Add the CIDR ranges of authorized management networks. Or: az aks update --resource-group <RG> --name <CLUSTER> --api-server-authorized-ip-ranges <CIDR>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -90798,6 +90998,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure clusters are created with Private Nodes' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Create a new node pool with private nodes (no public IPs): az aks nodepool add --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --node-count 3 --no-public-ip-for-nodes. Existing public-IP node pools must be replaced.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92674,6 +92875,7 @@
         "severity": "High",
         "rationale": "Without private endpoints, workspace traffic traverses public Microsoft backbone infrastructure, increasing exposure to interception and reducing network isolation guarantees."
       },
+      "remediation": "Azure Portal > Azure Databricks > [workspace] > Networking > Private endpoint connections > Add. Create a private endpoint in the VNet and configure private DNS to resolve the workspace URL to the private IP.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92748,6 +92950,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Public Network Access is Disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Settings > Networking > Public network access: Disable. Or: az keyvault update --resource-group <RG> --name <VAULT> --public-network-access Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92822,6 +93025,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Private Endpoints are used to access Azure Key Vault' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Settings > Networking > Private endpoint connections > Add. Create a private endpoint in the VNet and configure private DNS zone 'privatelink.vaultcore.azure.net'.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92896,6 +93100,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Private Endpoints are used to access Storage Accounts' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Networking > Private endpoint connections > Add. Create a private endpoint and configure DNS zone 'privatelink.blob.core.windows.net'.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92970,6 +93175,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Public Network Access' is 'Disabled' for storage acc' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Networking > Public network access: Disabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --public-network-access Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93044,6 +93250,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure public network access is disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Networking > Public network access: Disabled. Or: az webapp update --resource-group <RG> --name <APP> --public-network-access Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93118,6 +93325,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure App Service plan SKU supports private endpoints' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Upgrade the App Service plan from Free/Shared/Basic to Standard or Premium to support private endpoints. Azure Portal > App Service plans > [plan] > Scale up (App Service plan).",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93192,6 +93400,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure private endpoints are used to access App Service apps' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Networking > Private endpoints > Add. Select the VNet and subnet for the private endpoint. Configure private DNS zone integration.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93266,6 +93475,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure private endpoints used to access App Service apps use priv' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "When creating the private endpoint for App Service, enable private DNS zone integration: select the zone 'privatelink.azurewebsites.net'. Azure Portal > App Services > [app] > Networking > Private endpoints > Add > integrate with private DNS zone: Yes.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93340,6 +93550,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure app is integrated with a virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Networking > VNet integration > Add VNet integration. Select the VNet and a delegated subnet. Or: az webapp vnet-integration add --resource-group <RG> --name <APP> --vnet <VNET> --subnet <SUBNET>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93414,6 +93625,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure configuration is routed through the virtual network integr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "After enabling VNet integration, enable route-all traffic: Azure Portal > App Services > [app] > Networking > VNet integration > Route All: Enabled. Or: az webapp config set --resource-group <RG> --name <APP> --vnet-route-all-enabled true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93488,6 +93700,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure all traffic is routed through the virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Ensure all outbound traffic routes through the VNet by enabling route-all: Azure Portal > App Services > [app] > Networking > VNet integration > Route All: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93562,6 +93775,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure public network access is disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Networking > Public network access: Disabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93636,6 +93850,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure deployment slot is integrated with a virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Add VNet integration. Select the VNet and delegated subnet.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93710,6 +93925,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure configuration is routed through the virtual network integr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Route All: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93784,6 +94000,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure all traffic is routed through the virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Route All: Enabled to route all outbound traffic through the VNet.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93858,6 +94075,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure public network access is disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Networking > Public network access: Disabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -93932,6 +94150,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure function app is integrated with a virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Networking > VNet integration > Add VNet integration. Select the VNet and delegated subnet.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94006,6 +94225,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure configuration is routed through the virtual network integr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Networking > VNet integration > Route All: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94080,6 +94300,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure all traffic is routed through the virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Networking > VNet integration > Route All: Enabled to route all outbound traffic through the VNet.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94154,6 +94375,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure public network access is disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Networking > Public network access: Disabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94228,6 +94450,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure deployment slot is integrated with a virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Add VNet integration.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94302,6 +94525,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure configuration is routed through the virtual network integr' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Route All: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94376,6 +94600,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure all traffic is routed through the virtual network' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Networking > VNet integration > Route All: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94450,6 +94675,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Cosmos DB uses Private Endpoints where possible' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Cosmos DB > [account] > Networking > Private endpoint connections > Add. Create a private endpoint and configure DNS to resolve the Cosmos DB endpoint to the private IP.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94524,6 +94750,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Private Endpoints Are Used for Azure MySQL Databases' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Networking > Private endpoint connections > Add. Configure private DNS zone 'privatelink.mysql.database.azure.com'.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94598,6 +94825,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Private Endpoints Are Used for Azure Database for PostgreS' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Networking > Private endpoint connections > Add. Configure private DNS zone 'privatelink.postgres.database.azure.com'.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94672,6 +94900,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure clusters are created with Private Endpoint Enabled and Pub' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Create or update the cluster with a private endpoint: az aks update --resource-group <RG> --name <CLUSTER> --enable-private-cluster. Public API server access must be disabled in the cluster networking settings.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -94881,6 +95110,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure DDoS Network Protection is enabled on virtual networ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Virtual networks > [VNet] > DDoS protection > Standard: Enable. Or: az network ddos-protection create --resource-group <RG> --name <PLAN>; az network vnet update --resource-group <RG> --name <VNET> --ddos-protection-plan <PLAN>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -101445,6 +101675,7 @@
         "severity": "High",
         "rationale": "VMs without endpoint protection are undefended against malware, ransomware, and fileless attacks."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Extensions + applications. Install Microsoft Antimalware extension. Or: az vm extension set --resource-group <RG> --vm-name <VM> --name IaaSAntimalware --publisher Microsoft.Azure.Security",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -101524,6 +101755,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Microsoft Defender for Cloud is configured to check V' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings. Enable 'System updates should be installed on your machines' recommendation in the Defender for Servers configuration.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -101603,6 +101835,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Microsoft Defender for APIs is set to 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > APIs: On. Save. Defender for APIs protects Azure API Management endpoints.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -101682,6 +101915,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Defender for Servers is set to 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Servers: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -101761,6 +101995,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Vulnerability assessment for machines' component sta' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings > Vulnerability assessment for machines: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -101840,6 +102075,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Endpoint protection' component status is set to 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings > Endpoint protection: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -101919,6 +102155,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Agentless scanning for machines' component status is' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings > Agentless scanning for machines: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -101998,6 +102235,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for Containers Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Containers: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -102077,6 +102315,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for Azure Cosmos DB Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Azure Cosmos DB: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -102156,6 +102395,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for Resource Manager Is Set To 'On' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Resource Manager: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -102235,6 +102475,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for IoT Hub Is Set To 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > IoT: On. Save. Requires Azure IoT Hub.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -102314,6 +102555,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Endpoint Protection for all Virtual Machines is insta' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Extensions + applications. Install Microsoft Antimalware or Defender for Endpoint extension. Or enable Defender for Servers in Defender for Cloud, which provisions endpoint protection automatically.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -102393,6 +102635,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Image Vulnerability Scanning using Microsoft Defender for ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Defender for Cloud > Environment settings > [subscription] > Containers plan > Enable. This enables vulnerability scanning for images in Azure Container Registry via Microsoft Defender for Containers.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -107067,6 +107310,7 @@
         "severity": "Medium",
         "rationale": "Without soft delete, a deleted Key Vault permanently destroys all cryptographic material, potentially causing application outages."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Settings > Properties > Soft-delete: Enabled. Or: az keyvault update --resource-group <RG> --name <VAULT> --enable-soft-delete true. Note: soft-delete cannot be disabled once enabled.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -107108,6 +107352,7 @@
         "severity": "High",
         "rationale": "Without purge protection, an attacker with Key Vault delete permissions can permanently destroy all secrets, keys, and certificates."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Settings > Properties > Purge protection: Enable. Or: az keyvault update --resource-group <RG> --name <VAULT> --enable-purge-protection true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -107150,6 +107395,7 @@
         "severity": "Medium",
         "rationale": "Keys without expiry never rotate, allowing long-term exploitation of any compromise without detection."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Objects > Keys and Secrets. Set expiration dates on all keys and secrets. Or: az keyvault key set-attributes --vault-name <VAULT> --name <KEY> --expires <DATE>",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -107553,6 +107799,7 @@
         "severity": "High",
         "rationale": "Unencrypted HTTP transfers can expose storage access keys and data to network-level interception."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Secure transfer required: Enabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --https-only true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -107597,6 +107844,7 @@
         "severity": "Medium",
         "rationale": "TLS 1.0/1.1 vulnerabilities allow downgrade attacks against storage communications."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Minimum TLS version: TLS 1.2. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --min-tls-version TLS1_2",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -107640,6 +107888,7 @@
         "severity": "High",
         "rationale": "Public blob containers have caused numerous data breaches through accidental exposure of sensitive files."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Allow Blob anonymous access: Disabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --allow-blob-public-access false",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -107682,6 +107931,7 @@
         "severity": "High",
         "rationale": "Unencrypted VM disks expose CUI if the underlying hardware is repurposed or physically accessed."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Disks. Enable Azure Disk Encryption: Extensions > Add > Azure Disk Encryption. Or: az vm encryption enable --resource-group <RG> --name <VM> --disk-encryption-keyvault <VAULT>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -107725,6 +107975,7 @@
         "severity": "High",
         "rationale": "Unencrypted SQL databases expose CUI stored in database files and backups."
       },
+      "remediation": "Azure Portal > SQL databases > [database] > Security > Transparent data encryption. Set to On. Or: az sql db tde set --resource-group <RG> --server <SERVER> --database <DB> --status Enabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -107806,6 +108057,7 @@
         "severity": "High",
         "rationale": "Unencrypted inter-node cluster traffic exposes data in process to passive interception within the virtual network."
       },
+      "remediation": "Azure Portal > Azure Databricks > [workspace] > Encryption. Enable cluster encryption (encryption at rest covers data on cluster nodes). For encryption in transit between workers, configure at cluster level via spark.databricks.encryption.enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -107886,6 +108138,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure Resource Manager Delete locks are applied to Azure S' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Locks > Add lock. Apply CanNotDelete lock. Or: az lock create --name <LOCK> --resource-group <RG> --resource-type Microsoft.Storage/storageAccounts --resource <ACCOUNT> --lock-type CanNotDelete",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -107966,6 +108219,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure Resource Manager ReadOnly locks are considered for A' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Locks > Add lock. Evaluate applying ReadOnly lock to critical storage accounts. Ensure that applications can still function with read-only access before applying.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108046,6 +108300,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Virtual Machines are utilizing Managed Disks' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Disks. If any disk shows 'Unmanaged', the VM must be migrated to managed disks. Or: az vm convert --resource-group <RG> --name <VM>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108126,6 +108381,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that encryption at host is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Configuration > Encryption at host: Enabled. Or: az vm update --resource-group <RG> --name <VM> --set storageProfile.osDisk.encryptionSettings.encryptionAtHost=true. Requires the feature to be registered: az feature register --namespace Microsoft.Compute --name EncryptionAtHost",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108206,6 +108462,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Data encryption' is set to 'On' on a SQL Database' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > SQL databases > [database] > Security > Transparent data encryption: On. Or: az sql db tde set --resource-group <RG> --server <SERVER> --database <DB> --status Enabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108286,6 +108543,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Consider external secret storage' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Integrate the cluster with Azure Key Vault using the Secrets Store CSI driver: az aks enable-addons --addons azure-keyvault-secrets-provider --resource-group <RG> --name <CLUSTER>. Reference Key Vault secrets in pod specs via SecretProviderClass.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108366,6 +108624,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Kubernetes Secrets are encrypted' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Enable encryption at rest for Kubernetes Secrets using an Azure Key Vault key: Azure Portal > Kubernetes services > [cluster] > Settings > Encryption (preview). Or use a KMS plugin via az aks create/update with --enable-azure-keyvault-kms.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108446,6 +108705,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure the SSL policy's 'Min protocol version' is set to 'TLSv1_2' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Application gateways > [gateway] > Settings > SSL policy. Set 'Policy type' to Custom and 'Min protocol version' to TLS 1.2. Remove TLS 1.0 and 1.1 cipher suites.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108527,6 +108787,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Microsoft Defender External Attack Surface Monitoring' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > External Attack Surface Management: Enable (requires EASM workspace).",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108607,6 +108868,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure an Azure Bastion Host Exists' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Create a resource > Azure Bastion. Deploy Azure Bastion in a subnet named 'AzureBastionSubnet' (/27 or larger) within the VNet. Once deployed, use Bastion for all RDP/SSH to VMs instead of public IPs.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108687,6 +108949,7 @@
         "severity": "High",
         "rationale": "SMB versions below 3.1.1 lack mandatory encryption and integrity validation, exposing file shares to eavesdropping and MITM attacks."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Data storage > File shares > [share] > Properties > Protocol settings > SMB protocol version. Set to SMB 3.1.1 (disable 2.1 and 3.0). Or configure via az storage share-rm.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108767,6 +109030,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'SMB channel encryption' is set to 'AES-256-GCM' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Data storage > File shares > [share] > Properties > Protocol settings > SMB channel encryption. Set to AES-256-GCM. Or configure via az storage share-rm protocol.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108847,6 +109111,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Secure transfer required' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Secure transfer required: Enabled. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --https-only true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -108927,6 +109192,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure the 'Minimum TLS version' for storage accounts is set to '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Minimum TLS version: Version 1.2. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --min-tls-version TLS1_2",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109007,6 +109273,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure App Service Environment has TLS 1.0 and 1.1 disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Service Environments > [ASE] > Settings > Configuration > TLS 1.0/1.1: Disabled. Set minimum TLS version to 1.2.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109087,6 +109354,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure App Service Environment has TLS cipher suite ordering conf' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Configure TLS cipher suite ordering via ASE PowerShell or CLI. The ordering must be set per Microsoft's recommended cipher suite list. See: az appservice ase update --resource-group <RG> --name <ASE> with custom cipher ordering.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109167,6 +109435,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'HTTPS Only' is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > HTTPS Only: On. Or: az webapp update --resource-group <RG> --name <APP> --https-only true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109247,6 +109516,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Minimum Inbound TLS Version' is set to '1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Minimum Inbound TLS Version: 1.2. Or: az webapp config set --resource-group <RG> --name <APP> --min-tls-version 1.2",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109327,6 +109597,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure end-to-end TLS encryption is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > End-to-end TLS encryption: Enabled. This requires the App Service plan to support this feature (Standard or higher).",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109407,6 +109678,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'HTTPS Only' is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > HTTPS Only: On.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109487,6 +109759,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Minimum Inbound TLS Version' is set to '1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Minimum Inbound TLS Version: 1.2.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109567,6 +109840,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure end-to-end TLS encryption is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > End-to-end TLS encryption: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109647,6 +109921,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'HTTPS Only' is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > HTTPS Only: On. Or: az functionapp update --resource-group <RG> --name <APP> --set httpsOnly=true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109727,6 +110002,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Minimum Inbound TLS Version' is set to '1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Minimum Inbound TLS Version: 1.2.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109807,6 +110083,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure end-to-end TLS encryption is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > End-to-end TLS encryption: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109887,6 +110164,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'HTTPS Only' is set to 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > HTTPS Only: On.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -109967,6 +110245,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Minimum Inbound TLS Version' is set to '1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Minimum Inbound TLS Version: 1.2.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -110047,6 +110326,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure end-to-end TLS encryption is enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > End-to-end TLS encryption: Enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -110127,6 +110407,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure server parameter 'tls_version' is set to 'TLSv1.2' (or hig' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'tls_version'. Set to TLSv1.2 (remove TLSv1 and TLSv1.1). Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -110207,6 +110488,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure server parameter 'ssl_min_protocol_version' is set to 'TLS' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'ssl_min_protocol_version'. Set to TLSv1.2. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -110287,6 +110569,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Minimum TLS Version' is set to 'TLS 1.2' or higher' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Security > Networking > Minimum TLS version: 1.2. Or: az sql server update --resource-group <RG> --name <SERVER> --minimal-tls-version 1.2",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -110367,6 +110650,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Encrypt traffic to HTTPS load balancers with TLS certificates' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Configure TLS certificates on HTTPS load balancers. Use cert-manager or Azure Application Gateway Ingress Controller (AGIC) with a certificate from Azure Key Vault. Ensure all ingress resources specify TLS secretName.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -113759,6 +114043,7 @@
         "severity": "High",
         "rationale": "Without customer-managed keys, Microsoft-managed keys control data access; a compromised cloud admin account can decrypt data without tenant knowledge."
       },
+      "remediation": "Azure Portal > Azure Databricks > [workspace] > Encryption. Enable customer-managed keys (CMK) for the managed storage account. CMK must be configured in the Azure Key Vault and linked at workspace creation or updated via az databricks workspace update.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -113822,6 +114107,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure the storage account containing the container with activity' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [activity log storage account] > Settings > Encryption. Set 'Encryption type' to Customer-managed keys and link to an Azure Key Vault key.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -113885,6 +114171,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that logging for Azure Key Vault is 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Monitoring > Diagnostic settings > Add diagnostic setting. Enable AuditEvent log category and send to Log Analytics Workspace. Retention: 90 days minimum.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -113948,6 +114235,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure That Microsoft Defender for Key Vault Is Set To 'On'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans > Key Vault: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114011,6 +114299,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure automatic key rotation is enabled within Azure Key Vault' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Objects > Keys > [key] > Rotation policy. Set a rotation period (e.g., 90 days) and enable automatic rotation. Or: az keyvault key rotation-policy update --vault-name <VAULT> --name <KEY> --value @policy.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114074,6 +114363,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Azure Key Vault Managed HSM is used when required' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Settings > Managed HSM. Assess whether cryptographic operations require FIPS 140-2 Level 3 compliance. If required, create a Managed HSM and migrate key material.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114137,6 +114427,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure certificate 'Validity Period (in months)' is less than or ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Key vaults > [vault] > Certificates > [certificate] > Current version. Review 'Valid from' and 'Expires' to ensure validity period is 12 months or less. Create new certificates with a shorter validity period as existing ones expire.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114200,6 +114491,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'OS and Data' disks are encrypted with Customer Manag' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Disks > [disk] > Encryption. Set encryption type to Customer-managed keys. Link to an Azure Key Vault key. Or via disk update: az disk update --resource-group <RG> --name <DISK> --encryption-type EncryptionAtRestWithCustomerKey --disk-encryption-set <DES-ID>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114263,6 +114555,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Unattached disks' are encrypted with 'Customer Manag' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Disks (standalone, unattached). Filter by 'Unattached'. For each disk: Encryption > Encryption type: Customer-managed keys. Or: az disk update --resource-group <RG> --name <DISK> --encryption-type EncryptionAtRestWithCustomerKey",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114326,6 +114619,7 @@
         "severity": "High",
         "rationale": "Failure to configure '[Legacy] Ensure that VHDs are Encrypted' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Virtual machines > [VM] > Settings > Disks. Ensure all disks use managed disks (not VHDs in storage accounts). Migrate from VHDs using: az vm convert --resource-group <RG> --name <VM>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114389,6 +114683,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure critical data is encrypted with customer-managed keys (CMK' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Cosmos DB > [account] > Settings > Encryption. Select 'Customer-managed key' and provide the Azure Key Vault key URI. CMK must be configured at account creation or via update before data is written.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114452,6 +114747,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure Database for MySQL uses Customer Managed Keys for En' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL > [server] > Settings > Encryption. Set 'Data encryption' to Customer-managed key. Link to an Azure Key Vault key with appropriate permissions.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114515,6 +114811,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure Database for PostgreSQL uses Customer Managed Keys f' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Encryption. Set 'Data encryption' to Customer-managed key. Link to an Azure Key Vault key.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114578,6 +114875,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure SQL server's Transparent Data Encryption (TDE) protector i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Security > Transparent data encryption > TDE protector. Select 'Customer-managed key'. Choose or import a key from Azure Key Vault. Or: az sql server tde-key set --resource-group <RG> --server <SERVER> --server-key-type AzureKeyVault --kid <KEY-URL>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114641,6 +114939,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Minimize access to secrets' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Review RBAC Role/ClusterRole definitions granting 'get','list','watch' on 'secrets'. Use: kubectl get roles,clusterroles -A -o yaml | grep -A5 'secrets'. Replace with least-privilege roles scoped to specific namespaces.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114877,6 +115176,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure soft delete for Azure File Shares is Enabled' leaves the environment exposed, reducing the ability to recover from security incidents."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Data storage > File shares > [share] > Properties. Enable Soft delete with a retention period (e.g., 14 days). Or: az storage account file-service-properties update --account-name <ACCOUNT> --resource-group <RG> --enable-delete-retention true --delete-retention-days 14",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114935,6 +115235,7 @@
         "severity": "High",
         "rationale": "Without soft delete, accidentally or maliciously deleted blobs/containers are unrecoverable, causing permanent data loss."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Data storage > Containers > [container] > Properties > Soft delete: Enabled with retention period >= 7 days. Or: az storage account blob-service-properties update --account-name <ACCOUNT> --enable-delete-retention true --delete-retention-days 7",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -114993,6 +115294,7 @@
         "severity": "High",
         "rationale": "Without soft delete, accidentally or maliciously deleted blobs/containers are unrecoverable, causing permanent data loss."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Data management > Data protection > Container soft delete: Enabled with retention >= 7 days. Or: az storage account blob-service-properties update --account-name <ACCOUNT> --enable-container-delete-retention true --container-delete-retention-days 7",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -115051,6 +115353,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Versioning' is set to 'Enabled' on Azure Blob Storage sto' leaves the environment exposed, reducing the ability to recover from security incidents."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Data management > Data protection > Blob versioning: Enabled. Or: az storage account blob-service-properties update --account-name <ACCOUNT> --enable-versioning true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -115109,6 +115412,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Redundancy is set to 'geo-redundant storage (GRS)' on crit' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Settings > Configuration > Replication. Set to Geo-redundant storage (GRS) or Read-access geo-redundant storage (RA-GRS) for critical accounts. Or: az storage account update --resource-group <RG> --name <ACCOUNT> --sku Standard_GRS",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -116299,6 +116603,7 @@
         "severity": "High",
         "rationale": "Without paid Defender plans, threat detection and vulnerability scanning are absent for critical workloads."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Defender plans. Enable required Defender plans (Servers, Storage, SQL, etc.).",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -116341,6 +116646,7 @@
         "severity": "High",
         "rationale": "A low secure score indicates widespread unresolved security findings that increase risk of compromise."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Overview > Secure score. Review failing recommendations and remediate to raise the secure score above the organizational threshold.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -116421,6 +116727,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure App Service Environment has internal encryption enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Service Environments > [ASE] > Settings > Configuration > Internal encryption: Enabled. This encrypts traffic between the ASE front end and workers.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -116501,6 +116808,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'HTTP2' is set to 'Enabled' on Azure Application Gateway' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Application gateways > [gateway] > Settings > Configuration. Set 'HTTP2': Enabled.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -116581,6 +116889,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure App Service Environment is deployed with an internal load ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "App Service Environment v3 must be deployed with an internal load balancer at creation time. To migrate: create a new internal ASE v3 and redeploy applications. Azure Portal > App Service Environments > Create > Virtual IP: Internal.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -116661,6 +116970,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'FTP State' is set to 'FTPS only' or 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > FTP state: Disabled or FTPS only. Or: az webapp config set --resource-group <RG> --name <APP> --ftps-state Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -116741,6 +117051,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'HTTP version' is set to '2.0' (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > HTTP version: 2.0. Or: az webapp config set --resource-group <RG> --name <APP> --http20-enabled true",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -116820,6 +117131,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'FTP state' is set to 'FTPS only' or 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > FTP state: Disabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -116900,6 +117212,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'HTTP version' is set to '2.0' (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > HTTP version: 2.0.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -116979,6 +117292,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'FTP state' is set to 'FTPS only' or 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > FTP state: Disabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -117059,6 +117373,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'HTTP version' is set to '2.0' (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > HTTP version: 2.0.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -117138,6 +117453,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'FTP state' is set to 'FTPS only' or 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > FTP state: Disabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -117218,6 +117534,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'HTTP version' is set to '2.0' (if in use)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > HTTP version: 2.0.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -117297,6 +117614,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure server parameter 'require_secure_transport' is set to 'ON'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Server parameters > Filter 'require_secure_transport'. Set value to ON. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -117377,6 +117695,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure server parameter 'require_secure_transport' is set to 'ON'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'require_secure_transport'. Set to ON. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118175,6 +118494,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Storage Account access keys are periodically regenera' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Storage accounts > [account] > Security + networking > Access keys > Rotate key1 and key2. Ensure consuming applications are updated before rotating. Automate with Azure Key Vault rotation policy.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118238,6 +118558,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the --rotate-certificates argument is not set to fals' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply a custom kubelet configuration with rotateCertificates: true. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118301,6 +118622,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the RotateKubeletServerCertificate argument is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply a custom kubelet configuration with RotateKubeletServerCertificate: true. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118364,6 +118686,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Prefer using secrets as files over secrets as environment variabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Update application workload manifests to mount secrets as files (volumeMounts) rather than injecting them as environment variables (env.valueFrom.secretKeyRef). This prevents secrets from appearing in process listings.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118484,6 +118807,7 @@
         "severity": "Medium",
         "rationale": "Without Unity Catalog, data access controls and audit trails are per-workspace rather than centralised, increasing risk of unauthorised data access across workspaces."
       },
+      "remediation": "Azure Portal > Azure Databricks > [workspace] > Settings > Unity Catalog. Create or attach a Unity Catalog metastore via Azure Databricks account console. Unity Catalog must be enabled for centralized data governance.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -118554,6 +118878,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure passwordless authentication methods are considered' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Security > Authentication methods. Enable Windows Hello for Business, FIDO2 security keys, or Microsoft Authenticator passwordless sign-in. Configure Conditional Access to require passwordless for target users.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118625,6 +118950,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Authentication type' is set to 'Azure Active Directory' o' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Virtual network gateways > [gateway] > Settings > Point-to-site configuration > Tunnel type. Set to IKEv2 or OpenVPN. Authentication type: Microsoft Entra ID. Remove certificate-based authentication if not required.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118697,6 +119023,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure incoming client certificates are enabled and required (if ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Incoming client certificates: Required. Or: az webapp update --resource-group <RG> --name <APP> --set clientCertEnabled=true clientCertMode=Required",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118768,6 +119095,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure incoming client certificates are enabled and required (if ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Incoming client certificates: Required.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118839,6 +119167,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure incoming client certificates are enabled and required (if ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Incoming client certificates: Required.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118910,6 +119239,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure incoming client certificates are enabled and required (if ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Incoming client certificates: Required.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118981,6 +119311,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Enable Data Access Authentication Mode' is 'Checked'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Disks > [disk] > Settings > Networking > Enable data access authentication mode: Checked. This requires SAS token or Entra authentication to export or import disk content.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -119052,6 +119383,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure Database for MySQL uses only Microsoft Entra Authent' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for MySQL flexible server > [server] > Settings > Authentication. Set 'Authentication method' to Microsoft Entra authentication only. Add an Entra user or group as admin.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -119123,6 +119455,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure Database for PostgreSQL uses only Microsoft Entra Au' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Authentication. Set 'Authentication method' to Microsoft Entra authentication only. Add an Entra admin.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -119194,6 +119527,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Microsoft Entra authentication is Configured for SQL ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Settings > Microsoft Entra ID > Set admin. Select an Entra user or group as the SQL Server Microsoft Entra administrator. Or: az sql server ad-admin create --resource-group <RG> --server <SERVER> --display-name <ADMIN> --object-id <OID>",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -119265,6 +119599,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the --anonymous-auth argument is set to false' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply a custom kubelet configuration disabling anonymous auth. Create a kubelet config file with anonymousAuth: false and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -119336,6 +119671,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the --client-ca-file argument is set as appropriate' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "AKS manages TLS certificates for the API server automatically. Ensure the cluster uses the AKS-managed CA by not overriding with --api-server-authorized-ip-ranges or custom CA unless required. Verify with: az aks show --resource-group <RG> --name <CLUSTER> --query 'networkProfile'",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -119994,6 +120330,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Azure Key Vaults are Used to Store Secrets' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Store application secrets in Azure Key Vault. Azure Portal > App Services > [app] > Settings > Configuration > Application settings. Replace plaintext secret values with Key Vault references: @Microsoft.KeyVault(SecretUri=https://<VAULT>.vault.azure.net/secrets/<SECRET>/)",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120069,6 +120406,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Basic Authentication Publishing Credentials' are 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Settings > Configuration > General settings > Basic Auth Publishing Credentials: Off. Or: az resource update --resource-type Microsoft.Web/sites/basicPublishingCredentialsPolicies --name scm --set properties.allow=false",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120144,6 +120482,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Basic Authentication Publishing Credentials' are 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > App Services > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Basic Auth Publishing Credentials: Off.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120219,6 +120558,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Basic Authentication Publishing Credentials' are 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Settings > Configuration > General settings > Basic Auth Publishing Credentials: Off.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120294,6 +120634,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Basic Authentication Publishing Credentials' are 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Function App > [app] > Deployment slots > [slot] > Settings > Configuration > General settings > Basic Auth Publishing Credentials: Off.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120749,6 +121090,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure server parameter 'connection_throttle.enable' is set to 'O' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'connection_throttle.enable'. Set to ON. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120964,6 +121306,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the --streaming-connection-idle-timeout argument is n' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply a custom kubelet configuration setting streamingConnectionIdleTimeout to a non-zero value (e.g., 4h). Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -122074,6 +122417,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Guest invite restrictions' is set to 'Only users ass' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > External identities > External collaboration settings > Guest invite restrictions. Select 'Only users assigned to specific admin roles can invite guest users' or 'No one in the organization can invite guest users'. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -122158,6 +122502,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure there are between 2 and 3 subscription owners' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Azure Portal > Subscriptions > [subscription] > Access control (IAM) > Role assignments. Filter by Owner role. Ensure 2-3 users or groups are assigned. Add or remove as needed.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -122242,6 +122587,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Azure admin accounts are not used for daily operation' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Microsoft Entra admin center > Roles and administrators > Global administrator. Ensure admin accounts are separate from daily-use accounts. Admin accounts should not have assigned licenses or email access for non-administrative tasks.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -122579,6 +122925,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure Diagnostic Setting captures appropriate categories' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Monitor > Activity log > Diagnostic settings > [setting]. Verify that Administrative, Security, Alert, and Policy log categories are all enabled.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -122658,6 +123005,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that virtual network flow logs are captured and sent to Lo' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Virtual networks > [VNet] > Monitoring > Flow logs. Enable VNet flow logs and send to Log Analytics Workspace. Set retention to 90 days minimum.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122736,6 +123084,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that Intune logs are captured and sent to Log Analytics' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Intune > Reports > Diagnostic settings > Add diagnostic setting. Enable IntuneAuditLogs and IntuneOperationalLogs and route to Log Analytics Workspace.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122814,6 +123163,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure Application Insights are Configured' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > [Resource Group or Application]. Create an Application Insights resource: Azure Portal > Application Insights > Create. Instrument the application with the Application Insights SDK or enable auto-instrumentation for supported runtimes.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122892,6 +123242,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that Network Watcher is 'Enabled' for Azure Regions that a' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Network Watcher > Overview > Region list. Enable Network Watcher for each Azure region in use. Or: az network watcher configure --resource-group NetworkWatcherRG --locations <REGION> --enabled true",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -122972,6 +123323,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that virtual network flow log retention days is set to gre' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Virtual networks > [VNet] > Monitoring > Flow logs. Set retention period to 90 days or greater. Or: az network watcher flow-log update --resource-group <RG> --name <LOG> --retention 90",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -123051,6 +123403,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure That 'All users with the following roles' is set to 'Owner' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Email notifications. Set 'All users with the following roles' to include Owner. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -123129,6 +123482,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Additional email addresses' is Configured with a Security' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Email notifications > Additional email addresses. Add at least one security contact email address. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -123207,6 +123561,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure that 'Notify about alerts with the following severity (or ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Email notifications > Notify about alerts with the following severity: High or above. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -123285,6 +123640,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Notify about attack paths with the following risk le' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Email notifications > Notify about attack paths: High or above. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -123364,6 +123720,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'File Integrity Monitoring' component status is set t' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Microsoft Defender for Cloud > Environment settings > [subscription] > Servers plan > Settings > File Integrity Monitoring: On. Save.",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -123443,6 +123800,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure server parameter 'logfiles.retention_days' is greater than' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > Azure Database for PostgreSQL flexible server > [server] > Settings > Server parameters > Filter 'logfiles.retention_days'. Set to a value greater than 3. Save.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -123521,6 +123879,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that 'Auditing' is set to 'On'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Azure Portal > SQL servers > [server] > Security > Auditing > Enable Azure SQL Auditing: On. Or: az sql server audit-policy update --resource-group <RG> --name <SERVER> --state Enabled --blob-storage-target-state Enabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -123600,6 +123959,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure that the --eventRecordQPS argument is set to 0 or a level ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Apply a custom kubelet configuration setting eventRecordQPS to 0 or an appropriate rate limit. Create a kubelet config file and apply via: az aks nodepool update --resource-group <RG> --cluster-name <CLUSTER> --name <POOL> --kubelet-config kubelet.json",
       "effort": {
         "complexity": 3,
         "isPhased": false,

--- a/data/registry.json
+++ b/data/registry.json
@@ -7057,6 +7057,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enforce password history' is set to '24 or more password(' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Enforce password history: 24 or more passwords. Or: secpol.msc > Account Policies > Password Policy > Enforce password history",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7132,6 +7133,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Maximum password age' is set to '365 or fewer days, but n' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Maximum password age: 365 or fewer days (but not 0). Or: secpol.msc > Account Policies > Password Policy > Maximum password age",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7207,6 +7209,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Minimum password age' is set to '1 or more day(s)'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Minimum password age: 1 or more day. Or: secpol.msc > Account Policies > Password Policy > Minimum password age",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7282,6 +7285,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Minimum password length' is set to '14 or more character(' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Minimum password length: 14 or more characters. Or: secpol.msc > Account Policies > Password Policy > Minimum password length",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7357,6 +7361,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Password must meet complexity requirements' is set to 'En' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Password must meet complexity requirements: Enabled. Or: secpol.msc > Account Policies > Password Policy > Password must meet complexity requirements",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7432,6 +7437,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Relax minimum password length limits' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Relax minimum password length limits: Enabled. Or: secpol.msc > Account Policies > Password Policy > Relax minimum password length limits",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7507,6 +7513,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Store passwords using reversible encryption' is set to 'D' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Password Policy > Store passwords using reversible encryption: Disabled. Or: secpol.msc > Account Policies > Password Policy > Store passwords using reversible encryption",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7582,6 +7589,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Account lockout duration' is set to '15 or more minute(s)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy > Account lockout duration: 15 or more minutes. Or: secpol.msc > Account Policies > Account Lockout Policy > Account lockout duration",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7657,6 +7665,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Account lockout threshold' is set to '5 or fewer invalid ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy > Account lockout threshold: 5 or fewer invalid logon attempts (not 0). Or: secpol.msc > Account Policies > Account Lockout Policy > Account lockout threshold",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7732,6 +7741,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Reset account lockout counter after' is set to '15 or mor' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy > Reset account lockout counter after: 15 or more minutes. Or: secpol.msc > Account Policies > Account Lockout Policy > Reset account lockout counter after",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7807,6 +7817,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Accounts: Guest account status' is set to 'Disabled' (MS ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Accounts: Guest account status: Disabled (MS only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7884,6 +7895,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Domain member: Maximum machine account password age' is s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Maximum machine account password age: 30 or fewer days (not 0). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -7961,6 +7973,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Audit Other Account Management Events' is set to include ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Other Account Management Events: Success (DC only). Or: auditpol.exe /set /subcategory:\"Other Account Management Events\" /success:enable",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -8038,6 +8051,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Password Settings: Password Complexity' is set to 'Enable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Password Settings: Password Complexity: Enabled: Large letters + small letters + numbers + special characters (or Passphrase)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -8114,6 +8128,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Password Settings: Password Length' is set to 'Enabled: 1' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Password Settings: Password Length: Enabled: 15 or more",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -8342,6 +8357,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow Administrator account lockout' is set to 'Enabled' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Account Policies\\Account Lockout Policy > Allow Administrator account lockout: Enabled (MS only). Or: secpol.msc > Account Policies > Account Lockout Policy > Allow Administrator account lockout",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -8417,6 +8433,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Audit Account Lockout' is set to include 'Failure'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Account Lockout: Failure. Or: auditpol.exe /set /subcategory:\"Account Lockout\" /failure:enable",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -14873,6 +14890,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Create a token object' is set to 'No One'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create a token object: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment > Create a token object",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -14938,6 +14956,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Impersonate a client after authentication' is set to 'Adm' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Impersonate a client after authentication: Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE, RESTRICTED SERVICES\\PrintSpoolerService (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -15003,6 +15022,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Impersonate a client after authentication' is set to 'Adm' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Impersonate a client after authentication: Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE, RESTRICTED SERVICES\\PrintSpoolerService (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -15068,6 +15088,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Replace a process level token' is set to 'LOCAL SERVICE, ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Replace a process level token: LOCAL SERVICE, NETWORK SERVICE. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -15133,6 +15154,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Interactive logon: Machine inactivity limit' is set to '9' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Machine inactivity limit: 900 or fewer seconds (not 0). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -15197,6 +15219,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Microsoft network server: Amount of idle time required be' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network server: Amount of idle time required before suspending session: 15 or fewer minutes. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -15261,6 +15284,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Prevent enabling lock screen camera' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Control Panel\\Personalization > Prevent enabling lock screen camera: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -15324,6 +15348,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Prevent enabling lock screen slide show' is set to 'Enabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Control Panel\\Personalization > Prevent enabling lock screen slide show: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -15387,6 +15412,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Apply UAC restrictions to local accounts on network logon' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Apply UAC restrictions to local accounts on network logons via registry: HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System > LocalAccountTokenFilterPolicy: 0 (MS only). Or deploy MSS ADMX templates and enable the setting in GPMC.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -15451,6 +15477,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off app notifications on the lock screen' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Turn off app notifications on the lock screen: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -15514,6 +15541,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off toast notifications on the lock screen' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Push Notifications > Turn off toast notifications on the lock screen: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -23873,6 +23901,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Access this computer from the network' is set to 'Adminis' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Access this computer from the network: Administrators, Authenticated Users, ENTERPRISE DOMAIN CONTROLLERS (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -23959,6 +23988,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Access this computer from the network'  is set to 'Admini' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Access this computer from the network: Administrators, Authenticated Users (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24045,6 +24075,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Act as part of the operating system' is set to 'No One'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Act as part of the operating system: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment > Act as part of the operating system",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24131,6 +24162,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Add workstations to domain' is set to 'Administ' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Add workstations to domain: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment > Add workstations to domain",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24217,6 +24249,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Adjust memory quotas for a process' is set to 'Administra' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Adjust memory quotas for a process: Administrators, LOCAL SERVICE, NETWORK SERVICE. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24303,6 +24336,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Allow log on through Remote Desktop Services' i' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Allow log on through Remote Desktop Services: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24389,6 +24423,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Allow log on through Remote Desktop Services' i' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Allow log on through Remote Desktop Services: Administrators, Remote Desktop Users (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24475,6 +24510,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Change the system time' is set to 'Administrato' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Change the system time: Administrators, LOCAL SERVICE. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24561,6 +24597,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Create a pagefile' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create a pagefile: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment > Create a pagefile",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24647,6 +24684,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Create global objects' is set to 'Administrators, LOCAL S' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create global objects: Administrators, LOCAL SERVICE, NETWORK SERVICE, SERVICE. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24733,6 +24771,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Create permanent shared objects' is set to 'No One'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create permanent shared objects: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24819,6 +24858,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Create symbolic links' is set to 'Administrators' (DC onl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create symbolic links: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24905,6 +24945,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Create symbolic links' is set to 'Administrators, NT VIRT' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Create symbolic links: Administrators, NT VIRTUAL MACHINE\\Virtual Machines (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -24991,6 +25032,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Debug programs' is set to 'Administrators'' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Debug programs: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment > Debug programs",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25077,6 +25119,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Deny access to this computer from the network' to include' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny access to this computer from the network: include Guests (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25163,6 +25206,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Deny access to this computer from the network' to include' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny access to this computer from the network: Guests, Local account and member of Administrators group (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25249,6 +25293,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Deny log on as a batch job' to include 'Guests'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on as a batch job: include Guests. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25335,6 +25380,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Deny log on as a service' to include 'Guests'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on as a service: include Guests. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25421,6 +25467,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Deny log on locally' to include 'Guests'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on locally: include Guests. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25507,6 +25554,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Deny log on through Remote Desktop Services' to include '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on through Remote Desktop Services: include Guests (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25593,6 +25641,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Deny log on through Remote Desktop Services' is set to 'G' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Deny log on through Remote Desktop Services: Guests, Local account (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25679,6 +25728,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Force shutdown from a remote system' is set to ' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Force shutdown from a remote system: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25765,6 +25815,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Increase scheduling priority' is set to 'Administrators, ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Increase scheduling priority: Administrators, Window Manager\\Window Manager Group. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25851,6 +25902,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Load and unload device drivers' is set to 'Administrators' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Load and unload device drivers: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -25937,6 +25989,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Lock pages in memory' is set to 'No One'' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Lock pages in memory: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26023,6 +26076,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Log on as a batch job' is set to 'Administrators' (DC Onl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Log on as a batch job: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26109,6 +26163,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Modify an object label' is set to 'No One'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Modify an object label: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26195,6 +26250,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Modify firmware environment values' is set to 'Administra' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Modify firmware environment values: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26281,6 +26337,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Perform volume maintenance tasks' is set to 'Administrato' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Perform volume maintenance tasks: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26367,6 +26424,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Profile single process' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Profile single process: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26453,6 +26511,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Profile system performance' is set to 'Administrators, NT' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Profile system performance: Administrators, NT SERVICE\\WdiServiceHost. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26539,6 +26598,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Shut down the system' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Shut down the system: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26625,6 +26685,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Synchronize directory service data' is set to 'No One' (D' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Synchronize directory service data: (blank — No One) (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26711,6 +26772,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Take ownership of files or other objects' is set to 'Admi' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Take ownership of files or other objects: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26797,6 +26859,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Configure 'Accounts: Rename guest account'' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Accounts: Rename guest account: set to a non-default name. Or: secpol.msc > Local Policies > Security Options > Accounts: Rename guest account",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26883,6 +26946,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Domain member: Disable machine account password' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Disable machine account password changes: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -26969,6 +27033,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Interactive logon: Do not require CTRL+ALT+DEL'' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Do not require CTRL+ALT+DEL: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27055,6 +27120,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Microsoft network client: Send unencrypted pass' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network client: Send unencrypted password to third-party SMB servers: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27141,6 +27207,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Network access: Allow anonymous SID/Name transl' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Allow anonymous SID/Name translation: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27227,6 +27294,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Do not allow anonymous enumeration of SAM' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Do not allow anonymous enumeration of SAM accounts: Enabled (MS only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27313,6 +27381,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Do not allow anonymous enumeration of SAM' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Do not allow anonymous enumeration of SAM accounts and shares: Enabled (MS only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27399,6 +27468,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Do not allow storage of passwords and cre' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Do not allow storage of passwords and credentials for network authentication: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27485,6 +27555,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Network access: Let Everyone permissions apply ' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Let Everyone permissions apply to anonymous users: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27571,6 +27642,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Named Pipes that can be accessed anonymou' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Named Pipes that can be accessed anonymously: (configured per DC requirements). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27657,6 +27729,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Named Pipes that can be accessed anonymou' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Named Pipes that can be accessed anonymously: (blank — empty list) (MS only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27743,6 +27816,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Remotely accessible registry paths' is co' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Remotely accessible registry paths: configure per CIS benchmark. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27829,6 +27903,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Remotely accessible registry paths and su' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Remotely accessible registry paths and sub-paths: configure per CIS benchmark. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -27915,6 +27990,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Restrict anonymous access to Named Pipes ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Restrict anonymous access to Named Pipes and Shares: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28001,6 +28077,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Shares that can be accessed anonymously' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Shares that can be accessed anonymously: (blank — None). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28087,6 +28164,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Network access: Sharing and security model for ' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Sharing and security model for local accounts: Classic - local users authenticate as themselves. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28173,6 +28251,7 @@
         "severity": "High",
         "rationale": "Overly permissive user rights assignment for 'Ensure 'Network security: Allow LocalSystem NULL sessio' allows non-administrative principals to perform privileged OS operations."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Allow LocalSystem NULL session fallback: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28259,6 +28338,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'User Account Control: Admin Approval Mode for the Built-i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Admin Approval Mode for the Built-in Administrator account: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28345,6 +28425,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'User Account Control: Behavior of the elevation prompt fo' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Behavior of the elevation prompt for administrators in Admin Approval Mode: Prompt for consent on the secure desktop (or higher). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28431,6 +28512,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'User Account Control: Behavior of the elevation prompt fo' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Behavior of the elevation prompt for standard users: Automatically deny elevation requests. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28517,6 +28599,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'User Account Control: Detect application installations an' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Detect application installations and prompt for elevation: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28603,6 +28686,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'User Account Control: Only elevate UIAccess applications ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Only elevate UIAccess applications that are installed in secure locations: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28689,6 +28773,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'User Account Control: Run all administrators in Admin App' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Run all administrators in Admin Approval Mode: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28775,6 +28860,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'User Account Control: Switch to the secure desktop when p' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Switch to the secure desktop when prompting for elevation: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28861,6 +28947,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'User Account Control: Virtualize file and registry write ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > User Account Control: Virtualize file and registry write failures to per-user locations: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -28947,6 +29034,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Audit Application Group Management' is set to 'Success an' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Application Group Management: Success and Failure. Or: auditpol.exe /set /subcategory:\"Application Group Management\" /success:enable /failure:enable",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -29033,6 +29121,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow Microsoft accounts to be optional' is set to 'Enabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft accounts > Allow Microsoft accounts to be optional: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -29118,6 +29207,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Block all consumer Microsoft account user authentication'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft accounts > Block all consumer Microsoft account user authentication: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -44529,6 +44619,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Devices: Prevent users from installing printer drivers' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Devices: Prevent users from installing printer drivers: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -44620,6 +44711,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Domain controller: Allow server operators to schedule tas' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: Allow server operators to schedule tasks: Disabled (DC only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -44710,6 +44802,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Domain controller: Allow vulnerable Netlogon secure chann' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: Allow vulnerable Netlogon secure channel connections: Not Configured (DC only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -44800,6 +44893,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Configure 'Interactive logon: Message text for users attempting t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Message text for users attempting to log on: configure with organizational legal notice text. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -44890,6 +44984,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Configure 'Interactive logon: Message title for users attempting ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Message title for users attempting to log on: configure with organizational title text. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -44980,6 +45075,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Network Security: Allow PKU2U authentication requests to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network Security: Allow PKU2U authentication requests to this computer to use online identities: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -45070,6 +45166,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'System objects: Require case insensitivity for non-Window' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > System objects: Require case insensitivity for non-Windows subsystems: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -45160,6 +45257,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'System objects: Strengthen default permissions of interna' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > System objects: Strengthen default permissions of internal system objects (e.g. Symbolic Links): Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -45250,6 +45348,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Print Spooler (Spooler)' is set to 'Disabled' (DC only)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "services.msc > Print Spooler > Properties > Startup type: Disabled > Stop service. Or via Group Policy: GPMC > Computer Configuration\\Windows Settings\\Security Settings\\System Services > Print Spooler: Disabled (DC only). Or: Stop-Service -Name Spooler -Force; Set-Service -Name Spooler -StartupType Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -45339,6 +45438,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Print Spooler (Spooler)' is set to 'Disabled' (MS only)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "services.msc > Print Spooler > Properties > Startup type: Disabled > Stop service. Or via Group Policy: GPMC > Computer Configuration\\Windows Settings\\Security Settings\\System Services > Print Spooler: Disabled (MS only). Or: Stop-Service -Name Spooler -Force; Set-Service -Name Spooler -StartupType Disabled",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -45428,6 +45528,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Online Tips' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Control Panel\\Regional and Language Options > Allow Online Tips: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -45517,6 +45618,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow users to enable online speech recognition services'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Speech > Allow users to enable online speech recognition services: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -45606,6 +45708,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure SMB v1 client driver' is set to 'Enabled: Disab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Configure SMB v1 client driver: Enabled: Disable driver. Or: sc.exe config mrxsmb10 start= disabled && sc.exe stop mrxsmb10",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -45696,6 +45799,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure SMB v1 server' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Disable SMB v1 server: Set-SmbServerConfiguration -EnableSMB1Protocol $false -Force. Or: GPMC > Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Configure SMB v1 server: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -45786,6 +45890,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable Structured Exception Handling Overwrite Protection' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Enable SEHOP via registry: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\kernel > DisableExceptionChainValidation: 0. Or deploy MSS ADMX and enable 'MSS: Enable Structured Exception Handling Overwrite Protection (SEHOP)': Enabled in GPMC.",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -45876,6 +45981,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'NetBT NodeType configuration' is set to 'Enabled: P-node ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Configure NetBT NodeType configuration: Enabled: P-node. Or via registry: HKLM\\SYSTEM\\CurrentControlSet\\Services\\NetBT\\Parameters > NodeType: 2",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -45966,6 +46072,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'MSS: (DisableIPSourceRouting IPv6) IP source routing prot' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (DisableIPSourceRouting IPv6): Enabled: Highest protection",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -46055,6 +46162,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'MSS: (DisableIPSourceRouting) IP source routing protectio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (DisableIPSourceRouting): Enabled: Highest protection",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -46144,6 +46252,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'MSS: (EnableICMPRedirect) Allow ICMP redirects to overrid' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (EnableICMPRedirect): Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -46233,6 +46342,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'MSS: (KeepAliveTime) How often keep-alive packets are sen' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (KeepAliveTime): Enabled: 300,000 or 5 minutes",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -46323,6 +46433,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'MSS: (NoNameReleaseOnDemand) Allow the computer to ignore' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (NoNameReleaseOnDemand): Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -46413,6 +46524,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'MSS: (PerformRouterDiscovery) Allow IRDP to detect and co' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (PerformRouterDiscovery): Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -46502,6 +46614,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'MSS: (TcpMaxDataRetransmissions IPv6) How many times unac' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (TcpMaxDataRetransmissions IPv6): Enabled: 3",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -46592,6 +46705,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'MSS: (TcpMaxDataRetransmissions) How many times unacknowl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (TcpMaxDataRetransmissions): Enabled: 3",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -46682,6 +46796,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configure multicast DNS (mDNS) protocol' is set to 'Disab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Configure multicast DNS (mDNS) protocol: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -46771,6 +46886,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure NetBIOS settings' is set to 'Enabled: Disable N' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Configure NetBIOS settings: Enabled: Disable NetBIOS name resolution on public networks",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -46861,6 +46977,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn off default IPv6 DNS Servers' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Turn off default IPv6 DNS Servers: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -46951,6 +47068,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn off multicast name resolution' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\DNS Client > Turn off multicast name resolution: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -47041,6 +47159,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable remote mailslots' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Enable remote mailslots: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -47130,6 +47249,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Mandate the minimum version of SMB' is set to 'Enabled: 3' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Mandate the minimum version of SMB: Enabled: 3.1.1",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -47220,6 +47340,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable remote mailslots' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Enable remote mailslots: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -47309,6 +47430,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Mandate the minimum version of SMB' is set to 'Enabled: 3' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Mandate the minimum version of SMB: Enabled: 3.1.1",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -47399,6 +47521,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn on Mapper I/O (LLTDIO) driver' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Link-Layer Topology Discovery > Turn on Mapper I/O (LLTDIO) driver: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -47488,6 +47611,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn on Responder (RSPNDR) driver' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Link-Layer Topology Discovery > Turn on Responder (RSPNDR) driver: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -47577,6 +47701,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn off Microsoft Peer-to-Peer Networking Services' is s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Microsoft Peer-to-Peer Networking Services > Turn off Microsoft Peer-to-Peer Networking Services: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -47667,6 +47792,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Prohibit installation and configuration of Network Bridge' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Network Connections > Prohibit installation and configuration of Network Bridge on your DNS domain network: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -47757,6 +47883,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Prohibit use of Internet Connection Sharing on your DNS d' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Network Connections > Prohibit use of Internet Connection Sharing on your DNS domain network: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -47847,6 +47974,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require domain users to elevate when setting a network's ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Network Connections > Require domain users to elevate when setting a network's location: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -47937,6 +48065,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Disable IPv6 (Ensure TCPIP6 Parameter 'DisabledComponents' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Disable IPv6 via registry: HKLM\\SYSTEM\\CurrentControlSet\\Services\\TCPIP6\\Parameters > DisabledComponents: 0xFF (255). Or: Set-NetAdapterBinding -Name '*' -ComponentID ms_tcpip6 -Enabled $false",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -48026,6 +48155,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configuration of wireless settings using Windows Connect ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Wireless Lan Service\\WLAN Settings > Configuration of wireless settings using Windows Connect Now: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -48115,6 +48245,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Prohibit access of the Windows Connect Now wizards' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Wireless Lan Service\\WLAN Settings > Prohibit access of the Windows Connect Now wizards: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48205,6 +48336,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Minimize the number of simultaneous connections to the In' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Windows Connection Manager > Minimize the number of simultaneous connections to the Internet or a Windows Domain: Enabled: 3 = Prevent Wi-Fi when on Ethernet",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48295,6 +48427,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Prohibit connection to non-domain networks when connected' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Windows Connection Manager > Prohibit connection to non-domain networks when connected to domain authenticated network: Enabled (MS only)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48385,6 +48518,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow Print Spooler to accept client connections' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Allow Print Spooler to accept client connections: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48475,6 +48609,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Redirection Guard' is set to 'Enabled: Redirect' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure Redirection Guard: Enabled: Redirection Guard Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48565,6 +48700,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure RPC connection settings: Protocol to use for ou' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC connection settings: Protocol to use for outgoing RPC connections: Enabled: RPC over TCP",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48655,6 +48791,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure RPC connection settings: Use authentication for' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC connection settings: Use authentication for outgoing RPC connections: Enabled: Default",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48745,6 +48882,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure RPC listener settings: Protocols to allow for i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC listener settings: Protocols to allow for incoming RPC connections: Enabled: RPC over TCP",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48835,6 +48973,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure RPC listener settings: Authentication protocol ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC listener settings: Authentication protocol to use for incoming RPC connections: Enabled: Negotiate (or higher)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -48925,6 +49064,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure RPC over TCP port' is set to 'Enabled: 0'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC over TCP port: Enabled: 0",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -49015,6 +49155,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure RPC packet level privacy setting for incoming c' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure RPC packet level privacy setting for incoming connections: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -49105,6 +49246,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Windows protected print' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Configure Windows protected print: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -49195,6 +49337,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Manage processing of Queue-specific files' is set to 'Ena' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Manage processing of Queue-specific files: Enabled: Limit Queue-specific files to Color profiles",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -49284,6 +49427,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Prevent automatic download of applications associated wit' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Installation\\Device Installation Restrictions > Prevent automatic download of applications associated with device metadata: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -49373,6 +49517,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Boot-Start Driver Initialization Policy' is set to 'Enabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Early Launch Antimalware > Boot-Start Driver Initialization Policy: Enabled: Good, unknown and bad but critical",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -49462,6 +49607,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure security policy processing: Process even if the' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Group Policy\\Security Policy Processing > Configure security policy processing: Process even if the Group Policy objects have not changed: Enabled: TRUE",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -49552,6 +49698,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Continue experiences on this device' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Group Policy > Continue experiences on this device: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -49641,6 +49788,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off background refresh of Group Policy' is set to 'D' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Group Policy > Turn off background refresh of Group Policy: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -49730,6 +49878,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn off downloading of print drivers over HTTP' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off downloading of print drivers over HTTP: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -49820,6 +49969,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off handwriting personalization data sharing' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off handwriting personalization data sharing: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -49909,6 +50059,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off handwriting recognition error reporting' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off handwriting recognition error reporting: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -49998,6 +50149,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Internet Connection Wizard if URL connection is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Internet Connection Wizard if URL connection is referring to Microsoft.com: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50087,6 +50239,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Internet download for Web publishing and online ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Internet download for Web publishing and online ordering wizards: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50176,6 +50329,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Registration if URL connection is referring to M' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Registration if URL connection is referring to Microsoft.com: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50265,6 +50419,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Search Companion content file updates' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Search Companion content file updates: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50354,6 +50509,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off the \"Order Prints\" picture task' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off the \"Order Prints\" picture task: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50443,6 +50599,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off the \"Publish to Web\" task for files and folders'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off the \"Publish to Web\" task for files and folders: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50532,6 +50689,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off the Windows Messenger Customer Experience Improv' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off the Windows Messenger Customer Experience Improvement Program: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50621,6 +50779,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Windows Customer Experience Improvement Program'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Windows Customer Experience Improvement Program: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50710,6 +50869,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Windows Error Reporting' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off Windows Error Reporting: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50799,6 +50959,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Custom SSPs and APs to be loaded into LSASS' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Local Security Authority > Allow Custom SSPs and APs to be loaded into LSASS: Disabled (DC only)",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -50888,6 +51049,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configures LSASS to run as a protected process' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Local Security Authority > Configures LSASS to run as a protected process: Enabled: Enabled with UEFI Lock",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -50978,6 +51140,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Disallow copying of user input methods to the system acco' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Disallow copying of user input methods to the system account for sign-in: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -51068,6 +51231,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Block user from showing account details on sign-in' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Block user from showing account details on sign-in: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -51158,6 +51322,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not enumerate connected users on domain-joined compute' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Do not enumerate connected users on domain-joined computers: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -51248,6 +51413,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enumerate local users on domain-joined computers' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Enumerate local users on domain-joined computers: Disabled (MS only)",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -51337,6 +51503,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn on convenience PIN sign-in' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Turn on convenience PIN sign-in: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -51426,6 +51593,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Block NetBIOS-based discovery for domain controller locat' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Net Logon\\DC Locator DNS Records > Block NetBIOS-based discovery for domain controller location: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -51516,6 +51684,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Clipboard synchronization across devices' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\OS Policies > Allow Clipboard synchronization across devices: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -51605,6 +51774,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow upload of User Activities' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\User Profile > Allow upload of User Activities: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -51694,6 +51864,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow network connectivity during connected-standby (on b' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Power Management\\Sleep Settings > Allow network connectivity during connected-standby (on battery): Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -51783,6 +51954,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow network connectivity during connected-standby (plug' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Power Management\\Sleep Settings > Allow network connectivity during connected-standby (plugged in): Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -51872,6 +52044,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configure Offer Remote Assistance' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Remote Assistance > Configure Offer Remote Assistance: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -51961,6 +52134,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configure Solicited Remote Assistance' is set to 'Disable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Remote Assistance > Configure Solicited Remote Assistance: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -52050,6 +52224,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable RPC Endpoint Mapper Client Authentication' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Remote Procedure Call > Enable RPC Endpoint Mapper Client Authentication: Enabled (MS only)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -52140,6 +52315,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Restrict Unauthenticated RPC clients' is set to 'Enabled:' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Remote Procedure Call > Restrict Unauthenticated RPC clients: Enabled: Authenticated (MS only)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -52230,6 +52406,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure SAM change password RPC methods policy' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Security Account Manager > Configure SAM change password RPC methods policy: Enabled: Allow strong encryption change password RPC method only (DC only)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -52320,6 +52497,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure SAM change password RPC methods policy' is set ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Security Account Manager > Configure SAM change password RPC methods policy: Enabled: Block all change password RPC methods (MS only)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -52410,6 +52588,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Microsoft Support Diagnostic Tool: Turn on MSDT interacti' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Troubleshooting and Diagnostics\\Microsoft Support Diagnostic Tool > Turn on MSDT interactive communication with support provider: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -52499,6 +52678,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable/Disable PerfTrack' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Performance Control Panel\\WDI > Enable/Disable PerfTrack: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -52588,6 +52768,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off the advertising ID' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off the advertising ID: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -52677,6 +52858,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable Windows NTP Client' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Windows Time Service\\Time Providers > Enable Windows NTP Client: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -52766,6 +52948,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable Windows NTP Server' is set to 'Disabled' (MS only)' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Windows Time Service\\Time Providers > Enable Windows NTP Server: Disabled (MS only)",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -52855,6 +53038,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow a Windows app to share application data between use' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\App Package Deployment > Allow a Windows app to share application data between users: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -52944,6 +53128,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Not allow per-user unsigned packages to install by defaul' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Not allow per-user unsigned packages to install by default: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -53033,6 +53218,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Disallow Autoplay for non-volume devices' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\AutoPlay Policies > Disallow Autoplay for non-volume devices: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -53123,6 +53309,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set the default behavior for AutoRun' is set to 'Enabled:' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\AutoPlay Policies > Set the default behavior for AutoRun: Enabled: Do not execute any autorun commands",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -53213,6 +53400,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn off Autoplay' is set to 'Enabled: All drives'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\AutoPlay Policies > Turn off Autoplay: Enabled: All drives",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -53303,6 +53491,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure enhanced anti-spoofing' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Biometrics\\Facial Features > Configure enhanced anti-spoofing: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -53393,6 +53582,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Use of Camera' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Camera > Allow Use of Camera: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -53482,6 +53672,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off cloud consumer account state content' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Turn off cloud consumer account state content: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -53571,6 +53762,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off cloud optimized content' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Turn off cloud optimized content: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -53660,6 +53852,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require pin for pairing' is set to 'Enabled: First Time' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Connect > Require pin for pairing: Enabled: First Time (or Always)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -53750,6 +53943,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not display the password reveal button' is set to 'Ena' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Credential User Interface > Do not display the password reveal button: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -53840,6 +54034,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enumerate administrator accounts on elevation' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Credential User Interface > Enumerate administrator accounts on elevation: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -53929,6 +54124,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Authenticated Proxy usage for the Connected Use' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Configure Authenticated Proxy usage for the Connected User Experience and Telemetry service: Enabled: Disable Authenticated Proxy usage",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -54019,6 +54215,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Do not show feedback notifications' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Do not show feedback notifications: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54108,6 +54305,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Limit Dump Collection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Limit Dump Collection: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54197,6 +54395,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable App Installer' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54286,6 +54485,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable App Installer Experimental Features' is set to 'Di' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer Experimental Features: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54375,6 +54575,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable App Installer Hash Override' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer Hash Override: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54464,6 +54665,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable App Installer Local Archive Malware Scan Override'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer Local Archive Malware Scan Override: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54553,6 +54755,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable App Installer ms-appinstaller protocol' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer ms-appinstaller protocol: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54642,6 +54845,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable App Installer Microsoft Store Source Certificate V' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable App Installer Microsoft Store Source Certificate Validation Bypass: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54731,6 +54935,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable Windows Package Manager command line interfaces' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Desktop App Installer > Enable Windows Package Manager command line interfaces: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54820,6 +55025,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Do not apply the Mark of the Web tag to files copied from' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\File Explorer > Do not apply the Mark of the Web tag to files copied from insecure sources: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54909,6 +55115,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Data Execution Prevention for Explorer' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\File Explorer > Turn off Data Execution Prevention for Explorer: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -54998,6 +55205,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off heap termination on corruption' is set to 'Disab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\File Explorer > Turn off heap termination on corruption: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55087,6 +55295,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off shell protocol protected mode' is set to 'Disabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\File Explorer > Turn off shell protocol protected mode: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55176,6 +55385,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off location' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Location and Sensors\\Windows Location Provider > Turn off location: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55265,6 +55475,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configure local setting override for reporting to Microso' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\MAPS > Configure local setting override for reporting to Microsoft MAPS: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55354,6 +55565,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off real-time protection' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Real-time Protection > Turn off real-time protection: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55443,6 +55655,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configure Watson events' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Reporting > Configure Watson events: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55532,6 +55745,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Scan removable drives' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Scan removable drives: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -55622,6 +55836,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn off Push To Install service' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Push To Install > Turn off Push To Install service: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -55712,6 +55927,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Do not allow passwords to be saved' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Connections > Do not allow passwords to be saved: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55801,6 +56017,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow UI Automation redirection' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Allow UI Automation redirection: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55890,6 +56107,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Do not delete temp folders upon exit' is set to 'Disabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Temporary Folders > Do not delete temp folders upon exit: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -55979,6 +56197,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Do not use temporary folders per session' is set to 'Disa' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Temporary Folders > Do not use temporary folders per session: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56068,6 +56287,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Prevent downloading of enclosures' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\RSS Feeds > Prevent downloading of enclosures: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56157,6 +56377,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Cloud Search' is set to 'Enabled: Disable Cloud Sea' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Search > Allow Cloud Search: Enabled: Disable Cloud Search",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56246,6 +56467,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow indexing of encrypted files' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Search > Allow indexing of encrypted files: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56335,6 +56557,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow search highlights' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Search > Allow search highlights: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56424,6 +56647,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off KMS Client Online AVS Validation' is set to 'Ena' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Software Protection Platform > Turn off KMS Client Online AVS Validation: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56513,6 +56737,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow suggested apps in Windows Ink Workspace' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Ink Workspace > Allow suggested apps in Windows Ink Workspace: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56602,6 +56827,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Windows Ink Workspace' is set to 'Enabled: On, but ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Ink Workspace > Allow Windows Ink Workspace: Enabled: On, but disallow access above lock (or Disabled)",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56691,6 +56917,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow user control over installs' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Installer > Allow user control over installs: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56780,6 +57007,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Always install with elevated privileges' is set to 'Disab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Installer > Always install with elevated privileges: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56869,6 +57097,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Prevent Internet Explorer security prompt for Windows Ins' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Installer > Prevent Internet Explorer security prompt for Windows Installer scripts: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -56958,6 +57187,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configure the transmission of the user's password in the ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Logon Options > Configure the transmission of the user's password in the content of MPR notifications sent by winlogon: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57047,6 +57277,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Sign-in and lock last interactive user automatically afte' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Logon Options > Sign-in and lock last interactive user automatically after a restart: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57136,6 +57367,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Basic authentication' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Client > Allow Basic authentication: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57225,6 +57457,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow unencrypted traffic' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Client > Allow unencrypted traffic: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57314,6 +57547,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Basic authentication' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Service > Allow Basic authentication: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57403,6 +57637,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow remote server management through WinRM' is set to '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Service > Allow remote server management through WinRM: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57492,6 +57727,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow unencrypted traffic' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Service > Allow unencrypted traffic: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57581,6 +57817,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Disallow WinRM from storing RunAs credentials' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Service > Disallow WinRM from storing RunAs credentials: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -57671,6 +57908,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Allow Remote Shell Access' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Shell > Allow Remote Shell Access: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57760,6 +57998,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Prevent users from modifying settings' is set to 'Enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Security\\App and Browser protection > Prevent users from modifying settings: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -57850,6 +58089,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'No auto-restart with logged on users for scheduled automa' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage end user experience > No auto-restart with logged on users for scheduled automatic updates installations: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -57939,6 +58179,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Automatic Updates: Scheduled install day' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage end user experience > Configure Automatic Updates: Scheduled install day: 0 - Every day",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -58029,6 +58270,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Disable HTTP proxy features: Disable WPAD' is set to 'Ena' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Internet Explorer\\Internet Control Panel\\Advanced Page > Disable HTTP proxy features: Disable WPAD: Enabled: Checked",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -58118,6 +58360,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Disable HTTP proxy features: Disable proxy authentication' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Internet Explorer\\Internet Control Panel\\Advanced Page > Disable HTTP proxy features: Disable proxy authentication: Enabled: Disable authentication over loopback interfaces (or higher)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -58208,6 +58451,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Help Experience Improvement Program' is set to '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Help Experience Improvement Program > Turn off Help Experience Improvement Program: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -58297,6 +58541,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Do not suggest third-party content in Windows spotlight' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Do not suggest third-party content in Windows spotlight: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -58386,6 +58631,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Do not use diagnostic data for tailored experiences' is s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Do not use diagnostic data for tailored experiences: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -58475,6 +58721,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off Spotlight collection on Desktop' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Turn off Spotlight collection on Desktop: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -58564,6 +58811,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Prevent users from sharing files within their profile.' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Network Sharing > Prevent users from sharing files within their profile: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -58653,6 +58901,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Prevent Codec Download' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Media Player\\Networking > Prevent Codec Download: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -75391,6 +75640,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Accounts: Limit local account use of blank passwords to c' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Accounts: Limit local account use of blank passwords to console logon only: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75471,6 +75721,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit: Force audit policy subcategory settings (Windows V' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Audit: Force audit policy subcategory settings to override audit policy category settings: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75551,6 +75802,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit: Shut down system immediately if unable to log secu' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Audit: Shut down system immediately if unable to log security audits: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75631,6 +75883,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Interactive logon: Don't display last signed-in' is set t' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Don't display last signed-in: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75711,6 +75964,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Interactive logon: Require Domain Controller Authenticati' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Require Domain Controller Authentication to unlock workstation: Enabled (MS only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75791,6 +76045,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Microsoft network server: Disconnect clients when logon h' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network server: Disconnect clients when logon hours expire: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75871,6 +76126,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Network security: Force logoff when logon hours expire' i' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Force logoff when logon hours expire: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -75951,6 +76207,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Network security: Restrict NTLM: Audit Incoming NTLM Traf' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Restrict NTLM: Audit Incoming NTLM Traffic: Enable auditing for all accounts. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76031,6 +76288,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Shutdown: Allow system to be shut down without having to ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Shutdown: Allow system to be shut down without having to log on: Disabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76111,6 +76369,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Credential Validation' is set to 'Success and Failu' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Logon > Audit Credential Validation: Success and Failure. Or: auditpol.exe /set /subcategory:\"Credential Validation\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76191,6 +76450,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Kerberos Authentication Service' is set to 'Success' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Logon > Audit Kerberos Authentication Service: Success and Failure (DC only). Or: auditpol.exe /set /subcategory:\"Kerberos Authentication Service\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76271,6 +76531,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Kerberos Service Ticket Operations' is set to 'Succ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Logon > Audit Kerberos Service Ticket Operations: Success and Failure (DC only). Or: auditpol.exe /set /subcategory:\"Kerberos Service Ticket Operations\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76351,6 +76612,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Computer Account Management' is set to include 'Suc' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Computer Account Management: Success (DC only). Or: auditpol.exe /set /subcategory:\"Computer Account Management\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76431,6 +76693,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Distribution Group Management' is set to include 'S' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Distribution Group Management: Success (DC only). Or: auditpol.exe /set /subcategory:\"Distribution Group Management\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76511,6 +76774,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Security Group Management' is set to include 'Succe' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit Security Group Management: Success. Or: auditpol.exe /set /subcategory:\"Security Group Management\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76591,6 +76855,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit User Account Management' is set to 'Success and Fai' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Account Management > Audit User Account Management: Success and Failure. Or: auditpol.exe /set /subcategory:\"User Account Management\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76671,6 +76936,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit PNP Activity' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Detailed Tracking > Audit PNP Activity: Success. Or: auditpol.exe /set /subcategory:\"Plug and Play Events\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76751,6 +77017,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Directory Service Access' is set to include 'Failur' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\DS Access > Audit Directory Service Access: Failure (DC only). Or: auditpol.exe /set /subcategory:\"Directory Service Access\" /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76831,6 +77098,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Directory Service Changes' is set to include 'Succe' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\DS Access > Audit Directory Service Changes: Success (DC only). Or: auditpol.exe /set /subcategory:\"Directory Service Changes\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76911,6 +77179,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Group Membership' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Group Membership: Success. Or: auditpol.exe /set /subcategory:\"Group Membership\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -76991,6 +77260,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Logoff' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Logoff: Success. Or: auditpol.exe /set /subcategory:\"Logoff\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77071,6 +77341,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Logon' is set to 'Success and Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Logon: Success and Failure. Or: auditpol.exe /set /subcategory:\"Logon\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77151,6 +77422,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Other Logon/Logoff Events' is set to 'Success and F' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Other Logon/Logoff Events: Success and Failure. Or: auditpol.exe /set /subcategory:\"Other Logon/Logoff Events\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77231,6 +77503,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Special Logon' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Logon/Logoff > Audit Special Logon: Success. Or: auditpol.exe /set /subcategory:\"Special Logon\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77311,6 +77584,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Detailed File Share' is set to include 'Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access > Audit Detailed File Share: Failure. Or: auditpol.exe /set /subcategory:\"Detailed File Share\" /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77391,6 +77665,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit File Share' is set to 'Success and Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access > Audit File Share: Success and Failure. Or: auditpol.exe /set /subcategory:\"File Share\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77471,6 +77746,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Other Object Access Events' is set to 'Success and ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access > Audit Other Object Access Events: Success and Failure. Or: auditpol.exe /set /subcategory:\"Other Object Access Events\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77551,6 +77827,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Removable Storage' is set to 'Success and Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Object Access > Audit Removable Storage: Success and Failure. Or: auditpol.exe /set /subcategory:\"Removable Storage\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77631,6 +77908,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Audit Policy Change' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit Audit Policy Change: Success. Or: auditpol.exe /set /subcategory:\"Audit Policy Change\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77711,6 +77989,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Authentication Policy Change' is set to include 'Su' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit Authentication Policy Change: Success. Or: auditpol.exe /set /subcategory:\"Authentication Policy Change\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77791,6 +78070,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Authorization Policy Change' is set to include 'Suc' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit Authorization Policy Change: Success. Or: auditpol.exe /set /subcategory:\"Authorization Policy Change\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77871,6 +78151,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Other Policy Change Events' is set to include 'Fail' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit Other Policy Change Events: Failure. Or: auditpol.exe /set /subcategory:\"Other Policy Change Events\" /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -77951,6 +78232,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Sensitive Privilege Use' is set to 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Privilege Use > Audit Sensitive Privilege Use: Success and Failure. Or: auditpol.exe /set /subcategory:\"Sensitive Privilege Use\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -78031,6 +78313,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Other System Events' is set to 'Success and Failure' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit Other System Events: Success and Failure. Or: auditpol.exe /set /subcategory:\"Other System Events\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -78111,6 +78394,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Security State Change' is set to include 'Success'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit Security State Change: Success. Or: auditpol.exe /set /subcategory:\"Security State Change\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -78191,6 +78475,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit Security System Extension' is set to include 'Succe' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit Security System Extension: Success. Or: auditpol.exe /set /subcategory:\"Security System Extension\" /success:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -78271,6 +78556,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit System Integrity' is set to 'Success and Failure'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit System Integrity: Success and Failure. Or: auditpol.exe /set /subcategory:\"System Integrity\" /success:enable /failure:enable",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -78351,6 +78637,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'MSS: (WarningLevel) Percentage threshold for the security' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (WarningLevel): Enabled: 90% or less",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -78430,6 +78717,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable Font Providers' is set to 'Disabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Enable Font Providers: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -78509,6 +78797,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit client does not support encryption' is set to 'Enab' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Audit client does not support encryption: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -78588,6 +78877,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit client does not support signing' is set to 'Enabled' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Audit client does not support signing: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -78667,6 +78957,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit insecure guest logon' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Audit insecure guest logon: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -78746,6 +79037,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit insecure guest logon' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Audit insecure guest logon: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -78825,6 +79117,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit server does not support encryption' is set to 'Enab' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Audit server does not support encryption: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -78904,6 +79197,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Audit server does not support signing' is set to 'Enabled' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Audit server does not support signing: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -78983,6 +79277,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable insecure guest logons' is set to 'Disabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Enable insecure guest logons: Disabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79062,6 +79357,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Hardened UNC Paths' is set to 'Enabled, with \"Require Mut' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Network Provider > Hardened UNC Paths: Enabled. Configure \\\\*\\NETLOGON and \\\\*\\SYSVOL with RequireMutualAuthentication=1, RequireIntegrity=1, RequirePrivacy=1",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79141,6 +79437,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn off notifications network usage' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Start Menu and Taskbar\\Notifications > Turn off notifications network usage: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79220,6 +79517,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable / disable CLFS logfile authentication' is set to '' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\CLFS Logfile > Enable / disable CLFS logfile authentication: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79299,6 +79597,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configure security policy processing: Do not apply during' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Group Policy\\Security Policy Processing > Configure security policy processing: Do not apply during periodic background processing: Enabled: FALSE",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79378,6 +79677,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Post-authentication actions: Actions' is set to 'Enabled:' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Post-authentication actions: Actions: Enabled: Reset the password and logoff the managed account (or higher)",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79457,6 +79757,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Do not display network selection UI' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Logon > Do not display network selection UI: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79536,6 +79837,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Enable OneSettings Auditing' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Enable OneSettings Auditing: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79615,6 +79917,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Limit Diagnostic Log Collection' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Limit Diagnostic Log Collection: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79694,6 +79997,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Application: Specify the maximum log file size (KB)' is s' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Application > Specify the maximum log file size (KB): Enabled: 32,768 or greater",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79773,6 +80077,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Security: Specify the maximum log file size (KB)' is set ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Security > Specify the maximum log file size (KB): Enabled: 196,608 or greater",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79852,6 +80157,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Setup: Specify the maximum log file size (KB)' is set to ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Setup > Specify the maximum log file size (KB): Enabled: 32,768 or greater",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -79931,6 +80237,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'System: Specify the maximum log file size (KB)' is set to' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\System > Specify the maximum log file size (KB): Enabled: 32,768 or greater",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -80010,6 +80317,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Always prompt for password upon connection' is set to 'En' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Always prompt for password upon connection: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -80089,6 +80397,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Turn on PowerShell Script Block Logging' is set to 'Enabl' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows PowerShell > Turn on PowerShell Script Block Logging: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -80168,6 +80477,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Configure Automatic Updates' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage end user experience > Configure Automatic Updates: Enabled",
       "effort": {
         "complexity": 1,
         "isPhased": false,
@@ -91074,6 +91384,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Firewall state' is set to 'On (' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Windows Defender Firewall: Domain: Firewall state: On. Or: wf.msc > Windows Defender Firewall Properties > Domain Profile > Firewall state: On",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91149,6 +91460,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Inbound connections' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Inbound connections: Block (default). Or: wf.msc > Domain Profile > Inbound connections: Block",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91224,6 +91536,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Settings: Display a notificatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Settings: Display a notification: No. Or: wf.msc > Domain Profile > Settings > Display a notification: No",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91299,6 +91612,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Logging: Name' is configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Logging: Name: configure a path (e.g., %SystemRoot%\\System32\\logfiles\\firewall\\pfirewall.log). Or: wf.msc > Domain Profile > Logging",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91374,6 +91688,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Logging: Size limit (KB)' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Logging: Size limit (KB): 16,384 or greater. Or: wf.msc > Domain Profile > Logging > Size limit",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91449,6 +91764,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Logging: Log dropped packets' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Logging: Log dropped packets: Yes. Or: wf.msc > Domain Profile > Logging > Log dropped packets",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91524,6 +91840,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Domain: Logging: Log successful connect' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Domain Profile > Logging: Log successful connections: Yes. Or: wf.msc > Domain Profile > Logging > Log successful connections",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91599,6 +91916,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Firewall state' is set to 'On ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Firewall state: On. Or: wf.msc > Private Profile > Firewall state: On",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91674,6 +91992,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Inbound connections' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Inbound connections: Block (default). Or: wf.msc > Private Profile > Inbound connections: Block",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91749,6 +92068,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Settings: Display a notificati' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Settings: Display a notification: No. Or: wf.msc > Private Profile > Settings > Display a notification: No",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91824,6 +92144,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Logging: Name' is configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Logging: Name: configure a path. Or: wf.msc > Private Profile > Logging > Log file name",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91899,6 +92220,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Logging: Size limit (KB)' is s' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Logging: Size limit (KB): 16,384 or greater. Or: wf.msc > Private Profile > Logging > Size limit",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -91974,6 +92296,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Logging: Log dropped packets' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Logging: Log dropped packets: Yes. Or: wf.msc > Private Profile > Logging > Log dropped packets",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92049,6 +92372,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Private: Logging: Log successful connec' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Private Profile > Logging: Log successful connections: Yes. Or: wf.msc > Private Profile > Logging > Log successful connections",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92124,6 +92448,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Firewall state' is set to 'On (' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Firewall state: On. Or: wf.msc > Public Profile > Firewall state: On",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92199,6 +92524,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Inbound connections' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Inbound connections: Block (default). Or: wf.msc > Public Profile > Inbound connections: Block",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92274,6 +92600,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Settings: Display a notificatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Settings: Display a notification: No. Or: wf.msc > Public Profile > Settings > Display a notification: No",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92349,6 +92676,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Settings: Apply local firewall ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Settings: Apply local firewall rules: No. Or: wf.msc > Public Profile > Settings > Apply local firewall rules: No",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92424,6 +92752,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Settings: Apply local connectio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Settings: Apply local connection security rules: No. Or: wf.msc > Public Profile > Settings > Apply local connection security rules: No",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92499,6 +92828,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Logging: Name' is configured' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Logging: Name: configure a path. Or: wf.msc > Public Profile > Logging > Log file name",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92574,6 +92904,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Logging: Size limit (KB)' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Logging: Size limit (KB): 16,384 or greater. Or: wf.msc > Public Profile > Logging > Size limit",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92649,6 +92980,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Logging: Log dropped packets' i' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Logging: Log dropped packets: Yes. Or: wf.msc > Public Profile > Logging > Log dropped packets",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92724,6 +93056,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Windows Firewall: Public: Logging: Log successful connect' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Windows Defender Firewall with Advanced Security\\Windows Defender Firewall with Advanced Security\\Public Profile > Logging: Log successful connections: Yes. Or: wf.msc > Public Profile > Logging > Log successful connections",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -92799,6 +93132,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Audit MPSSVC Rule-Level Policy Change' is set to 'Success' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Policy Change > Audit MPSSVC Rule-Level Policy Change: Success and Failure. Or: auditpol.exe /set /subcategory:\"MPSSVC Rule-Level Policy Change\" /success:enable /failure:enable",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -102715,6 +103049,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Control whether exclusions are visible to local users' is' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Control whether exclusions are visible to local users: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -102795,6 +103130,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable EDR in block mode' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Enable EDR in block mode: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -102875,6 +103211,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Attack Surface Reduction rules' is set to 'Enab' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Microsoft Defender Exploit Guard\\Attack Surface Reduction > Configure Attack Surface Reduction rules: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -102955,6 +103292,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Prevent users and apps from accessing dangerous websites'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Microsoft Defender Exploit Guard\\Network Protection > Prevent users and apps from accessing dangerous websites: Enabled: Block",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103035,6 +103373,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable file hash computation feature' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\MpEngine > Enable file hash computation feature: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103115,6 +103454,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Convert warn verdict to block' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\MpEngine > Convert warn verdict to block: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103195,6 +103535,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure real-time protection and Security Intelligence ' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure real-time protection and Security Intelligence Updates during OOBE: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103275,6 +103616,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Scan all downloaded files and attachments' is set to 'Ena' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Real-time Protection > Scan all downloaded files and attachments: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103355,6 +103697,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn on behavior monitoring' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Real-time Protection > Turn on behavior monitoring: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103435,6 +103778,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn on script scanning' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Real-time Protection > Turn on script scanning: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103515,6 +103859,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Brute-Force Protection aggressiveness' is set t' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure Brute-Force Protection aggressiveness: Enabled: Medium (or higher)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103595,6 +103940,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Remote Encryption Protection Mode' is set to 'E' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure Remote Encryption Protection Mode: Enabled: Audit (or higher)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103675,6 +104021,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure how aggressively Remote Encryption Protection b' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure how aggressively Remote Encryption Protection blocks threats: Enabled: Medium (or higher)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103755,6 +104102,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Scan excluded files and directories during quick scans' i' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Scan excluded files and directories during quick scans: Enabled: 1",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103835,6 +104183,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Scan packed executables' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Scan packed executables: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103915,6 +104264,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Trigger a quick scan after X days without any scans' is s' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Trigger a quick scan after X days without any scans: Enabled: 7",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -103995,6 +104345,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn on e-mail scanning' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Scan > Turn on e-mail scanning: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -104075,6 +104426,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Windows Defender SmartScreen' is set to 'Enable' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Defender SmartScreen\\Explorer > Configure Windows Defender SmartScreen: Enabled: Warn and prevent bypass",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -104155,6 +104507,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Notify antivirus programs when opening attachments' is se' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Attachment Manager > Notify antivirus programs when opening attachments: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -110731,6 +111084,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Domain controller: LDAP server channel binding token requ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: LDAP server channel binding token requirements: Always (DC only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -110813,6 +111167,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Domain controller: LDAP server signing requirements Enfor' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: LDAP server signing requirements: Require signing (DC only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": true,
@@ -110895,6 +111250,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Microsoft network server: Server SPN target name validati' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network server: Server SPN target name validation level: Accept if provided by client (or higher) (MS only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -110977,6 +111333,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network access: Restrict clients allowed to make remote c' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network access: Restrict clients allowed to make remote calls to SAM: Administrators: Remote Access: Allow (MS only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -111059,6 +111416,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: LDAP client encryption requirements' is' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: LDAP client encryption requirements: Negotiate sealing (or higher). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -111141,6 +111499,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: LDAP client signing requirements' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: LDAP client signing requirements: Negotiate signing (or higher). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -111223,6 +111582,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Audit Process Creation' is set to include 'Success'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\Detailed Tracking > Audit Process Creation: Success. Or: auditpol.exe /set /subcategory:\"Process Creation\" /success:enable",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -111305,6 +111665,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Audit IPsec Driver' is set to 'Success and Failure'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Advanced Audit Policy Configuration\\Audit Policies\\System > Audit IPsec Driver: Success and Failure. Or: auditpol.exe /set /subcategory:\"IPsec Driver\" /success:enable /failure:enable",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -111387,6 +111748,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable Certificate Padding' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System > Enable Certificate Padding: Enabled. Or via registry: HKLM\\Software\\Microsoft\\Cryptography\\Wintrust\\Config > EnableCertPaddingCheck: 1",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -111468,6 +111830,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'MSS: (AutoAdminLogon) Enable Automatic Logon' is set to '' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (AutoAdminLogon) Enable Automatic Logon: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -111549,6 +111912,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'MSS: (SafeDllSearchMode) Enable Safe DLL search mode' is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "Deploy MSS Legacy ADMX templates. GPMC: Computer Configuration\\Administrative Templates\\MSS (Legacy) > MSS: (SafeDllSearchMode): Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -111630,6 +111994,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Limits print driver installation to Administrators' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Limits print driver installation to Administrators: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -111711,6 +112076,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Point and Print Restrictions: When installing drivers for' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Point and Print Restrictions: When installing drivers for a new connection: Enabled: Show warning and elevation prompt",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -111792,6 +112158,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Point and Print Restrictions: When updating drivers for a' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Point and Print Restrictions: When updating drivers for an existing connection: Enabled: Show warning and elevation prompt",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -111873,6 +112240,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require IPPS for IPP printers' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Require IPPS for IPP printers: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -111954,6 +112322,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set TLS/SSL security policy for IPP printers: Disallow in' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Set TLS/SSL security policy for IPP printers: Disallow invalid certificate authority: Enabled: Checked",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112035,6 +112404,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set TLS/SSL security policy for IPP printers: Disallow no' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Set TLS/SSL security policy for IPP printers: Disallow non-server certificates: Enabled: Checked",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112116,6 +112486,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set TLS/SSL security policy for IPP printers: Disallow in' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Set TLS/SSL security policy for IPP printers: Disallow invalid certificate common name: Enabled: Checked",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112197,6 +112568,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set TLS/SSL security policy for IPP printers: Disallow in' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Printers > Set TLS/SSL security policy for IPP printers: Disallow invalid certificate date: Enabled: Checked",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112278,6 +112650,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Include command line in process creation events' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Audit Process Creation > Include command line in process creation events: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112359,6 +112732,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Remote host allows delegation of non-exportable credentia' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Credentials Delegation > Remote host allows delegation of non-exportable credentials: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112440,6 +112814,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security' is set to 'Enabled' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112521,6 +112896,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Select Platform Se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Select Platform Security Level: Secure Boot (or higher)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112602,6 +112978,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Virtualization Bas' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Virtualization Based Protection of Code Integrity: Enabled with UEFI lock",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112683,6 +113060,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Require UEFI Memor' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Require UEFI Memory Attributes Table: True (checked)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112764,6 +113142,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Credential Guard C' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Credential Guard Configuration: Enabled with UEFI lock (MS only)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112845,6 +113224,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Credential Guard C' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Credential Guard Configuration: Disabled (DC only)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -112926,6 +113306,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn On Virtualization Based Security: Secure Launch Conf' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Device Guard > Turn On Virtualization Based Security > Secure Launch Configuration: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113007,6 +113388,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn off printing over HTTP' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Internet Communication Management\\Internet Communication settings > Turn off printing over HTTP: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113088,6 +113470,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enumeration policy for external devices incompatible with' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Kernel DMA Protection > Enumeration policy for external devices incompatible with Kernel DMA Protection: Enabled: Block All",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113169,6 +113552,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow Diagnostic Data' is set to 'Enabled: Diagnostic dat' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Data Collection and Preview Builds > Allow Diagnostic Data: Enabled: Diagnostic data off (not recommended) or Send required diagnostic data",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113250,6 +113634,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure detection for potentially unwanted applications' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus > Configure detection for potentially unwanted applications: Enabled: Block",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113331,6 +113716,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Join Microsoft MAPS' is set to 'Enabled: Advanced'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\MAPS > Join Microsoft MAPS: Enabled: Advanced",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113412,6 +113798,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Attack Surface Reduction rules: Set the state f' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Microsoft Defender Antivirus\\Microsoft Defender Exploit Guard\\Attack Surface Reduction > Configure Attack Surface Reduction rules: Set the state for each ASR rule: configure per CIS benchmark table",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113493,6 +113880,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require use of specific security layer for remote (RDP) c' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Require use of specific security layer for remote (RDP) connections: Enabled: SSL",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113574,6 +113962,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set client connection encryption level' is set to 'Enable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Set client connection encryption level: Enabled: High Level",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113655,6 +114044,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Manage preview builds' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage preview builds > Manage preview builds: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113736,6 +114126,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Select when Quality Updates are received' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Update\\Manage updates offered from Windows Update > Select when Quality Updates are received: Enabled: 0 days",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113817,6 +114208,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not preserve zone information in file attachments' is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Attachment Manager > Do not preserve zone information in file attachments: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113898,6 +114290,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure Windows spotlight on lock screen' is set to 'Di' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Configure Windows spotlight on lock screen: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -113979,6 +114372,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn off all Windows spotlight features' is set to 'Enabl' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Cloud Content > Turn off all Windows spotlight features: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -115471,6 +115865,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Access Credential Manager as a trusted caller' is set to ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Access Credential Manager as a trusted caller: (blank — No One). Or: secpol.msc > Local Policies > User Rights Assignment > Access Credential Manager as a trusted caller",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -115531,6 +115926,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow log on locally' is set to 'Administrators, ENTERPRI' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Allow log on locally: Administrators, ENTERPRISE DOMAIN CONTROLLERS (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -115591,6 +115987,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow log on locally' is set to 'Administrators' (MS only' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Allow log on locally: Administrators (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -115651,6 +116048,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Back up files and directories' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Back up files and directories: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment > Back up files and directories",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -115711,6 +116109,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Restore files and directories' is set to 'Administrators'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Restore files and directories: Administrators. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -115771,6 +116170,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Domain controller: Refuse machine account password change' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain controller: Refuse machine account password changes: Disabled (DC only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -115831,6 +116231,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure password backup directory' is set to 'Enabled: ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Configure password backup directory: Enabled: Active Directory (or Azure Active Directory)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -115890,6 +116291,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Application: Control Event Log behavior when the log file' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Application > Control Event Log behavior when the log file reaches its maximum size: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -115949,6 +116351,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Security: Control Event Log behavior when the log file re' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Security > Control Event Log behavior when the log file reaches its maximum size: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -116008,6 +116411,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Setup: Control Event Log behavior when the log file reach' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\Setup > Control Event Log behavior when the log file reaches its maximum size: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -116067,6 +116471,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'System: Control Event Log behavior when the log file reac' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Event Log Service\\System > Control Event Log behavior when the log file reaches its maximum size: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -116126,6 +116531,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Allow Message Service Cloud Sync' is set to 'Disabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Messaging > Allow Message Service Cloud Sync: Disabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -117776,6 +118182,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Domain member: Digitally encrypt or sign secure channel d' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Digitally encrypt or sign secure channel data (always): Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -117858,6 +118265,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Domain member: Digitally encrypt secure channel data (whe' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Digitally encrypt secure channel data (when possible): Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -117940,6 +118348,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Domain member: Digitally sign secure channel data (when p' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Digitally sign secure channel data (when possible): Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118022,6 +118431,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Domain member: Require strong (Windows 2000 or later) ses' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Domain member: Require strong (Windows 2000 or later) session key: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118104,6 +118514,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Microsoft network client: Digitally sign communications (' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network client: Digitally sign communications (always): Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118186,6 +118597,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Microsoft network server: Digitally sign communications (' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Microsoft network server: Digitally sign communications (always): Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -118268,6 +118680,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require Encryption' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Server > Require Encryption: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -118349,6 +118762,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Encryption Oracle Remediation' is set to 'Enabled: Force ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Credentials Delegation > Encryption Oracle Remediation: Enabled: Force Updated Clients",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -118430,6 +118844,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Disallow Digest authentication' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows Remote Management (WinRM)\\WinRM Client > Disallow Digest authentication: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -118750,6 +119165,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Configure validation of ROCA-vulnerable WHfB keys during ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Security Account Manager > Configure validation of ROCA-vulnerable WHfB keys during authentication: Enabled: Block (DC only)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -119743,6 +120159,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Support device authentication using certificate' is set t' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Kerberos > Support device authentication using certificate: Enabled: Automatic",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -119815,6 +120232,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: Allow Local System to use computer iden' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Allow Local System to use computer identity for NTLM: Enabled. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -119888,6 +120306,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: Configure encryption types allowed for ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Configure encryption types allowed for Kerberos: AES128_HMAC_SHA1, AES256_HMAC_SHA1, Future encryption types. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -119961,6 +120380,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: LAN Manager authentication level' is se' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: LAN Manager authentication level: Send NTLMv2 response only. Refuse LM & NTLM. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120034,6 +120454,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: Minimum session security for NTLM SSP b' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Minimum session security for NTLM SSP based clients: Require NTLMv2 session security, Require 128-bit encryption. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120107,6 +120528,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: Minimum session security for NTLM SSP b' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Minimum session security for NTLM SSP based servers: Require NTLMv2 session security, Require 128-bit encryption. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120180,6 +120602,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: Restrict NTLM: Audit NTLM authenticatio' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Restrict NTLM: Audit NTLM authentication in this domain: Enable all (DC only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120253,6 +120676,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Network security: Restrict NTLM: Outgoing NTLM traffic to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Network security: Restrict NTLM: Outgoing NTLM traffic to remote servers: Audit all (or higher). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -120710,6 +121134,7 @@
         "severity": "Medium",
         "rationale": "Failure to configure 'Ensure 'Interactive logon: Prompt user to change password before ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Prompt user to change password before expiration: 5 to 14 days. Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -120786,6 +121211,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not allow password expiration time longer than require' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Do not allow password expiration time longer than required by policy: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -120862,6 +121288,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable password encryption' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Enable password encryption: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -120938,6 +121365,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Password Settings: Password Age (Days)' is set to 'Enable' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Password Settings: Password Age (Days): Enabled: 30 or fewer",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121014,6 +121442,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Post-authentication actions: Grace period (hours)' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\LAPS > Post-authentication actions: Grace period (hours): Enabled: 8 or fewer hours (not 0)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121166,6 +121595,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable authentication rate limiter' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Enable authentication rate limiter: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121242,6 +121672,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set authentication rate limiter delay (milliseconds)' is ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Network\\Lanman Workstation > Set authentication rate limiter delay (milliseconds): Enabled: 2000 or more",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121370,6 +121801,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Interactive logon: Number of previous logons to cache (in' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Number of previous logons to cache: 4 or fewer (MS only). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -121435,6 +121867,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Interactive logon: Smart card removal behavior' is set to' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Interactive logon: Smart card removal behavior: Lock Workstation (or higher). Or: secpol.msc > Local Policies > Security Options",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -121500,6 +121933,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require a password when a computer wakes (on battery)' is' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Power Management\\Sleep Settings > Require a password when a computer wakes (on battery): Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121564,6 +121998,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require a password when a computer wakes (plugged in)' is' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\System\\Power Management\\Sleep Settings > Require a password when a computer wakes (plugged in): Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121628,6 +122063,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Restrict Remote Desktop Services users to a single Remote' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Connections > Restrict Remote Desktop Services users to a single Remote Desktop Services session: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121692,6 +122128,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not allow COM port redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow COM port redirection: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121756,6 +122193,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not allow drive redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow drive redirection: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121820,6 +122258,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not allow location redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow location redirection: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121884,6 +122323,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not allow LPT port redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow LPT port redirection: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -121948,6 +122388,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not allow supported Plug and Play device redirection' ' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow supported Plug and Play device redirection: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122012,6 +122453,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Do not allow WebAuthn redirection' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Do not allow WebAuthn redirection: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122076,6 +122518,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Restrict clipboard transfer from server to client' is set' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Device and Resource Redirection > Restrict clipboard transfer from server to client: Enabled: Disable clipboard transfers from server to client",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122140,6 +122583,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require secure RPC communication' is set to 'Enabled'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Require secure RPC communication: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122204,6 +122648,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Require user authentication for remote connections by usi' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Security > Require user authentication for remote connections by using Network Level Authentication: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122268,6 +122713,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set time limit for active but idle Remote Desktop Service' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Session Time Limits > Set time limit for active but idle Remote Desktop Services sessions: Enabled: 15 minutes or less (not Never)",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122332,6 +122778,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Set time limit for disconnected sessions' is set to 'Enab' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Remote Desktop Services\\Remote Desktop Session Host\\Session Time Limits > Set time limit for disconnected sessions: Enabled: 1 minute",
       "effort": {
         "complexity": 2,
         "isPhased": false,
@@ -122672,6 +123119,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable computer and user accounts to be trusted for deleg' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Enable computer and user accounts to be trusted for delegation: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -122758,6 +123206,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Enable computer and user accounts to be trusted for deleg' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Enable computer and user accounts to be trusted for delegation: (blank — No One) (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -122844,6 +123293,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Configure 'Accounts: Rename administrator account'' leaves the environment exposed, increasing the risk of unauthorized access or data compromise."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\Security Options > Accounts: Rename administrator account: set to a non-default name. Or: secpol.msc > Local Policies > Security Options > Accounts: Rename administrator account",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -124039,6 +124489,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Generate security audits' is set to 'LOCAL SERVICE, NETWO' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Generate security audits: LOCAL SERVICE, NETWORK SERVICE, RESTRICTED SERVICES\\PrintSpoolerService. Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -124120,6 +124571,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Manage auditing and security log' is set to 'Administrato' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Manage auditing and security log: Administrators (DC only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -124201,6 +124653,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Manage auditing and security log' is set to 'Administrato' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Windows Settings\\Security Settings\\Local Policies\\User Rights Assignment > Manage auditing and security log: Administrators (MS only). Or: secpol.msc > Local Policies > User Rights Assignment",
       "effort": {
         "complexity": 3,
         "isPhased": false,
@@ -124282,6 +124735,7 @@
         "severity": "High",
         "rationale": "Failure to configure 'Ensure 'Turn on PowerShell Transcription' is set to 'Enabled'' leaves the environment exposed, reducing the ability to detect and respond to security incidents."
       },
+      "remediation": "GPMC: Computer Configuration\\Administrative Templates\\Windows Components\\Windows PowerShell > Turn on PowerShell Transcription: Enabled",
       "effort": {
         "complexity": 2,
         "isPhased": false,


### PR DESCRIPTION
## Summary

- Adds `remediation` strings to all **360 AZ-\*** Azure resource checks (Azure Portal navigation + `az` CLI commands)
- Adds `remediation` strings to all **454 WIN-\*** Windows Server CIS checks (GPMC secpol.msc/auditpol.exe/Administrative Templates paths)

All 814 AZ-assess source checks now have structured remediation guidance.

## Closes

- Closes #227
- Closes #228

## Test plan

- [x] `Build-Registry.py` runs cleanly
- [x] 281/281 Pester tests pass
- [x] All 814 AZ/WIN checks have non-empty `remediation` in `az-assess-source-checks.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)