### PR TITLE
feat: enable automated check for BACKUP-ENABLED-001

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -118242,8 +118242,8 @@
       "checkId": "BACKUP-ENABLED-001",
       "name": "Ensure Microsoft 365 Backup is Enabled to Protect Backup CUI Confidentiality",
       "category": "BACKUP",
-      "collector": "Compliance",
-      "hasAutomatedCheck": false,
+      "collector": "Backup",
+      "hasAutomatedCheck": true,
       "licensing": {
         "minimum": "E3"
       },
@@ -118415,9 +118415,7 @@
         }
       ],
       "tags": [
-        "business-continuity-disaster-recovery",
-        "compliance",
-        "purview"
+        "business-continuity-disaster-recovery"
       ]
     },
     {

--- a/data/registry.schema.json
+++ b/data/registry.schema.json
@@ -244,7 +244,8 @@
               "Forms",
               "PurviewRetention",
               "EntApp",
-              "AzAssess"
+              "AzAssess",
+              "Backup"
             ]
           }
         }

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -7996,8 +7996,8 @@
       "checkId": "BACKUP-ENABLED-001",
       "name": "Ensure Microsoft 365 Backup is Enabled to Protect Backup CUI Confidentiality",
       "category": "BACKUP",
-      "collector": "Compliance",
-      "hasAutomatedCheck": false,
+      "collector": "Backup",
+      "hasAutomatedCheck": true,
       "licensing": "E3",
       "scfPrimary": "BCD-11.4",
       "scfAdditional": [

--- a/tests/registry-integrity.Tests.ps1
+++ b/tests/registry-integrity.Tests.ps1
@@ -174,7 +174,7 @@ Describe 'Control Registry Integrity' {
     }
 
     It 'Collector values are from the known set' {
-        $knownCollectors = @('Entra', 'CAEvaluator', 'ExchangeOnline', 'DNS', 'Defender', 'Compliance', 'Intune', 'SharePoint', 'Teams', 'PowerBI', 'StrykerReadiness', 'Forms', 'PurviewRetention', 'EntApp', 'AzAssess')
+        $knownCollectors = @('Entra', 'CAEvaluator', 'ExchangeOnline', 'DNS', 'Defender', 'Compliance', 'Intune', 'SharePoint', 'Teams', 'PowerBI', 'StrykerReadiness', 'Forms', 'PurviewRetention', 'EntApp', 'AzAssess', 'Backup')
         $automated = $checks | Where-Object { $_.hasAutomatedCheck -eq $true }
         foreach ($check in $automated) {
             $check.collector | Should -BeIn $knownCollectors `


### PR DESCRIPTION
## Summary

- Flips `BACKUP-ENABLED-001` from `hasAutomatedCheck: false` to `true`
- Sets collector to `"Backup"` (new, semantically accurate)
- Adds `'Backup'` to the Pester known-collectors list

## API Details

**Endpoint:** `GET /solutions/backupRestore/serviceApps`
**Required permission:** `BackupRestore-Control.Read.All` (Application)

**Check logic:**
| Response | Meaning | Result |
|----------|---------|--------|
| 200 with service app | Backup controller registered → backup active | PASS |
| 404 `ServiceAppNotFound` | No controller registered | FAIL |
| 403 | M365 Backup service not enabled | FAIL |

**Investigation notes:**
- `BackupRestore.Read.All` no longer exists — permissions are now granularized (`BackupRestore-Configuration`, `-Control`, `-Monitor`, `-Restore`, `-Search`)
- `GET /solutions/backupRestore` (root) requires the calling app to be registered as a backup controller — not suitable for a read-only compliance scanner
- `GET /solutions/backupRestore/serviceApps` is accessible with `BackupRestore-Control.Read.All` alone and returns a meaningful 404 when no controller exists
- M365 Backup is pay-as-you-go (no per-user license), enabled via Admin Center → Settings → Microsoft 365 Backup after linking an Azure subscription for billing

## M365-Assess work needed

Implement `Get-BackupRestoreResult` collector using the `Backup` collector name. Handle 200/404/403 response codes as described above.

## Closes

- Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)