### PR TITLE
feat: Sprint B CA hygiene checks + ISO 27002 as 17th framework

### DIFF
--- a/data/frameworks/iso-27002.json
+++ b/data/frameworks/iso-27002.json
@@ -1,0 +1,43 @@
+{
+  "frameworkId": "iso-27002",
+  "label": "ISO/IEC 27002:2022",
+  "version": "2022",
+  "description": "International standard providing a reference set of information security controls and guidance for their implementation. ISO 27002 is the implementation guide behind ISO 27001 Annex A — it specifies the 93 controls that organizations select from when treating identified risks.",
+  "homepageUrl": "https://www.iso.org/standard/75652.html",
+  "css": "fw-iso27002",
+  "totalControls": 93,
+  "registryKey": "iso-27002",
+  "csvColumn": "Iso27002",
+  "displayOrder": 20,
+  "scoring": {
+    "method": "control-coverage",
+    "themes": {
+      "5": {
+        "label": "Organizational Controls",
+        "controlCount": 37
+      },
+      "6": {
+        "label": "People Controls",
+        "controlCount": 8
+      },
+      "7": {
+        "label": "Physical Controls",
+        "controlCount": 14
+      },
+      "8": {
+        "label": "Technological Controls",
+        "controlCount": 34
+      }
+    }
+  },
+  "colors": {
+    "light": {
+      "background": "#ccfbf1",
+      "color": "#0f766e"
+    },
+    "dark": {
+      "background": "#134e4a",
+      "color": "#5eead4"
+    }
+  }
+}

--- a/data/registry.json
+++ b/data/registry.json
@@ -291,6 +291,9 @@
         "soc2": {
           "controlId": "CC1.1;CC1.1-POF3;CC2.2;CC2.3;CC3.2-POF6;CC3.2-POF7;CC3.3;CC3.3-POF1;CC3.3-POF2;CC3.3-POF3;CC3.3-POF4;CC3.3-POF5;CC3.4-POF6;CC4.2-POF1;CC4.2-POF2;CC4.2-POF3;CC9.1;CC9.2-POF13",
           "title": "COSO Principle 1: Integrity and Ethical Values; COSO Principle 14: Internal Communication; COSO Principle 15: External Communication; COSO Principle 8: Assesses Fraud Risk; Risk Mitigation Identification and Selection"
+        },
+        "iso-27002": {
+          "controlId": "10.1;5.31;5.36;5.7;6.8;7.4;7.4(a);7.4(b);7.4(c);7.4(d);8.1;8.34;8.8"
         }
       },
       "impactRating": {
@@ -534,6 +537,9 @@
           "controlId": "A1.2;CC1.1-POF3;CC3.1;CC3.1-POF16;CC3.2-POF1;CC3.2-POF2;CC3.2-POF3;CC3.2-POF6;CC3.2-POF8;CC3.2-POF9;CC3.4-POF1;CC3.4-POF2;CC3.4-POF3;CC3.4-POF4;CC3.4-POF5;CC4.1;CC4.1-POF8;CC5.2;CC6.1-POF2;CC7.2-POF4;CC7.3",
           "title": "COSO Principle 6: Specifies Suitable Objectives; COSO Principle 16: Selects and Develops Ongoing and Separate Evaluations; COSO Principle 11: Selects and Develops General Controls over Technology; Evaluation of Identified Security Events"
         },
+        "iso-27002": {
+          "controlId": "5.21;5.23;5.35;5.36;5.8;6.1.2(d);6.1.2(d)(1);6.1.2(d)(2);6.1.2(d)(3);6.1.2(e);6.1.2(e)(1);6.1.2(e)(2);7.5;8.1;8.2;8.29;8.34;8.8;9.1;9.1(a);9.1(b);9.1(c);9.1(d);9.1(e);9.1(f)"
+        },
         "cis-m365-v6": {
           "controlId": "6.2"
         }
@@ -742,6 +748,9 @@
         "soc2": {
           "controlId": "CC3.3;CC3.3-POF1;CC3.3-POF2;CC3.3-POF3;CC3.3-POF4;CC3.3-POF5;CC6.1",
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.16;5.19;8.3"
         }
       },
       "impactRating": {
@@ -958,6 +967,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.1-POF8;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         },
         "cisa-scuba": {
           "controlId": "MS.AAD.1.1v1"
@@ -1181,6 +1193,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.1-POF7;CC6.1-POF8;CC6.6-POF3;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -1404,6 +1419,9 @@
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.1-POF8;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.17;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.2.5",
           "title": "Ensure 'Phishing-resistant MFA strength' is required for Administrators",
@@ -1625,6 +1643,9 @@
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.1-POF8;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.17;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.3.1",
           "title": "Ensure Microsoft Authenticator is configured to protect against MFA fatigue",
@@ -1830,6 +1851,9 @@
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "7.2.2",
           "title": "Ensure SharePoint and OneDrive integration with Azure AD B2B is enabled",
@@ -2026,6 +2050,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         },
         "cis-m365-v6": {
           "controlId": "7.2.3",
@@ -2225,6 +2252,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         },
         "cis-m365-v6": {
           "controlId": "7.2.4",
@@ -2438,6 +2468,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;5.17;5.18;8.2;8.3"
         }
       },
       "impactRating": {
@@ -3797,6 +3830,9 @@
           "controlId": "CC6.1;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.2.1",
           "title": "Ensure multifactor authentication is enabled for all users in administrative roles",
@@ -4007,6 +4043,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         },
         "cis-m365-v6": {
           "controlId": "5.2.2.2",
@@ -4223,6 +4262,9 @@
           "controlId": "CC6.1;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.2.11",
           "title": "Ensure sign-in frequency for Intune Enrollment is set to 'Every time'",
@@ -4433,6 +4475,9 @@
           "controlId": "CC6.1;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.3.4",
           "title": "Ensure all member users are 'MFA capable'",
@@ -4641,6 +4686,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         },
         "cis-m365-v6": {
           "controlId": "5.2.3.6",
@@ -4854,6 +4902,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.17;5.18;8.12;8.2;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "5.3.7",
           "profiles": [
@@ -5049,6 +5100,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         },
         "nist-csf": {
           "controlId": "PR.AA-03",
@@ -5251,6 +5305,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.1-POF8;CC6.6-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.17;5.18"
         }
       },
       "impactRating": {
@@ -5637,6 +5694,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         }
       },
       "impactRating": {
@@ -5860,6 +5920,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.2;CC6.2-POF2;CC6.2-POF3;CC6.3;CC6.3-POF3;CC6.3-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Enrollment and Authorization Based on Credentials"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2;8.3"
+        },
         "cisa-scuba": {
           "controlId": "MS.AAD.7.2v1"
         }
@@ -6072,6 +6135,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         },
         "cis-m365-v6": {
           "controlId": "1.3.1",
@@ -6297,6 +6363,9 @@
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.3.2",
           "title": "Ensure custom banned passwords lists are used",
@@ -6518,6 +6587,9 @@
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.3.3",
           "title": "Ensure password protection is enabled for on-prem Active Directory",
@@ -6738,6 +6810,9 @@
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.4.1",
           "title": "Ensure 'Self service password reset enabled' is set to 'All'",
@@ -6839,6 +6914,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -6915,6 +6993,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -6991,6 +7072,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7066,6 +7150,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7141,6 +7228,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7217,6 +7307,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7293,6 +7386,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7369,6 +7465,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7445,6 +7544,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7521,6 +7623,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7597,6 +7702,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7673,6 +7781,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7749,6 +7860,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7825,6 +7939,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7901,6 +8018,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -7979,6 +8099,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -8057,6 +8180,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -8135,6 +8261,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -8212,6 +8341,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -8289,6 +8421,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -8365,6 +8500,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -8441,6 +8579,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -8517,6 +8658,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -8693,6 +8837,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.1-POF11;CC6.6-POF2;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.24;8.26"
         }
       },
       "impactRating": {
@@ -8857,6 +9004,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         },
         "cis-m365-v6": {
           "controlId": "5.1.8.1",
@@ -9033,6 +9183,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -9230,6 +9383,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF7;CC6.2-POF2;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.17;5.18;8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -10085,6 +10241,9 @@
           "controlId": "CC6.1;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
+        },
         "cis-m365-v6": {
           "controlId": "1.2.2",
           "title": "Ensure sign-in to shared mailboxes is blocked",
@@ -10492,6 +10651,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         },
         "cis-m365-v6": {
           "controlId": "2.1.8",
@@ -10912,6 +11074,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.3.1",
           "title": "Ensure a dynamic group for guest users is created",
@@ -11317,6 +11482,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.3.1",
@@ -11726,6 +11894,9 @@
           "controlId": "CC6.1;CC6.2;CC6.2-POF1;CC6.2-POF2;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
+        },
         "cisa-scuba": {
           "controlId": "MS.AAD.7.4v1"
         },
@@ -12132,6 +12303,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -12516,6 +12690,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF7;CC6.2-POF2;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -12887,6 +13064,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         }
       },
       "impactRating": {
@@ -12972,6 +13152,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         }
       },
       "impactRating": {
@@ -13131,6 +13314,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.2-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         },
         "cis-m365-v6": {
           "controlId": "5.3.2",
@@ -13319,6 +13505,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.2-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         },
         "cis-m365-v6": {
           "controlId": "5.3.3",
@@ -13521,6 +13710,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         },
         "cis-m365-v6": {
           "controlId": "1.1.2",
@@ -13746,6 +13938,9 @@
           "controlId": "A1.2;A1.2-POF1;A1.2-POF10;A1.2-POF11;A1.2-POF2;A1.2-POF3;A1.2-POF4;A1.2-POF5;A1.2-POF6;CC6.1;CC7.4-POF5;CC7.5;CC7.5-POF1;CC7.5-POF2;CC7.5-POF4;CC7.5-POF5;CC8.1-POF15;CC9.1;CC9.1-POF1;CC9.1-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Identification of Recovery from Identified Security Incidents; Risk Mitigation Identification and Selection"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;5.29;5.3"
+        },
         "cis-m365-v6": {
           "controlId": "1.1.4",
           "title": "Ensure administrative accounts use licenses with a reduced application footprint",
@@ -13924,6 +14119,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.2-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         },
         "nist-csf": {
           "controlId": "PR.AA-05",
@@ -14106,6 +14304,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.3.8",
@@ -14299,6 +14500,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.2-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.17;5.18"
         }
       },
       "impactRating": {
@@ -14493,6 +14697,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF2;CC6.2-POF3;CC6.3-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -14680,6 +14887,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.2-POF2;CC6.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18"
         }
       },
       "impactRating": {
@@ -14894,6 +15104,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC7.2;CC7.2-POF1;CC7.2-POF4;CC7.3;CC8.1;CC8.1-POF12;CC8.1-POF6;PI1.4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.15;8.16;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -14972,6 +15185,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15036,6 +15252,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15100,6 +15319,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15166,6 +15388,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15232,6 +15457,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15298,6 +15526,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15364,6 +15595,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15429,6 +15663,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15494,6 +15731,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15558,6 +15798,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15622,6 +15865,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15687,6 +15933,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15751,6 +16000,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -15953,6 +16205,9 @@
         "soc2": {
           "controlId": "CC3.3;CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF2;CC6.2-POF3;CC6.3-POF4",
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;5.19;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -16173,6 +16428,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.18"
         },
         "cis-m365-v6": {
           "controlId": "5.1.6.1",
@@ -16414,6 +16672,9 @@
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;CC6.6-POF3;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.18;6.7"
+        },
         "cis-m365-v6": {
           "controlId": "7.4"
         }
@@ -16632,6 +16893,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.18"
         },
         "cis-m365-v6": {
           "controlId": "8.2.1",
@@ -16866,6 +17130,9 @@
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;CC6.6-POF3;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.18;6.7"
+        },
         "cis-m365-v6": {
           "controlId": "8.3"
         }
@@ -17084,6 +17351,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.18"
         },
         "cis-m365-v6": {
           "controlId": "8.5.3",
@@ -17312,6 +17582,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.18"
         }
       },
       "impactRating": {
@@ -17533,6 +17806,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.18"
         }
       },
       "impactRating": {
@@ -17756,6 +18032,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "1.3.6",
@@ -17981,6 +18260,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "1.3.9",
           "title": "Ensure shared bookings pages are restricted to select users",
@@ -18205,6 +18487,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.1.2.1",
@@ -18439,6 +18724,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.4.6",
           "title": "Ensure users are restricted from recovering BitLocker keys",
@@ -18645,6 +18933,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.1.6.2",
@@ -18861,6 +19152,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "7.2.7",
           "title": "Ensure link sharing is restricted in SharePoint and OneDrive",
@@ -19073,6 +19367,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "7.2.11",
           "title": "Ensure the SharePoint default sharing link permission is set",
@@ -19109,6 +19406,212 @@
         "identification-authentication",
         "sharepoint",
         "sharing"
+      ]
+    },
+    {
+      "checkId": "CA-FALLBACK-001",
+      "name": "CA policies have no valid include target (applies to nobody)",
+      "category": "FALLBACK",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "scf": {
+        "primaryControlId": "IAC-21",
+        "additionalControlIds": [
+          "CFG-03"
+        ],
+        "domain": "Identification & Authentication",
+        "controlName": "Does the organization utilize the concept of least privilege, allowing only authorized access to processes necessary to accomplish assigned tasks in accordance with organizational business functions?",
+        "controlDescription": "Does the organization utilize the concept of least privilege, allowing only authorized access to processes necessary to accomplish assigned tasks in accordance with organizational business functions?",
+        "relativeWeighting": 10,
+        "csfFunction": "Protect",
+        "maturityLevels": {
+          "cmm0_notPerformed": false,
+          "cmm1_informal": false,
+          "cmm2_planned": false,
+          "cmm3_defined": false,
+          "cmm4_controlled": false,
+          "cmm5_improving": false
+        },
+        "assessmentObjectives": [
+          {
+            "aoId": "IAC-21.1_A01",
+            "text": "security functions are identified."
+          },
+          {
+            "aoId": "IAC-21.1_A02",
+            "text": "access to security functions is authorized in accordance with the principle of least privilege."
+          },
+          {
+            "aoId": "IAC-21_A01",
+            "text": "organization-defined systems or system components implement the security design principle of least privilege."
+          },
+          {
+            "aoId": "IAC-21_A02",
+            "text": "privileged accounts are identified."
+          },
+          {
+            "aoId": "IAC-21_A03",
+            "text": "access to privileged accounts is authorized in accordance with the principle of least privilege."
+          },
+          {
+            "aoId": "IAC-21_A04",
+            "text": "systems or system components that implement the security design principle of least privilege are defined."
+          },
+          {
+            "aoId": "IAC-21_A05",
+            "text": "approved authorizations for logical access to system resources are enforced in accordance with applicable access control policies."
+          },
+          {
+            "aoId": "IAC-21_A06",
+            "text": "system access for users (or processes acting on behalf of users) is authorized only when necessary to accomplish assigned organizational tasks."
+          }
+        ],
+        "risks": [
+          "R-AC-1",
+          "R-AC-2",
+          "R-AC-3",
+          "R-AC-4",
+          "R-AM-1",
+          "R-AM-2",
+          "R-AM-3",
+          "R-BC-1",
+          "R-BC-2",
+          "R-BC-3",
+          "R-BC-4",
+          "R-BC-5",
+          "R-EX-1",
+          "R-EX-2",
+          "R-EX-3",
+          "R-EX-4",
+          "R-EX-5",
+          "R-EX-6",
+          "R-EX-7",
+          "R-GV-1",
+          "R-GV-2",
+          "R-GV-3",
+          "R-GV-4",
+          "R-GV-5",
+          "R-GV-6",
+          "R-GV-7",
+          "R-GV-8",
+          "R-IR-1",
+          "R-IR-2",
+          "R-IR-3",
+          "R-IR-4",
+          "R-SA-1",
+          "R-SC-1",
+          "R-SC-2",
+          "R-SC-3",
+          "R-SC-4",
+          "R-SC-5",
+          "R-SC-6"
+        ],
+        "threats": [
+          "MT-1",
+          "MT-10",
+          "MT-11",
+          "MT-12",
+          "MT-13",
+          "MT-14",
+          "MT-15",
+          "MT-2",
+          "MT-24",
+          "MT-25",
+          "MT-27",
+          "MT-7",
+          "MT-8",
+          "MT-9",
+          "NT-7"
+        ]
+      },
+      "frameworks": {
+        "cis-controls-v8": {
+          "controlId": "4.0;4.6;4.8;5.4"
+        },
+        "cmmc": {
+          "controlId": "ACL2.-3.1.5;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
+        },
+        "essential-eight": {
+          "controlId": "ML1-P4;ML2-P4;ML3-P4"
+        },
+        "fedramp": {
+          "controlId": "AC-06;CM-07"
+        },
+        "hipaa": {
+          "controlId": "164.308(a)(3)(i);164.312(a)(1)"
+        },
+        "iso-27001": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
+        },
+        "iso-27017": {
+          "controlId": "9.1.1;9.1.2;9.2.1;9.2.2;9.4.1"
+        },
+        "mitre-attack": {
+          "controlId": "T1003;T1003.001;T1003.002;T1003.003;T1003.004;T1003.005;T1003.006;T1003.007;T1003.008;T1005;T1008;T1011;T1011.001;T1020.001;T1021;T1021.001;T1021.002;T1021.003;T1021.004;T1021.005;T1021.006;T1021.007;T1021.008;T1025;T1027;T1036;T1036.003;T1036.005;T1036.007;T1036.008;T1037;T1037.001;T1040;T1041;T1046;T1047;T1048;T1048.001;T1048.002;T1048.003;T1052;T1052.001;T1053;T1053.002;T1053.003;T1053.005;T1053.006;T1053.007;T1055;T1055.001;T1055.002;T1055.003;T1055.004;T1055.005;T1055.008;T1055.009;T1055.011;T1055.012;T1055.013;T1055.014;T1056.003;T1059;T1059.001;T1059.002;T1059.003;T1059.004;T1059.005;T1059.006;T1059.007;T1059.008;T1059.009;T1059.010;T1059.011;T1068;T1070;T1070.001;T1070.002;T1070.003;T1070.007;T1070.008;T1070.009;T1071;T1071.001;T1071.002;T1071.003;T1071.004;T1072;T1078;T1078.001;T1078.002;T1078.003;T1078.004;T1080;T1087;T1087.001;T1087.002;T1087.004;T1090;T1090.001;T1090.002;T1090.003;T1091;T1092;T1095;T1098;T1098.001;T1098.002;T1098.003;T1098.004;T1098.005;T1098.006;T1098.007;T1102;T1102.001;T1102.002;T1102.003;T1104;T1105;T1106;T1110;T1110.001;T1110.002;T1110.003;T1110.004;T1112;T1127;T1127.002;T1129;T1133;T1134;T1134.001;T1134.002;T1134.003;T1134.005;T1135;T1136;T1136.001;T1136.002;T1136.003;T1137;T1137.001;T1137.002;T1137.003;T1137.004;T1137.005;T1137.006;T1176;T1185;T1187;T1189;T1190;T1195;T1195.001;T1195.002;T1197;T1199;T1200;T1203;T1204;T1204.001;T1204.002;T1204.003;T1205;T1205.001;T1210;T1211;T1212;T1213;T1213.001;T1213.002;T1213.003;T1213.004;T1213.005;T1216;T1216.001;T1216.002;T1218;T1218.001;T1218.002;T1218.003;T1218.004;T1218.005;T1218.007;T1218.008;T1218.009;T1218.012;T1218.013;T1218.014;T1218.015;T1219;T1220;T1221;T1222;T1222.001;T1222.002;T1482;T1484;T1485;T1485.001;T1486;T1489;T1490;T1491;T1491.001;T1491.002;T1495;T1498;T1498.001;T1498.002;T1499;T1499.001;T1499.002;T1499.003;T1499.004;T1505;T1505.002;T1505.003;T1505.004;T1505.005;T1525;T1528;T1530;T1537;T1538;T1539;T1542;T1542.001;T1542.003;T1542.004;T1542.005;T1543;T1543.001;T1543.002;T1543.003;T1543.004;T1543.005;T1546;T1546.002;T1546.003;T1546.004;T1546.006;T1546.008;T1546.009;T1546.010;T1546.011;T1546.013;T1546.016;T1547.003;T1547.004;T1547.006;T1547.007;T1547.009;T1547.012;T1547.013;T1548;T1548.001;T1548.002;T1548.003;T1548.004;T1548.005;T1548.006;T1550;T1550.002;T1550.003;T1552;T1552.001;T1552.002;T1552.003;T1552.005;T1552.006;T1552.007;T1553;T1553.001;T1553.003;T1553.004;T1553.005;T1553.006;T1555;T1555.002;T1555.004;T1555.006;T1556;T1556.001;T1556.002;T1556.003;T1556.004;T1556.005;T1556.006;T1556.007;T1556.008;T1556.009;T1557;T1557.001;T1557.002;T1557.003;T1558;T1558.001;T1558.002;T1558.003;T1558.005;T1559;T1559.001;T1559.002;T1559.003;T1561;T1561.001;T1561.002;T1562;T1562.001;T1562.002;T1562.003;T1562.004;T1562.006;T1562.007;T1562.008;T1562.009;T1562.010;T1562.012;T1563;T1563.001;T1563.002;T1564.002;T1564.003;T1564.006;T1564.008;T1564.009;T1565;T1565.003;T1566.003;T1567;T1569;T1569.001;T1569.002;T1570;T1571;T1572;T1573;T1573.001;T1573.002;T1574;T1574.001;T1574.004;T1574.005;T1574.006;T1574.007;T1574.008;T1574.009;T1574.010;T1574.011;T1574.012;T1574.014;T1578;T1578.001;T1578.002;T1578.003;T1578.005;T1580;T1590.002;T1599;T1599.001;T1601;T1601.001;T1601.002;T1602;T1602.001;T1602.002;T1606;T1606.001;T1606.002;T1609;T1610;T1611;T1612;T1613;T1619;T1621;T1622;T1647;T1648;T1651;T1653;T1654;T1657"
+        },
+        "nist-800-171": {
+          "controlId": "3.1.5;3.4.6"
+        },
+        "nist-800-53": {
+          "controlId": "AC-06;CM-07;SA-08(14)",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High",
+            "Privacy"
+          ]
+        },
+        "nist-csf": {
+          "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties; The confidentiality, integrity, and availability of data-in-use are protected; Installation and execution of unauthorized software are prevented"
+        },
+        "pci-dss": {
+          "controlId": "1.2.5;1.2.6;1.3;1.4;1.4.1;1.4.2;2.2.4;3.4;3.4.2;7.1;7.2;7.2.1;7.2.2;7.2.6;7.3;7.3.1;7.3.2;7.3.3;8.6;8.6.1"
+        },
+        "soc2": {
+          "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
+        }
+      },
+      "impactRating": {
+        "severity": "High",
+        "rationale": "A Conditional Access policy with no valid include target is silently disabled — it evaluates to no users and provides no protection, creating a false sense of security in the policy inventory.",
+        "scfWeighting": 10
+      },
+      "effort": {
+        "complexity": 4,
+        "isPhased": true,
+        "phaseCount": 3,
+        "disruptionRisk": true,
+        "disruptionScope": "user-facing"
+      },
+      "remediation": "Entra admin center > Protection > Conditional Access > Policies. For each enabled policy, verify the Users > Include section contains at least one valid, resolvable user, group, or role. Policies with empty include targets should be disabled or remediated with a valid fallback include (e.g., 'All users').",
+      "impact": "Security controls defined in the policy (MFA, device compliance, session limits) are not enforced for any user — the policy is a no-op. Since the policy still appears in the inventory as 'Enabled', it creates audit evidence that does not reflect actual protection.",
+      "rationale": "A CA policy needs at least one valid subject to evaluate against. If all included users or groups have been deleted, the policy applies to an empty set and is effectively disabled. This means controls like MFA, compliant device, or session frequency that the policy was meant to enforce are silently absent.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-users-groups",
+          "title": "Microsoft Learn — Users and groups in Conditional Access policy"
+        },
+        {
+          "url": "https://maester.dev/docs/tests/EIDSCA",
+          "title": "Maester — MT.1036 CA policy has at least one valid include user"
+        }
+      ],
+      "tags": [
+        "conditional-access",
+        "identification-authentication",
+        "identity"
       ]
     },
     {
@@ -19177,6 +19680,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19262,6 +19768,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19347,6 +19856,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19432,6 +19944,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19517,6 +20032,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19602,6 +20120,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19687,6 +20208,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19772,6 +20296,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19857,6 +20384,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -19942,6 +20472,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20027,6 +20560,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20112,6 +20648,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20197,6 +20736,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20282,6 +20824,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20367,6 +20912,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20452,6 +21000,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20537,6 +21088,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20622,6 +21176,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20707,6 +21264,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20792,6 +21352,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20877,6 +21440,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -20962,6 +21528,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21047,6 +21616,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21132,6 +21704,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21217,6 +21792,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21302,6 +21880,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21387,6 +21968,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21472,6 +22056,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21557,6 +22144,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21642,6 +22232,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21727,6 +22320,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21812,6 +22408,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21897,6 +22496,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -21982,6 +22584,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22067,6 +22672,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22152,6 +22760,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22237,6 +22848,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22322,6 +22936,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22407,6 +23024,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22492,6 +23112,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22577,6 +23200,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22662,6 +23288,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22747,6 +23376,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22832,6 +23464,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -22917,6 +23552,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23002,6 +23640,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23087,6 +23728,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23172,6 +23816,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23257,6 +23904,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23342,6 +23992,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23427,6 +24080,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23512,6 +24168,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23597,6 +24256,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23682,6 +24344,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23767,6 +24432,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23852,6 +24520,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -23937,6 +24608,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24022,6 +24696,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24107,6 +24784,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24192,6 +24872,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24279,6 +24962,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24366,6 +25052,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24453,6 +25142,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24540,6 +25232,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24627,6 +25322,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24714,6 +25412,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24801,6 +25502,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24888,6 +25592,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -24975,6 +25682,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25062,6 +25772,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25149,6 +25862,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25236,6 +25952,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25323,6 +26042,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25410,6 +26132,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25497,6 +26222,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25584,6 +26312,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25671,6 +26402,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25758,6 +26492,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25845,6 +26582,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -25932,6 +26672,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26019,6 +26762,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26106,6 +26852,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26193,6 +26942,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26280,6 +27032,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26367,6 +27122,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26454,6 +27212,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26541,6 +27302,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26628,6 +27392,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26715,6 +27482,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26802,6 +27572,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26889,6 +27662,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -26976,6 +27752,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27063,6 +27842,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27150,6 +27932,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27237,6 +28022,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27324,6 +28112,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27411,6 +28202,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27498,6 +28292,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27585,6 +28382,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27672,6 +28472,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27759,6 +28562,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27846,6 +28652,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -27933,6 +28742,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28020,6 +28832,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28107,6 +28922,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28194,6 +29012,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28281,6 +29102,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28368,6 +29192,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28455,6 +29282,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28542,6 +29372,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28629,6 +29462,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28716,6 +29552,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28803,6 +29642,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28890,6 +29732,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -28977,6 +29822,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -29064,6 +29912,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -29151,6 +30002,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -29238,6 +30092,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -29325,6 +30182,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -29412,6 +30272,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -29498,6 +30361,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -29688,6 +30554,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.3.4",
@@ -29897,6 +30766,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.3.5",
@@ -30108,6 +30980,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cisa-scuba": {
           "controlId": "MS.INTUNE.1.2v1"
@@ -30342,6 +31217,9 @@
         "soc2": {
           "controlId": "CC3.3;CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;5.19;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -30576,6 +31454,9 @@
         "soc2": {
           "controlId": "CC3.3;CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;5.19;8.12;8.3"
         }
       },
       "impactRating": {
@@ -30778,6 +31659,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -30980,6 +31864,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -31185,6 +32072,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -31392,6 +32282,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -31595,6 +32488,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -31771,6 +32667,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -31970,6 +32869,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.2;8.3"
         },
         "cis-m365-v6": {
           "controlId": "1.1.1",
@@ -32186,6 +33088,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.2;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "1.1.1",
           "title": "Ensure Administrative accounts are cloud-only",
@@ -32372,6 +33277,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
         },
         "cis-m365-v6": {
           "controlId": "1.1.3",
@@ -32566,6 +33474,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
         },
         "cis-m365-v6": {
           "controlId": "1.1.4",
@@ -32775,6 +33686,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.2.4",
           "title": "Ensure access to the Entra admin center is restricted",
@@ -32961,6 +33875,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.25;8.26;8.3;8.5;8.9"
         },
         "cis-m365-v6": {
           "controlId": "5.1.4.3",
@@ -33150,6 +34067,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.25;8.26;8.3;8.5;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.4.4",
           "title": "Ensure local administrator assignment is limited during Entra join",
@@ -33334,6 +34254,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF6;CC6.1-POF7;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.14;5.15;5.18;8.12;8.2;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.10",
           "title": "Ensure access to APIs by service principals is restricted",
@@ -33517,6 +34440,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF6;CC6.1-POF7;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;5.15;5.18;8.12;8.2;8.3"
         },
         "cis-m365-v6": {
           "controlId": "9.1.10",
@@ -33704,6 +34630,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF6;CC6.1-POF7;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.14;5.15;5.18;8.12;8.2;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.11",
           "title": "Ensure service principals cannot create and use profiles",
@@ -33890,6 +34819,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF6;CC6.1-POF7;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.14;5.15;5.18;8.12;8.2;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.11",
           "title": "Ensure service principals cannot create and use profiles",
@@ -34072,6 +35004,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.17;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -34270,6 +35205,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -34478,6 +35416,9 @@
         "soc2": {
           "controlId": "CC3.3;CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;5.19;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -34676,6 +35617,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -34869,6 +35813,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -35064,6 +36011,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prior to Issuing System Credentials and Granting System Access; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -35089,6 +36039,188 @@
       ],
       "tags": [
         "entra-id",
+        "identification-authentication",
+        "identity"
+      ]
+    },
+    {
+      "checkId": "CA-STALEREF-001",
+      "name": "CA policies reference deleted or invalid groups",
+      "category": "STALEREF",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "scf": {
+        "primaryControlId": "IAC-21.3",
+        "additionalControlIds": [
+          "CFG-03"
+        ],
+        "domain": "Identification & Authentication",
+        "controlName": "Does the organization restrict the assignment of privileged accounts to management-approved personnel and/or roles?",
+        "controlDescription": "Does the organization restrict the assignment of privileged accounts to management-approved personnel and/or roles?",
+        "relativeWeighting": 10,
+        "csfFunction": "Protect",
+        "maturityLevels": {
+          "cmm0_notPerformed": false,
+          "cmm1_informal": false,
+          "cmm2_planned": false,
+          "cmm3_defined": false,
+          "cmm4_controlled": false,
+          "cmm5_improving": false
+        },
+        "assessmentObjectives": [
+          {
+            "aoId": "IAC-21.3_A01",
+            "text": "personnel or roles to which privileged accounts on the system are to be restricted are defined."
+          },
+          {
+            "aoId": "IAC-21.3_A02",
+            "text": "privileged accounts on the system are restricted to <A.03.01.06.ODP[01]: personnel or roles>."
+          }
+        ],
+        "risks": [
+          "R-AC-1",
+          "R-AC-2",
+          "R-AC-3",
+          "R-AC-4",
+          "R-AM-1",
+          "R-AM-2",
+          "R-AM-3",
+          "R-BC-1",
+          "R-BC-2",
+          "R-BC-3",
+          "R-BC-4",
+          "R-BC-5",
+          "R-EX-1",
+          "R-EX-2",
+          "R-EX-3",
+          "R-EX-4",
+          "R-EX-5",
+          "R-EX-6",
+          "R-EX-7",
+          "R-GV-1",
+          "R-GV-2",
+          "R-GV-3",
+          "R-GV-4",
+          "R-GV-5",
+          "R-GV-6",
+          "R-GV-7",
+          "R-GV-8",
+          "R-IR-1",
+          "R-IR-2",
+          "R-IR-3",
+          "R-IR-4",
+          "R-SA-1",
+          "R-SC-1",
+          "R-SC-2",
+          "R-SC-3",
+          "R-SC-4",
+          "R-SC-5",
+          "R-SC-6"
+        ],
+        "threats": [
+          "MT-1",
+          "MT-10",
+          "MT-11",
+          "MT-12",
+          "MT-13",
+          "MT-14",
+          "MT-15",
+          "MT-2",
+          "MT-24",
+          "MT-25",
+          "MT-27",
+          "MT-7",
+          "MT-8",
+          "MT-9",
+          "NT-7"
+        ]
+      },
+      "frameworks": {
+        "cis-controls-v8": {
+          "controlId": "4.0;4.6;4.8;5.4"
+        },
+        "cmmc": {
+          "controlId": "ACL2.-3.1.5;CML2.-3.4.6",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
+        },
+        "essential-eight": {
+          "controlId": "ML1-P4;ML2-P4;ML3-P4"
+        },
+        "fedramp": {
+          "controlId": "AC-06;AC-06(05);CM-07"
+        },
+        "hipaa": {
+          "controlId": "164.308(a)(3)(i);164.312(a)(1)"
+        },
+        "iso-27001": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3;8.9"
+        },
+        "iso-27017": {
+          "controlId": "9.1.1;9.1.2;9.2.1;9.2.2;9.2.3;9.4.1"
+        },
+        "mitre-attack": {
+          "controlId": "T1003;T1003.001;T1003.002;T1003.003;T1003.004;T1003.005;T1003.006;T1003.007;T1003.008;T1005;T1008;T1011;T1011.001;T1020.001;T1021;T1021.001;T1021.002;T1021.003;T1021.004;T1021.005;T1021.006;T1021.007;T1021.008;T1025;T1027;T1036;T1036.003;T1036.005;T1036.007;T1036.008;T1037;T1037.001;T1040;T1041;T1046;T1047;T1048;T1048.001;T1048.002;T1048.003;T1052;T1052.001;T1053;T1053.002;T1053.003;T1053.005;T1053.006;T1053.007;T1055;T1055.001;T1055.002;T1055.003;T1055.004;T1055.005;T1055.008;T1055.009;T1055.011;T1055.012;T1055.013;T1055.014;T1056.003;T1059;T1059.001;T1059.002;T1059.003;T1059.004;T1059.005;T1059.006;T1059.007;T1059.008;T1059.009;T1059.010;T1059.011;T1068;T1070;T1070.001;T1070.002;T1070.003;T1070.007;T1070.008;T1070.009;T1071;T1071.001;T1071.002;T1071.003;T1071.004;T1072;T1078;T1078.001;T1078.002;T1078.003;T1078.004;T1080;T1087;T1087.001;T1087.002;T1087.004;T1090;T1090.001;T1090.002;T1090.003;T1091;T1092;T1095;T1098;T1098.001;T1098.002;T1098.003;T1098.004;T1098.005;T1098.006;T1098.007;T1102;T1102.001;T1102.002;T1102.003;T1104;T1105;T1106;T1110;T1110.001;T1110.002;T1110.003;T1110.004;T1112;T1127;T1127.002;T1129;T1133;T1134;T1134.001;T1134.002;T1134.003;T1134.005;T1135;T1136;T1136.001;T1136.002;T1136.003;T1137;T1137.001;T1137.002;T1137.003;T1137.004;T1137.005;T1137.006;T1176;T1185;T1187;T1189;T1190;T1195;T1195.001;T1195.002;T1197;T1199;T1200;T1203;T1204;T1204.001;T1204.002;T1204.003;T1205;T1205.001;T1210;T1211;T1212;T1213;T1213.001;T1213.002;T1213.003;T1213.004;T1213.005;T1216;T1216.001;T1216.002;T1218;T1218.001;T1218.002;T1218.003;T1218.004;T1218.005;T1218.007;T1218.008;T1218.009;T1218.012;T1218.013;T1218.014;T1218.015;T1219;T1220;T1221;T1222;T1222.001;T1222.002;T1482;T1484;T1485;T1485.001;T1486;T1489;T1490;T1491;T1491.001;T1491.002;T1495;T1498;T1498.001;T1498.002;T1499;T1499.001;T1499.002;T1499.003;T1499.004;T1505;T1505.002;T1505.003;T1505.004;T1505.005;T1525;T1528;T1530;T1537;T1538;T1539;T1542;T1542.001;T1542.003;T1542.004;T1542.005;T1543;T1543.001;T1543.002;T1543.003;T1543.004;T1543.005;T1546;T1546.002;T1546.003;T1546.004;T1546.006;T1546.008;T1546.009;T1546.010;T1546.011;T1546.013;T1546.016;T1547.003;T1547.004;T1547.006;T1547.007;T1547.009;T1547.012;T1547.013;T1548;T1548.001;T1548.002;T1548.003;T1548.004;T1548.005;T1548.006;T1550;T1550.002;T1550.003;T1552;T1552.001;T1552.002;T1552.003;T1552.005;T1552.006;T1552.007;T1553;T1553.001;T1553.003;T1553.004;T1553.005;T1553.006;T1555;T1555.002;T1555.004;T1555.006;T1556;T1556.001;T1556.002;T1556.003;T1556.004;T1556.005;T1556.006;T1556.007;T1556.008;T1556.009;T1557;T1557.001;T1557.002;T1557.003;T1558;T1558.001;T1558.002;T1558.003;T1558.005;T1559;T1559.001;T1559.002;T1559.003;T1561;T1561.001;T1561.002;T1562;T1562.001;T1562.002;T1562.003;T1562.004;T1562.006;T1562.007;T1562.008;T1562.009;T1562.010;T1562.012;T1563;T1563.001;T1563.002;T1564.002;T1564.003;T1564.006;T1564.008;T1564.009;T1565;T1565.003;T1566.003;T1567;T1569;T1569.001;T1569.002;T1570;T1571;T1572;T1573;T1573.001;T1573.002;T1574;T1574.001;T1574.004;T1574.005;T1574.006;T1574.007;T1574.008;T1574.009;T1574.010;T1574.011;T1574.012;T1574.014;T1578;T1578.001;T1578.002;T1578.003;T1578.005;T1580;T1590.002;T1599;T1599.001;T1601;T1601.001;T1601.002;T1602;T1602.001;T1602.002;T1606;T1606.001;T1606.002;T1609;T1610;T1611;T1612;T1613;T1619;T1621;T1622;T1647;T1648;T1651;T1653;T1654;T1657"
+        },
+        "nist-800-171": {
+          "controlId": "3.1.5;3.4.6"
+        },
+        "nist-800-53": {
+          "controlId": "AC-06;AC-06(05);CM-07;SA-08(14)",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High",
+            "Privacy"
+          ]
+        },
+        "nist-csf": {
+          "controlId": "PR.AA-05;PR.DS-10;PR.PS-05",
+          "title": "Access permissions, entitlements, and authorizations are defined in a policy, managed, enforced, and reviewed, and incorporate the principles of least privilege and separation of duties; The confidentiality, integrity, and availability of data-in-use are protected; Installation and execution of unauthorized software are prevented"
+        },
+        "pci-dss": {
+          "controlId": "1.2.5;1.2.6;1.3;1.4;1.4.1;1.4.2;2.2.4;3.4;3.4.2;7.1;7.2;7.2.1;7.2.2;7.2.3;7.2.6;7.3;7.3.1;7.3.2;7.3.3;8.6;8.6.1"
+        },
+        "soc2": {
+          "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.2;8.3;8.9"
+        }
+      },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Conditional Access policies that reference deleted groups silently lose coverage for those conditions, creating unenforced access control gaps that can go undetected in routine audits.",
+        "scfWeighting": 10
+      },
+      "effort": {
+        "complexity": 3,
+        "isPhased": false,
+        "phaseCount": 1,
+        "disruptionRisk": true,
+        "disruptionScope": "user-facing"
+      },
+      "remediation": "Entra admin center > Protection > Conditional Access > Policies. For each policy, review the Users > Include and Exclude conditions and remove any group objects that have been deleted from Entra ID. Ensure every group reference resolves to an active group.",
+      "impact": "A CA policy with all include groups deleted applies to nobody (MFA requirement silently removed for all users), or a policy with exclude groups deleted begins enforcing on users who were previously exempted.",
+      "rationale": "When a group referenced in a CA policy condition is deleted, Entra silently removes it from the condition set. A policy scoped to 'selected groups' with all referenced groups deleted becomes effectively unscoped, applying to all users or nobody — depending on whether it was in Include or Exclude.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/troubleshoot-conditional-access",
+          "title": "Microsoft Learn — Troubleshoot Conditional Access policies"
+        },
+        {
+          "url": "https://maester.dev/docs/tests/EIDSCA",
+          "title": "Maester — MT.1038 CA policy references no deleted groups"
+        }
+      ],
+      "tags": [
+        "conditional-access",
         "identification-authentication",
         "identity"
       ]
@@ -35239,6 +36371,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.17;5.18;8.12;8.2;8.3"
         }
       },
       "impactRating": {
@@ -35422,6 +36557,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.1.6.3",
@@ -35638,6 +36776,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "7.2.5",
           "title": "Ensure that SharePoint guest users cannot share items they don't own",
@@ -35849,6 +36990,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "7.2.6",
@@ -36062,6 +37206,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "7.2.8",
           "title": "Ensure external sharing is restricted by security group",
@@ -36257,6 +37404,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
+        },
         "cisa-scuba": {
           "controlId": "MS.AAD.6.1v1"
         }
@@ -36450,6 +37600,9 @@
         },
         "pci-dss": {
           "controlId": "8.3.4"
+        },
+        "iso-27002": {
+          "controlId": "8.1"
         },
         "eidsca": {
           "controlId": "EIDSCA.PR01;EIDSCA.PR02"
@@ -36685,6 +37838,9 @@
         "soc2": {
           "controlId": "CC6.6;CC6.6-POF2;CC7.2;CC7.2-POF1;CC7.3;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Restriction of Access to System Boundaries; Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "8.1;8.15;8.16"
         }
       },
       "impactRating": {
@@ -37489,6 +38645,9 @@
           "controlId": "CC1.5;CC6.1;CC6.2-POF3;CC7.2;CC7.2-POF2;CC7.2-POF3",
           "title": "COSO Principle 5: Enforces Accountability; Logical Access Security Software, Infrastructure, and Architectures; Monitoring System Components for Anomalies"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;6.5"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.2.6",
           "title": "Enable Identity Protection user risk policies",
@@ -37714,6 +38873,9 @@
           "controlId": "CC1.5;CC6.1;CC6.2-POF3;CC7.2;CC7.2-POF2;CC7.2-POF3",
           "title": "COSO Principle 5: Enforces Accountability; Logical Access Security Software, Infrastructure, and Architectures; Monitoring System Components for Anomalies"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;6.5"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.2.7",
           "title": "Enable Identity Protection sign-in risk policies",
@@ -37935,6 +39097,9 @@
           "controlId": "CC1.5;CC6.1;CC6.2-POF3;CC7.2;CC7.2-POF2;CC7.2-POF3",
           "title": "COSO Principle 5: Enforces Accountability; Logical Access Security Software, Infrastructure, and Architectures; Monitoring System Components for Anomalies"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;6.5"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.2.8",
           "title": "Ensure 'sign-in risk' is blocked for medium and high risk",
@@ -38126,6 +39291,9 @@
         "soc2": {
           "controlId": "CC5.1;CC5.1-POF6",
           "title": "COSO Principle 10: Selects and Develops Control Activities"
+        },
+        "iso-27002": {
+          "controlId": "5.18;5.3"
         }
       },
       "impactRating": {
@@ -38369,6 +39537,9 @@
         "soc2": {
           "controlId": "CC1.4-POF7;CC2.2-POF12;CC2.2-POF8"
         },
+        "iso-27002": {
+          "controlId": "6.3;7.4;7.4(a);7.4(b);7.4(c);7.4(d)"
+        },
         "cis-m365-v6": {
           "controlId": "6.5.2",
           "title": "Ensure MailTips are enabled for end users",
@@ -38586,6 +39757,9 @@
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC6.1-POF1;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "5.9;8.12;8.25;8.26;8.3;8.5;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "4.1",
           "title": "Ensure devices without a compliance policy are marked 'not compliant'",
@@ -38801,6 +39975,9 @@
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC6.1;CC6.1-POF1;CC6.1-POF3;CC6.1-POF8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.16;5.9"
+        },
         "cis-m365-v6": {
           "controlId": "6.3"
         }
@@ -39000,6 +40177,9 @@
         },
         "soc2": {
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC6.1-POF1"
+        },
+        "iso-27002": {
+          "controlId": "5.9"
         }
       },
       "impactRating": {
@@ -39181,6 +40361,9 @@
         },
         "soc2": {
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC6.1-POF1"
+        },
+        "iso-27002": {
+          "controlId": "5.9;8.9"
         }
       },
       "impactRating": {
@@ -39362,6 +40545,9 @@
         },
         "soc2": {
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC6.1-POF1"
+        },
+        "iso-27002": {
+          "controlId": "5.9;8.9"
         }
       },
       "impactRating": {
@@ -39583,6 +40769,9 @@
         "soc2": {
           "controlId": "A1.2-POF7;C1.1;C1.1-POF2;CC2.1;CC6.1;CC6.5;CC6.7;CC6.7-POF2;CC8.1-POF16;CC8.1-POF17;PI1.4-POF1;PI1.4-POF2;PI1.4-POF3;PI1.4-POF4;PI1.5;PI1.5-POF1;PI1.5-POF2;PI1.5-POF3;PI1.5-POF4",
           "title": "COSO Principle 13: Obtains or Generates Relevant Information; Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "5.1;5.12;5.15;5.18;5.33;5.9;7.1;8.12;8.2"
         }
       },
       "impactRating": {
@@ -39791,6 +40980,9 @@
         "soc2": {
           "controlId": "C1.1;CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "7.1;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -39953,6 +41145,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "5.1;5.13;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -40186,6 +41381,9 @@
         "soc2": {
           "controlId": "A1.2-POF7;C1.1;C1.1-POF2;CC2.1;CC6.1;CC6.5;CC6.7;CC6.7-POF2;CC8.1-POF16;CC8.1-POF17;PI1.4-POF1;PI1.4-POF2;PI1.4-POF3;PI1.4-POF4;PI1.5;PI1.5-POF1;PI1.5-POF2;PI1.5-POF3;PI1.5-POF4",
           "title": "COSO Principle 13: Obtains or Generates Relevant Information; Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "5.1;5.12;5.15;5.18;5.33;5.9;7.1;8.12;8.2"
         }
       },
       "impactRating": {
@@ -40354,6 +41552,9 @@
         "soc2": {
           "controlId": "CC6.7",
           "title": "Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "7.1"
         }
       },
       "impactRating": {
@@ -40595,6 +41796,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF8;CC6.7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "5.16"
         },
         "cis-m365-v6": {
           "controlId": "5.2.2.9",
@@ -40851,6 +42055,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF3;CC6.1-POF8;CC6.7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "5.16"
         },
         "cis-m365-v6": {
           "controlId": "5.2.2.10",
@@ -41236,6 +42443,9 @@
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;CC6.7;P6.1;P6.1-POF1;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Data Transmission and Movement Restriction"
         },
+        "iso-27002": {
+          "controlId": "5.14;5.18;5.33"
+        },
         "cis-m365-v6": {
           "controlId": "7.2.9",
           "title": "Ensure guest access to a site or OneDrive will expire automatically",
@@ -41441,6 +42651,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;CC6.7;P6.1;P6.1-POF1;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "5.14;5.18;5.33"
         },
         "cis-m365-v6": {
           "controlId": "8.5.6",
@@ -41679,6 +42892,9 @@
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.18"
+        },
         "cis-m365-v6": {
           "controlId": "3.6.1",
           "profiles": [
@@ -41916,6 +43132,9 @@
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.18"
+        },
         "cis-m365-v6": {
           "controlId": "3.6.1",
           "profiles": [
@@ -42152,6 +43371,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.18"
         }
       },
       "impactRating": {
@@ -42379,6 +43601,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.2;8.21"
         },
         "nist-csf": {
           "controlId": "GV.SC-07",
@@ -42738,6 +43963,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC7.2;CC7.3;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;6.8;8.12;8.15;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -42880,6 +44108,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -42969,6 +44200,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43059,6 +44293,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43148,6 +44385,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43238,6 +44478,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43327,6 +44570,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43416,6 +44662,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43506,6 +44755,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43596,6 +44848,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43686,6 +44941,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43776,6 +45034,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43866,6 +45127,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -43956,6 +45220,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44046,6 +45313,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44136,6 +45406,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44226,6 +45499,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44316,6 +45592,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44406,6 +45685,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44496,6 +45778,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44586,6 +45871,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44676,6 +45964,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44766,6 +46057,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44856,6 +46150,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -44946,6 +46243,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45036,6 +46336,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45126,6 +46429,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45218,6 +46524,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45309,6 +46618,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45400,6 +46712,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45491,6 +46806,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45582,6 +46900,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45673,6 +46994,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45764,6 +47088,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45855,6 +47182,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -45945,6 +47275,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46035,6 +47368,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46125,6 +47461,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46215,6 +47554,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46306,6 +47648,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46397,6 +47742,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46488,6 +47836,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46579,6 +47930,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46669,6 +48023,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46759,6 +48116,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46849,6 +48209,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -46940,6 +48303,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47031,6 +48397,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47121,6 +48490,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47212,6 +48584,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47303,6 +48678,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47393,6 +48771,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47484,6 +48865,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47575,6 +48959,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47666,6 +49053,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47756,6 +49146,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47847,6 +49240,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -47937,6 +49333,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48028,6 +49427,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48118,6 +49520,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48208,6 +49613,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48299,6 +49707,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48390,6 +49801,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48481,6 +49895,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48572,6 +49989,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48662,6 +50082,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48752,6 +50175,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48843,6 +50269,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -48934,6 +50363,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49025,6 +50457,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49116,6 +50551,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49207,6 +50645,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49298,6 +50739,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49389,6 +50833,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49480,6 +50927,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49571,6 +51021,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49662,6 +51115,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49753,6 +51209,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49844,6 +51303,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -49934,6 +51396,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50024,6 +51489,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50114,6 +51582,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50205,6 +51676,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50295,6 +51769,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50385,6 +51862,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50476,6 +51956,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50566,6 +52049,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50656,6 +52142,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50746,6 +52235,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50836,6 +52328,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -50926,6 +52421,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51016,6 +52514,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51106,6 +52607,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51196,6 +52700,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51286,6 +52793,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51376,6 +52886,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51466,6 +52979,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51556,6 +53072,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51647,6 +53166,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51738,6 +53260,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51829,6 +53354,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -51920,6 +53448,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52010,6 +53541,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52100,6 +53634,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52191,6 +53728,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52281,6 +53821,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52371,6 +53914,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52461,6 +54007,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52551,6 +54100,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52641,6 +54193,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52731,6 +54286,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52822,6 +54380,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -52913,6 +54474,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53004,6 +54568,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53095,6 +54662,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53185,6 +54755,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53275,6 +54848,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53365,6 +54941,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53455,6 +55034,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53545,6 +55127,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53635,6 +55220,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53725,6 +55313,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53816,6 +55407,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53907,6 +55501,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -53998,6 +55595,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54089,6 +55689,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54179,6 +55782,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54269,6 +55875,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54359,6 +55968,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54450,6 +56062,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54541,6 +56156,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54631,6 +56249,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54722,6 +56343,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54812,6 +56436,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54902,6 +56529,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -54992,6 +56622,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55082,6 +56715,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55172,6 +56808,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55262,6 +56901,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55352,6 +56994,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55442,6 +57087,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55532,6 +57180,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55622,6 +57273,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55712,6 +57366,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55802,6 +57459,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55892,6 +57552,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -55982,6 +57645,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56072,6 +57738,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56162,6 +57831,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56252,6 +57924,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56343,6 +58018,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56434,6 +58112,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56524,6 +58205,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56614,6 +58298,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56704,6 +58391,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56794,6 +58484,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56884,6 +58577,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -56974,6 +58670,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57064,6 +58763,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57154,6 +58856,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57244,6 +58949,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57334,6 +59042,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57424,6 +59135,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57514,6 +59228,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57604,6 +59321,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57694,6 +59414,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57784,6 +59507,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57874,6 +59600,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -57964,6 +59693,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58054,6 +59786,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58144,6 +59879,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58234,6 +59972,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58324,6 +60065,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58415,6 +60159,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58505,6 +60252,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58596,6 +60346,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58686,6 +60439,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58777,6 +60533,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58867,6 +60626,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -58958,6 +60720,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -59048,6 +60813,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -59138,6 +60906,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -59228,6 +60999,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -59318,6 +61092,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -59408,6 +61185,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -59597,6 +61377,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC7.2;CC8.1;CC8.1-POF11;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Monitoring System Components for Anomalies; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -59800,6 +61583,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         },
         "cis-m365-v6": {
           "controlId": "2.1.15",
@@ -60035,6 +61821,9 @@
           "controlId": "CC6.1;CC6.1-POF7;CC6.6-POF3;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.12;8.25;8.26;8.3;8.5;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.2.1",
           "title": "Ensure 'Per-user MFA' is disabled",
@@ -60248,6 +62037,9 @@
           "controlId": "CC6.1;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.12;8.25;8.26;8.3;8.5;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.4.5",
           "title": "Ensure Local Administrator Password Solution is enabled",
@@ -60460,6 +62252,9 @@
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "6.1"
         }
@@ -60667,6 +62462,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -60874,6 +62672,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -61077,6 +62878,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.12;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -61295,6 +63099,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1;CC6.8-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.19;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "1.3.4",
@@ -61529,6 +63336,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "1.3.7",
@@ -61771,6 +63581,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
         },
+        "iso-27002": {
+          "controlId": "8.1;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "4.2",
           "title": "Ensure device enrollment for personally owned devices is blocked by default",
@@ -61994,6 +63807,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "5.1.2.6",
@@ -62238,6 +64054,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF7;CC6.6;CC6.6-POF2;CC6.7-POF1;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.18;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.4.1",
           "title": "Ensure the ability to join devices to Entra is restricted",
@@ -62461,6 +64280,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "5.2.2.3",
@@ -62688,6 +64510,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "5.2.2.3",
@@ -62919,6 +64744,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.2.12",
           "title": "Ensure the device code sign-in flow is blocked",
@@ -63149,6 +64977,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "5.2.3.5",
@@ -63387,6 +65218,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "5.2.3.7",
           "title": "Ensure the email OTP authentication method is disabled",
@@ -63618,6 +65452,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1;CC6.8-POF1"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.19;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "6.3.1",
           "title": "Ensure users installing Outlook add-ins is not allowed",
@@ -63841,6 +65678,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "6.5.1",
@@ -64072,6 +65912,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "6.5.3",
           "title": "Ensure additional storage providers are restricted in Outlook on the web",
@@ -64290,6 +66133,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "6.5.4",
@@ -64534,6 +66380,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF3;CC6.1-POF4;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.16;8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "7.2.1",
@@ -64780,6 +66629,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
         },
+        "iso-27002": {
+          "controlId": "8.1;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "7.3.2",
           "title": "Ensure OneDrive sync is restricted for unmanaged devices",
@@ -65007,6 +66859,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1;CC6.8-POF1"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.19;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "7.3.3"
         }
@@ -65228,6 +67083,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1;CC6.8-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.19;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "7.3.4"
@@ -65453,6 +67311,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "8.1.1",
@@ -65683,6 +67544,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "8.2.2",
           "title": "Ensure communication with unmanaged Teams users is disabled",
@@ -65906,6 +67770,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "8.2.3",
           "title": "Ensure external Teams users cannot initiate conversations",
@@ -66124,6 +67991,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "8.2.4",
@@ -66355,6 +68225,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "8.5.8",
           "title": "Ensure external meeting chat is off",
@@ -66574,6 +68447,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "8.5.9",
@@ -66812,6 +68688,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.1",
           "title": "Ensure guest user access is restricted",
@@ -67044,6 +68923,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "9.1.1",
@@ -67278,6 +69160,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.2",
           "title": "Ensure external user invitations are restricted",
@@ -67510,6 +69395,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "9.1.2",
@@ -67744,6 +69632,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.3",
           "title": "Ensure guest access to content is restricted",
@@ -67977,6 +69868,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.3",
           "title": "Ensure guest access to content is restricted",
@@ -68206,6 +70100,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "9.1.4",
@@ -68437,6 +70334,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "9.1.4",
@@ -68700,6 +70600,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC5.2-POF3;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.7;8.8;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.5",
           "title": "Ensure 'Interact with and share R and Python' visuals is 'Disabled'",
@@ -68962,6 +70865,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC5.2-POF3;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.7;8.8;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.5",
           "title": "Ensure 'Interact with and share R and Python' visuals is 'Disabled'",
@@ -69191,6 +71097,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "9.1.8",
@@ -69423,6 +71332,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.8",
           "title": "Ensure enabling of external data sharing is restricted",
@@ -69651,6 +71563,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.12;8.3;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.9",
           "title": "Ensure 'Block ResourceKey Authentication' is 'Enabled'",
@@ -69877,6 +71792,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF7;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18;8.12;8.3;8.9"
         },
         "cis-m365-v6": {
           "controlId": "9.1.9",
@@ -70132,6 +72050,9 @@
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.2;CC6.2-POF1;CC6.2-POF3;CC6.3-POF1;CC6.3-POF2;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6",
           "title": "Prior to Issuing System Credentials and Granting System Access; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "5.16;5.18;8.12;8.25;8.26;8.3;8.5;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.12",
           "title": "Ensure service principals ability to create workspaces, connections and deployment pipelines is restricted",
@@ -70356,6 +72277,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         },
         "cisa-scuba": {
           "controlId": "MS.AAD.5.3v1"
@@ -70609,6 +72533,9 @@
         },
         "soc2": {
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC5.2-POF3;CC6.1-POF1;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "5.9;8.12;8.3;8.9"
         }
       },
       "impactRating": {
@@ -70850,6 +72777,9 @@
         },
         "soc2": {
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC5.2-POF3;CC6.1-POF1;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "5.9;8.12;8.3;8.9"
         }
       },
       "impactRating": {
@@ -71091,6 +73021,9 @@
         },
         "soc2": {
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC5.2-POF3;CC6.1-POF1;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "5.9;8.12;8.3;8.9"
         }
       },
       "impactRating": {
@@ -71302,6 +73235,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         }
       },
       "impactRating": {
@@ -71555,6 +73491,9 @@
         "soc2": {
           "controlId": "CC3.3;CC5.2-POF3;CC6.1;CC6.1-POF7;CC6.7-POF1",
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.18;5.19;8.12;8.3;8.9"
         }
       },
       "impactRating": {
@@ -71728,6 +73667,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.27;8.3;8.8;8.9"
         }
       },
       "impactRating": {
@@ -71878,6 +73820,9 @@
         },
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1-POF7;CC6.7-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.3;8.9"
         }
       },
       "impactRating": {
@@ -72055,6 +74000,9 @@
         },
         "soc2": {
           "controlId": "CC6.8-POF1"
+        },
+        "iso-27002": {
+          "controlId": "8.19"
         },
         "cis-m365-v6": {
           "controlId": "8.4.1",
@@ -72267,6 +74215,9 @@
         "soc2": {
           "controlId": "CC6.6-POF3;CC7.2;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15"
         }
       },
       "impactRating": {
@@ -72529,6 +74480,9 @@
         "soc2": {
           "controlId": "C1.2;CC2.2-POF13;CC3.4;CC3.4-POF4;CC6.8-POF3;CC8.1;CC8.1-POF1;CC8.1-POF10;CC8.1-POF11;CC8.1-POF13;CC8.1-POF14;CC8.1-POF16;CC8.1-POF2;CC8.1-POF3;CC8.1-POF4;CC8.1-POF5;CC8.1-POF6;CC8.1-POF7;CC8.1-POF8;CC8.1-POF9",
           "title": "COSO Principle 9: Identifies and Analyzes Changes; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "6.3;8.19;8.32"
         }
       },
       "impactRating": {
@@ -72713,6 +74667,9 @@
         "soc2": {
           "controlId": "CC3.4;CC3.4-POF4;CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC8.1-POF10;CC8.1-POF3",
           "title": "COSO Principle 9: Identifies and Analyzes Changes; Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.1.5.2",
@@ -72914,6 +74871,9 @@
         "soc2": {
           "controlId": "CC6.1;CC8.1-POF10;CC8.1-POF11;CC8.1-POF2;CC8.1-POF9",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.18;5.3"
         },
         "cisa-scuba": {
           "controlId": "MS.INTUNE.1.1v1"
@@ -73254,6 +75214,9 @@
         "soc2": {
           "controlId": "CC2.3;CC7.2;CC7.2-POF1;CC7.3;CC7.4",
           "title": "COSO Principle 15: External Communication; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Response to Identified Security Incidents"
+        },
+        "iso-27002": {
+          "controlId": "8.15;8.16"
         }
       },
       "impactRating": {
@@ -73480,6 +75443,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.8;CC6.8-POF4;CC7.2;CC7.2-POF1;CC7.2-POF2;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software; Monitoring System Components for Anomalies"
         },
+        "iso-27002": {
+          "controlId": "8.15;8.16;8.7;8.8"
+        },
         "cis-m365-v6": {
           "controlId": "2.1.3",
           "title": "Ensure notifications for internal users sending malware is Enabled",
@@ -73682,6 +75648,9 @@
           "controlId": "CC7.2;CC7.2-POF1;CC7.2-POF2",
           "title": "Monitoring System Components for Anomalies"
         },
+        "iso-27002": {
+          "controlId": "8.15;8.16"
+        },
         "cis-m365-v6": {
           "controlId": "2.1.10",
           "title": "Ensure DMARC Records for all Exchange Online domains are published",
@@ -73879,6 +75848,9 @@
           "controlId": "CC7.2;CC7.2-POF1;CC7.2-POF2",
           "title": "Monitoring System Components for Anomalies"
         },
+        "iso-27002": {
+          "controlId": "8.15;8.16"
+        },
         "cis-m365-v6": {
           "controlId": "2.4.3",
           "title": "Ensure Microsoft Defender for Cloud Apps is enabled and configured",
@@ -74074,6 +76046,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.2-POF2",
           "title": "Monitoring System Components for Anomalies"
+        },
+        "iso-27002": {
+          "controlId": "8.15;8.16"
         },
         "cis-m365-v6": {
           "controlId": "8.6.1",
@@ -74312,6 +76287,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC7.2;CC7.2-POF1;CC7.2-POF4;CC7.3;CC8.1;CC8.1-POF12;CC8.1-POF6;PI1.4",
           "title": "Detection and Monitoring of New Vulnerabilities; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.15;8.16;8.25;8.26;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -74403,6 +76381,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -74482,6 +76463,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -74561,6 +76545,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -74640,6 +76627,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -74719,6 +76709,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -74798,6 +76791,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -74877,6 +76873,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -74956,6 +76955,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75035,6 +77037,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75114,6 +77119,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75193,6 +77201,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75272,6 +77283,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75351,6 +77365,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75431,6 +77448,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75511,6 +77531,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75591,6 +77614,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75671,6 +77697,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75751,6 +77780,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75831,6 +77863,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75910,6 +77945,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -75989,6 +78027,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76068,6 +78109,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76147,6 +78191,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76227,6 +78274,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76306,6 +78356,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76385,6 +78438,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76464,6 +78520,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76543,6 +78602,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76623,6 +78685,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76702,6 +78767,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76781,6 +78849,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76862,6 +78933,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -76943,6 +79017,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77024,6 +79101,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77105,6 +79185,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77186,6 +79269,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77267,6 +79353,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77348,6 +79437,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77429,6 +79521,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77510,6 +79605,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77591,6 +79689,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77672,6 +79773,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77753,6 +79857,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77834,6 +79941,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77915,6 +80025,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -77996,6 +80109,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78077,6 +80193,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78158,6 +80277,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78239,6 +80361,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78320,6 +80445,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78401,6 +80529,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78482,6 +80613,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78563,6 +80697,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78644,6 +80781,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78725,6 +80865,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78806,6 +80949,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78887,6 +81033,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -78968,6 +81117,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79049,6 +81201,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79130,6 +81285,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79211,6 +81369,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79292,6 +81453,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79373,6 +81537,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79454,6 +81621,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79535,6 +81705,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79616,6 +81789,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79697,6 +81873,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79778,6 +81957,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79858,6 +82040,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -79938,6 +82123,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80018,6 +82206,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80098,6 +82289,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80178,6 +82372,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80258,6 +82455,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80338,6 +82538,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80418,6 +82621,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80498,6 +82704,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80578,6 +82787,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80658,6 +82870,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80738,6 +82953,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80818,6 +83036,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80898,6 +83119,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -80978,6 +83202,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81058,6 +83285,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81138,6 +83368,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81218,6 +83451,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81298,6 +83534,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81378,6 +83617,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81458,6 +83700,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81538,6 +83783,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81618,6 +83866,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -81823,6 +84074,9 @@
         "soc2": {
           "controlId": "CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC7.2;CC7.2-POF1;CC7.2-POF4;CC7.3;CC8.1;CC8.1-POF12;CC8.1-POF6;PI1.4",
           "title": "Detection and Monitoring of New Vulnerabilities; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.15;8.16;8.25;8.26;8.3;8.5;8.9"
         },
         "cis-m365-v6": {
           "controlId": "5.3"
@@ -82047,6 +84301,9 @@
           "controlId": "A1.2-POF5;CC2.2-POF10;CC2.2-POF3;CC2.2-POF4;CC2.2-POF6;CC2.3;CC2.3-POF1;CC2.3-POF8;CC3.1-POF10;CC7.2;CC7.2-POF1;CC7.3;CC7.3-POF1;CC7.3-POF2;CC7.3-POF3;CC7.3-POF4;CC7.3-POF5;CC7.3-POF6;CC7.3-POF7;CC7.4;CC7.4-POF1;CC7.4-POF10;CC7.4-POF11;CC7.4-POF12;CC7.4-POF13;CC7.4-POF2;CC7.4-POF3;CC7.4-POF4;CC7.4-POF5;CC7.4-POF6;CC7.4-POF7;CC7.4-POF8;CC7.4-POF9;CC7.5-POF2;P6.3;P6.7",
           "title": "COSO Principle 15: External Communication; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Response to Identified Security Incidents"
         },
+        "iso-27002": {
+          "controlId": "5.24;5.25;5.26;5.5;6.8;8.15"
+        },
         "cis-m365-v6": {
           "controlId": "6.1"
         }
@@ -82253,6 +84510,9 @@
         "soc2": {
           "controlId": "CC2.2-POF6;CC2.3-POF8;CC7.2;CC7.2-POF1;CC7.3;CC7.3-POF2;CC7.4;CC7.4-POF6;CC7.4-POF9",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Response to Identified Security Incidents"
+        },
+        "iso-27002": {
+          "controlId": "5.25;8.15"
         },
         "cis-m365-v6": {
           "controlId": "5.3.9",
@@ -82483,6 +84743,9 @@
           "controlId": "A1.2-POF5;CC2.2-POF10;CC2.2-POF3;CC2.2-POF6;CC2.3-POF8;CC6.6;CC6.6-POF2;CC7.2;CC7.2-POF1;CC7.3;CC7.3-POF1;CC7.3-POF3;CC7.3-POF4;CC7.3-POF5;CC7.3-POF6;CC7.3-POF7;CC7.4;CC7.4-POF1;CC7.4-POF10;CC7.4-POF11;CC7.4-POF12;CC7.4-POF13;CC7.4-POF2;CC7.4-POF3;CC7.4-POF4;CC7.4-POF5;CC7.4-POF6;CC7.4-POF7;CC7.4-POF8;CC7.4-POF9;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Restriction of Access to System Boundaries; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Response to Identified Security Incidents"
         },
+        "iso-27002": {
+          "controlId": "5.24;5.25;5.26;6.8;8.15;8.16"
+        },
         "cisa-scuba": {
           "controlId": "MS.INTUNE.1.3v1"
         }
@@ -82626,6 +84889,9 @@
         },
         "soc2": {
           "controlId": "PI1.4"
+        },
+        "iso-27002": {
+          "controlId": "8.15"
         }
       },
       "impactRating": {
@@ -82819,6 +85085,9 @@
         "soc2": {
           "controlId": "CC6.1;CC7.2;CC7.3;CC7.5;CC7.5-POF4;CC7.5-POF5",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Monitoring System Components for Anomalies; Evaluation of Identified Security Events; Identification of Recovery from Identified Security Incidents"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.16;5.18;6.8;8.15"
         },
         "cis-m365-v6": {
           "controlId": "2.2.1",
@@ -83015,6 +85284,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15"
         },
         "cis-m365-v6": {
           "controlId": "3.1.1",
@@ -83214,6 +85486,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15"
         },
         "cis-m365-v6": {
           "controlId": "6.1.1",
@@ -83417,6 +85692,9 @@
           "controlId": "CC7.2;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
         },
+        "iso-27002": {
+          "controlId": "6.8;8.15"
+        },
         "cis-m365-v6": {
           "controlId": "6.1.2",
           "title": "Ensure mailbox audit actions are configured",
@@ -83617,6 +85895,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15"
         },
         "cis-m365-v6": {
           "controlId": "6.1.3",
@@ -83826,6 +86107,9 @@
         "soc2": {
           "controlId": "C1.1-POF3;C1.2;C1.2-POF1;C1.2-POF2;CC6.5;CC6.5-POF2;P4.0;P4.2;P4.2-POF1;P4.3;P4.3-POF2;P4.3-POF3;PI1.5"
         },
+        "iso-27002": {
+          "controlId": "5.33;8.1"
+        },
         "cis-m365-v6": {
           "controlId": "5.4"
         }
@@ -84025,6 +86309,9 @@
         },
         "soc2": {
           "controlId": "C1.1-POF3;C1.2;C1.2-POF1;C1.2-POF2;CC6.5;CC6.5-POF2;P4.0;P4.2;P4.2-POF1;P4.3;P4.3-POF2;P4.3-POF3;PI1.5"
+        },
+        "iso-27002": {
+          "controlId": "5.33;8.1"
         }
       },
       "impactRating": {
@@ -84218,6 +86505,9 @@
         },
         "soc2": {
           "controlId": "C1.1-POF3;C1.2;C1.2-POF1;C1.2-POF2;CC6.5;CC6.5-POF2;P4.0;P4.2;P4.2-POF1;P4.3;P4.3-POF2;P4.3-POF3;PI1.5"
+        },
+        "iso-27002": {
+          "controlId": "5.33;8.1"
         }
       },
       "impactRating": {
@@ -84415,6 +86705,9 @@
         },
         "soc2": {
           "controlId": "C1.1-POF3;C1.2;C1.2-POF1;C1.2-POF2;CC6.5;CC6.5-POF2;P4.0;P4.2;P4.2-POF1;P4.3;P4.3-POF2;P4.3-POF3;PI1.5"
+        },
+        "iso-27002": {
+          "controlId": "5.33;8.1"
         }
       },
       "impactRating": {
@@ -84772,6 +87065,9 @@
         "soc2": {
           "controlId": "CC5.2;CC6.1-POF7;CC6.7-POF1;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF6;PI1.1-POF1;PI1.1-POF2;PI1.1-POF3",
           "title": "COSO Principle 11: Selects and Develops General Controls over Technology; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.29;8.3;8.5;8.9"
         }
       },
       "impactRating": {
@@ -85002,6 +87298,9 @@
           "controlId": "CC3.3;CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.8-POF1",
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;5.19;8.12;8.19;8.3"
+        },
         "eidsca": {
           "controlId": "EIDSCA.AP09;EIDSCA.CP04"
         }
@@ -85229,6 +87528,9 @@
         "soc2": {
           "controlId": "C1.1;CC3.3;CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;P6.0;P6.1-POF2;P6.1-POF3;P6.1-POF4;P6.4-POF1",
           "title": "COSO Principle 8: Assesses Fraud Risk; Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;5.19;7.1;8.12;8.3"
         }
       },
       "impactRating": {
@@ -85365,6 +87667,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -85447,6 +87752,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -85530,6 +87838,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -85613,6 +87924,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -85696,6 +88010,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -85779,6 +88096,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -85862,6 +88182,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -85945,6 +88268,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -86130,6 +88456,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21;8.3"
         }
       },
       "impactRating": {
@@ -86151,6 +88480,188 @@
         {
           "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/location-condition",
           "title": "Microsoft Learn — Location condition in Conditional Access"
+        }
+      ],
+      "tags": [
+        "conditional-access",
+        "identity",
+        "network-security"
+      ]
+    },
+    {
+      "checkId": "CA-NAMEDLOC-002",
+      "name": "CA policies reference stale or deleted named locations",
+      "category": "NAMEDLOC",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": {
+        "minimum": "E3"
+      },
+      "scf": {
+        "primaryControlId": "NET-01.1",
+        "additionalControlIds": [
+          "CFG-03"
+        ],
+        "domain": "Network Security",
+        "controlName": "Does the organization treat all users and devices as potential threats and prevent access to data and resources until the users can be properly authenticated and their access authorized?",
+        "controlDescription": "Does the organization treat all users and devices as potential threats and prevent access to data and resources until the users can be properly authenticated and their access authorized?",
+        "relativeWeighting": 8,
+        "csfFunction": "Protect",
+        "maturityLevels": {
+          "cmm0_notPerformed": false,
+          "cmm1_informal": false,
+          "cmm2_planned": false,
+          "cmm3_defined": false,
+          "cmm4_controlled": false,
+          "cmm5_improving": false
+        },
+        "assessmentObjectives": [
+          {
+            "aoId": "NET-01.1_A01",
+            "text": "all users are treated as potential threats and prevent access to data and resources until the user can be properly authenticated and their access authorized."
+          },
+          {
+            "aoId": "NET-01.1_A02",
+            "text": "all devices are treated as potential threats and prevent access to data and resources until the device can be properly authenticated and its access authorized."
+          }
+        ],
+        "risks": [
+          "R-AC-1",
+          "R-AC-2",
+          "R-AC-3",
+          "R-AC-4",
+          "R-AM-1",
+          "R-AM-2",
+          "R-AM-3",
+          "R-BC-1",
+          "R-BC-2",
+          "R-BC-3",
+          "R-BC-4",
+          "R-BC-5",
+          "R-EX-1",
+          "R-EX-2",
+          "R-EX-3",
+          "R-EX-4",
+          "R-EX-5",
+          "R-EX-6",
+          "R-EX-7",
+          "R-GV-1",
+          "R-GV-2",
+          "R-GV-3",
+          "R-GV-4",
+          "R-GV-5",
+          "R-GV-6",
+          "R-GV-7",
+          "R-GV-8",
+          "R-IR-1",
+          "R-IR-2",
+          "R-IR-3",
+          "R-IR-4",
+          "R-SA-1",
+          "R-SC-1",
+          "R-SC-2",
+          "R-SC-3",
+          "R-SC-4",
+          "R-SC-5",
+          "R-SC-6"
+        ],
+        "threats": [
+          "MT-1",
+          "MT-10",
+          "MT-11",
+          "MT-12",
+          "MT-13",
+          "MT-14",
+          "MT-15",
+          "MT-2",
+          "MT-24",
+          "MT-25",
+          "MT-27",
+          "MT-7",
+          "MT-8",
+          "MT-9",
+          "NT-7"
+        ]
+      },
+      "frameworks": {
+        "cis-controls-v8": {
+          "controlId": "12.0;12.1;12.2;12.3;12.6;13.5;4.0;4.6;4.8"
+        },
+        "cmmc": {
+          "controlId": "CML2.-3.4.6;SC.L1-B.1.X;SCL2.-3.13.1",
+          "profiles": [
+            "L1",
+            "L2"
+          ]
+        },
+        "fedramp": {
+          "controlId": "CM-07;SC-01"
+        },
+        "hipaa": {
+          "controlId": "164.312(e)(1);164.312(e)(2)(i)"
+        },
+        "iso-27001": {
+          "controlId": "5.14;8.12;8.2;8.21;8.3;8.9"
+        },
+        "iso-27017": {
+          "controlId": "13.1.1;13.1.2;13.2.1;9.4.1"
+        },
+        "mitre-attack": {
+          "controlId": "T1003;T1003.001;T1003.002;T1003.005;T1008;T1011;T1011.001;T1020.001;T1021;T1021.001;T1021.002;T1021.003;T1021.005;T1021.006;T1021.008;T1027;T1036;T1036.005;T1036.007;T1036.008;T1037;T1037.001;T1040;T1046;T1047;T1048;T1048.001;T1048.002;T1048.003;T1052;T1052.001;T1053;T1053.002;T1053.005;T1059;T1059.005;T1059.007;T1059.009;T1059.010;T1068;T1071;T1071.001;T1071.002;T1071.003;T1071.004;T1072;T1078;T1078.004;T1080;T1087;T1087.001;T1087.002;T1090;T1090.001;T1090.002;T1090.003;T1092;T1095;T1098;T1098.001;T1098.004;T1098.007;T1102;T1102.001;T1102.002;T1102.003;T1104;T1105;T1106;T1112;T1127;T1127.002;T1129;T1133;T1135;T1136;T1136.002;T1136.003;T1176;T1187;T1190;T1195;T1195.001;T1195.002;T1197;T1199;T1204;T1204.001;T1204.002;T1204.003;T1205;T1205.001;T1210;T1213;T1213.001;T1213.002;T1213.004;T1213.005;T1216;T1216.001;T1216.002;T1218;T1218.001;T1218.002;T1218.003;T1218.004;T1218.005;T1218.007;T1218.008;T1218.009;T1218.012;T1218.013;T1218.014;T1218.015;T1219;T1220;T1221;T1482;T1484;T1489;T1490;T1498;T1498.001;T1498.002;T1499;T1499.001;T1499.002;T1499.003;T1499.004;T1505.004;T1525;T1530;T1537;T1542.004;T1542.005;T1543;T1546.002;T1546.006;T1546.008;T1546.009;T1546.010;T1547.004;T1547.006;T1547.007;T1547.009;T1548;T1548.001;T1548.003;T1548.004;T1548.006;T1552;T1552.003;T1552.005;T1552.007;T1553;T1553.001;T1553.003;T1553.004;T1553.005;T1553.006;T1555.004;T1555.006;T1556;T1556.002;T1556.008;T1556.009;T1557;T1557.001;T1557.002;T1557.003;T1559;T1559.002;T1559.003;T1562;T1562.001;T1562.002;T1562.003;T1562.004;T1562.006;T1562.009;T1562.010;T1563;T1563.001;T1563.002;T1564.002;T1564.003;T1564.006;T1564.008;T1564.009;T1565;T1565.003;T1569;T1569.002;T1570;T1571;T1572;T1573;T1573.001;T1573.002;T1574;T1574.001;T1574.006;T1574.007;T1574.008;T1574.009;T1574.012;T1574.014;T1590.002;T1599;T1599.001;T1601;T1601.001;T1601.002;T1602;T1602.001;T1602.002;T1609;T1610;T1611;T1612;T1613;T1622;T1647;T1648;T1653"
+        },
+        "nis2": {
+          "controlId": "Article 21.2(e);Article 21.5"
+        },
+        "nist-800-171": {
+          "controlId": "3.13.1;3.4.6;NFO - SC-1"
+        },
+        "nist-800-53": {
+          "controlId": "CM-07;SC-01",
+          "profiles": [
+            "Low",
+            "Moderate",
+            "High",
+            "Privacy"
+          ]
+        },
+        "nist-csf": {
+          "controlId": "PR.IR-01;PR.PS-05",
+          "title": "Networks and environments are protected from unauthorized logical access and usage; Installation and execution of unauthorized software are prevented"
+        },
+        "pci-dss": {
+          "controlId": "1.1;1.2;1.2.5;1.2.6;1.4;1.4.1;1.4.2;11.2.1;2.2.4"
+        },
+        "soc2": {
+          "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF5;CC6.1-POF7;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1",
+          "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21;8.3;8.9"
+        }
+      },
+      "impactRating": {
+        "severity": "Medium",
+        "rationale": "Failure to treat all users and devices as potential threats by maintaining accurate network location definitions in Conditional Access policies can allow or block access unintentionally, undermining the intended security posture.",
+        "scfWeighting": 8
+      },
+      "effort": {
+        "complexity": 3,
+        "isPhased": false,
+        "phaseCount": 1,
+        "disruptionRisk": true,
+        "disruptionScope": "user-facing"
+      },
+      "remediation": "Entra admin center > Protection > Conditional Access > Named locations. Identify and remove named location objects that are no longer in use. Review each CA policy that references named locations and remove or replace stale location references.",
+      "impact": "A CA policy targeting a now-deleted named location applies to no locations at all, potentially allowing access from locations that should be blocked or applying MFA requirements in unintended ways.",
+      "rationale": "CA policies that reference named locations no longer present in Entra will silently drop that condition — the 'selected locations' include becomes empty, causing the policy to behave unexpectedly. This is a configuration hygiene issue that can silently widen or break policy scope.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/location-condition",
+          "title": "Microsoft Learn — Location condition in Conditional Access"
+        },
+        {
+          "url": "https://maester.dev/docs/tests/EIDSCA",
+          "title": "Maester — MT.1066 CA policy references valid named locations"
         }
       ],
       "tags": [
@@ -86494,6 +89005,9 @@
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "5.18;8.12;8.2;8.21"
+        },
         "cis-m365-v6": {
           "controlId": "1.3.3",
           "title": "Ensure 'External sharing' of calendars is not available",
@@ -86696,6 +89210,9 @@
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "5.18;8.12;8.2;8.21"
+        },
         "cis-m365-v6": {
           "controlId": "1.3.8",
           "title": "Ensure that Sways cannot be shared with people outside of your organization",
@@ -86858,6 +89375,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21"
         },
         "cis-m365-v6": {
           "controlId": "3.2.1",
@@ -87029,6 +89549,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.2;8.21"
         },
         "cis-m365-v6": {
           "controlId": "3.2.2",
@@ -87231,6 +89754,9 @@
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "5.18;8.12;8.2;8.21"
+        },
         "cis-m365-v6": {
           "controlId": "3.3.1",
           "title": "Ensure Information Protection sensitivity label policies are published",
@@ -87421,6 +89947,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.12;8.2;8.21;8.3"
         },
         "cis-m365-v6": {
           "controlId": "8.1.2",
@@ -87621,6 +90150,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "5.18;8.12;8.2;8.21"
         },
         "cis-m365-v6": {
           "controlId": "9.1.6",
@@ -87827,6 +90359,9 @@
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF2;CC6.6-POF3;CC6.6-POF4;CC6.7-POF1;CC6.8;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "5.18;8.12;8.2;8.21"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.6",
           "title": "Ensure 'Allow users to apply sensitivity labels for content' is 'Enabled'",
@@ -88026,6 +90561,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7;CC6.7-POF1;CC6.8;P6.1;P6.1-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Data Transmission and Movement Restriction; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "5.14;5.33;8.12;8.2;8.21"
         },
         "cis-m365-v6": {
           "controlId": "9.1.7",
@@ -88228,6 +90766,9 @@
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7;CC6.7-POF1;CC6.8;P6.1;P6.1-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Data Transmission and Movement Restriction; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "5.14;5.33;8.12;8.2;8.21"
+        },
         "cis-m365-v6": {
           "controlId": "9.1.7",
           "title": "Ensure shareable links are restricted",
@@ -88402,6 +90943,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.7;CC6.7-POF1;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Data Transmission and Movement Restriction; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "7.1;8.12;8.2;8.21"
         }
       },
       "impactRating": {
@@ -88608,6 +91152,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         },
         "cis-m365-v6": {
           "controlId": "2.1.12",
@@ -88825,6 +91372,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         },
         "cis-m365-v6": {
           "controlId": "2.1.13",
@@ -89059,6 +91609,9 @@
           "controlId": "CC6.1;CC6.1-POF5;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.21;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "5.2"
         }
@@ -89267,6 +91820,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         },
         "cis-m365-v6": {
           "controlId": "6.2.1",
@@ -89508,6 +92064,9 @@
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.14;5.18;8.2;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "8.1"
         }
@@ -89736,6 +92295,9 @@
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.14;5.18;8.2;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "8.2"
         }
@@ -89963,6 +92525,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;5.18;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90049,6 +92614,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90125,6 +92693,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90201,6 +92772,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90277,6 +92851,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90353,6 +92930,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90429,6 +93009,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90505,6 +93088,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90581,6 +93167,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90657,6 +93246,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90734,6 +93326,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90811,6 +93406,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90888,6 +93486,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -90965,6 +93566,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91042,6 +93646,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91119,6 +93726,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91196,6 +93806,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91273,6 +93886,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91350,6 +93966,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91426,6 +94045,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91502,6 +94124,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91578,6 +94203,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91654,6 +94282,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91730,6 +94361,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91806,6 +94440,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91882,6 +94519,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -91958,6 +94598,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92034,6 +94677,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92110,6 +94756,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92186,6 +94835,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92262,6 +94914,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92338,6 +94993,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92414,6 +95072,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92490,6 +95151,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92566,6 +95230,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92642,6 +95309,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92718,6 +95388,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92794,6 +95467,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92870,6 +95546,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -92946,6 +95625,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93022,6 +95704,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93098,6 +95783,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93174,6 +95862,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93250,6 +95941,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93326,6 +96020,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93402,6 +96099,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93478,6 +96178,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93554,6 +96257,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93630,6 +96336,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93706,6 +96415,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93782,6 +96494,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93858,6 +96573,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -93934,6 +96652,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94010,6 +96731,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94086,6 +96810,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94162,6 +96889,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94238,6 +96968,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94314,6 +97047,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94390,6 +97126,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94466,6 +97205,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94542,6 +97284,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94618,6 +97363,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.7-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94695,6 +97443,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94770,6 +97521,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94845,6 +97599,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94920,6 +97677,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -94995,6 +97755,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95070,6 +97833,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95145,6 +97911,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95220,6 +97989,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95295,6 +98067,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95370,6 +98145,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95445,6 +98223,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95520,6 +98301,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95595,6 +98379,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95670,6 +98457,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95745,6 +98535,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95820,6 +98613,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95895,6 +98691,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -95970,6 +98769,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96045,6 +98847,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96120,6 +98925,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96195,6 +99003,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96270,6 +99081,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96345,6 +99159,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96420,6 +99237,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96495,6 +99315,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96570,6 +99393,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96645,6 +99471,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96720,6 +99549,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF6;CC6.6;CC6.6-POF1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.2;8.3"
         }
       },
       "impactRating": {
@@ -96936,6 +99768,9 @@
         "soc2": {
           "controlId": "CC6.8",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.21"
         }
       },
       "impactRating": {
@@ -97294,6 +100129,9 @@
           "controlId": "CC6.1;CC6.1-POF5;CC6.6;CC6.6-POF1;CC6.6-POF3;CC6.6-POF4;CC6.8",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "6.7;8.2;8.21"
+        },
         "cis-m365-v6": {
           "controlId": "6.5.5",
           "title": "Ensure Direct Send submissions are rejected"
@@ -97502,6 +100340,9 @@
           "controlId": "CC6.6;CC6.6-POF3",
           "title": "Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "6.7"
+        },
         "cis-m365-v6": {
           "controlId": "8.5.7",
           "title": "Ensure external participants can't give or request control",
@@ -97660,6 +100501,9 @@
         "soc2": {
           "controlId": "CC6.6;CC6.6-POF3",
           "title": "Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "6.7"
         }
       },
       "impactRating": {
@@ -97823,6 +100667,9 @@
         "soc2": {
           "controlId": "CC6.1-POF5;CC6.1-POF6;CC6.6;CC6.6-POF3;CC6.6-POF4",
           "title": "Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "6.7"
         }
       },
       "impactRating": {
@@ -97994,6 +100841,9 @@
         "soc2": {
           "controlId": "CC6.6;CC6.6-POF3",
           "title": "Restriction of Access to System Boundaries"
+        },
+        "iso-27002": {
+          "controlId": "6.7"
         }
       },
       "impactRating": {
@@ -98171,6 +101021,9 @@
         },
         "pci-dss": {
           "controlId": "1.3;11.2;11.2.1;11.2.2;2.3;2.3.1;2.3.2;4.2.1"
+        },
+        "iso-27002": {
+          "controlId": "8.21"
         },
         "soc2": {
           "controlId": "CC6.1;CC6.3",
@@ -98364,6 +101217,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.1;8.24;8.5"
         },
         "cis-m365-v6": {
           "controlId": "6.2"
@@ -98561,6 +101417,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.8-POF1;CC8.1-POF2;CC8.1-POF9",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.19;8.3"
         },
         "cis-m365-v6": {
           "controlId": "1.2.1",
@@ -98763,6 +101622,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.8-POF1;CC8.1-POF2;CC8.1-POF9",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.19;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.1.2.2",
@@ -98973,6 +101835,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.8-POF1;CC8.1-POF2;CC8.1-POF9",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.19;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.2.3",
           "title": "Ensure 'Restrict non-admin users from creating tenants' is set to 'Yes'",
@@ -99177,6 +102042,9 @@
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.8-POF1;CC8.1-POF2;CC8.1-POF9",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
         },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.19;8.3"
+        },
         "cis-m365-v6": {
           "controlId": "5.1.3.2",
           "title": "Ensure users cannot create security groups",
@@ -99380,6 +102248,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7;CC6.8-POF1;CC8.1-POF2;CC8.1-POF9",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.19;8.3"
         },
         "cis-m365-v6": {
           "controlId": "5.1.5.1",
@@ -99671,6 +102542,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF14;CC8.1-POF16;CC8.1-POF6;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.7;8.8;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "2.1.1",
           "title": "Ensure Safe Links for Office Applications is Enabled",
@@ -99956,6 +102830,9 @@
         "soc2": {
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF14;CC8.1-POF16;CC8.1-POF6;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.7;8.8;8.9"
         },
         "cis-m365-v6": {
           "controlId": "2.1.2",
@@ -100246,6 +103123,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF14;CC8.1-POF16;CC8.1-POF6;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.7;8.8;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "2.1.4",
           "title": "Ensure Safe Attachments policy is enabled",
@@ -100528,6 +103408,9 @@
         "soc2": {
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7;8.8"
         },
         "cis-m365-v6": {
           "controlId": "2.1.5",
@@ -100813,6 +103696,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF14;CC8.1-POF16;CC8.1-POF6;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.7;8.8;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "2.1.6",
           "title": "Ensure Exchange Online Spam Policies are set to notify administrators",
@@ -101096,6 +103982,9 @@
         "soc2": {
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF14;CC8.1-POF16;CC8.1-POF6;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
+        },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.7;8.8;8.9"
         },
         "cis-m365-v6": {
           "controlId": "2.1.11",
@@ -101381,6 +104270,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF14;CC8.1-POF16;CC8.1-POF6;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.7;8.8;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "2.4.1",
           "title": "Ensure Priority account protection is enabled and configured",
@@ -101665,6 +104557,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.1-POF7;CC6.7-POF1;CC6.8;CC6.8-POF4;CC7.1;CC7.1-POF1;CC8.1;CC8.1-POF12;CC8.1-POF14;CC8.1-POF16;CC8.1-POF6;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software; Detection and Monitoring of New Vulnerabilities; Changes to Infrastructure, Data, Software, and Procedures"
         },
+        "iso-27002": {
+          "controlId": "8.12;8.25;8.26;8.3;8.5;8.7;8.8;8.9"
+        },
         "cis-m365-v6": {
           "controlId": "2.4.2",
           "title": "Ensure Priority accounts have 'Strict protection' presets applied",
@@ -101946,6 +104841,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.7;8.8"
+        },
         "cis-m365-v6": {
           "controlId": "2.4.4",
           "title": "Ensure Zero-hour auto purge for Microsoft Teams is on",
@@ -102221,6 +105119,9 @@
         "soc2": {
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7;8.8"
         },
         "cis-m365-v6": {
           "controlId": "3.6.2",
@@ -102499,6 +105400,9 @@
         "soc2": {
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7;8.8"
         },
         "cis-m365-v6": {
           "controlId": "4.2",
@@ -102780,6 +105684,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction; Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "5.14;8.24;8.26;8.7;8.8"
+        },
         "cis-m365-v6": {
           "controlId": "4.4"
         }
@@ -103056,6 +105963,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.7;8.8"
+        },
         "cis-m365-v6": {
           "controlId": "4.5"
         }
@@ -103329,6 +106239,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.7;8.8"
+        },
         "cis-m365-v6": {
           "controlId": "7.3.1",
           "title": "Ensure Office 365 SharePoint infected files are disallowed for download",
@@ -103589,6 +106502,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.8;CC6.8-POF4",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2;8.7"
         }
       },
       "impactRating": {
@@ -103722,6 +106638,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -103802,6 +106721,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -103882,6 +106804,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -103962,6 +106887,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104042,6 +106970,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104122,6 +107053,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104202,6 +107136,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104282,6 +107219,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104362,6 +107302,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104442,6 +107385,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104522,6 +107468,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104602,6 +107551,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104682,6 +107634,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104763,6 +107718,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104844,6 +107802,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -104925,6 +107886,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105006,6 +107970,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105087,6 +108054,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105168,6 +108138,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105249,6 +108222,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105330,6 +108306,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105411,6 +108390,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105492,6 +108474,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105573,6 +108558,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105654,6 +108642,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105735,6 +108726,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105816,6 +108810,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105897,6 +108894,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -105978,6 +108978,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -106059,6 +109062,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -106140,6 +109146,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -106338,6 +109347,9 @@
           "controlId": "CC3.2-POF7;CC3.2-POF9;CC3.4-POF6;CC6.8;CC6.8-POF4;CC8.1-POF14;CC8.1-POF16;CC9.2-POF13",
           "title": "Prevention and Detection of Unauthorized Software"
         },
+        "iso-27002": {
+          "controlId": "8.7;8.8"
+        },
         "cis-m365-v6": {
           "controlId": "6.4"
         }
@@ -106518,6 +109530,9 @@
         "soc2": {
           "controlId": "CC6.8;CC6.8-POF4;CC6.8-POF5",
           "title": "Prevention and Detection of Unauthorized Software"
+        },
+        "iso-27002": {
+          "controlId": "8.7"
         }
       },
       "impactRating": {
@@ -107946,6 +110961,9 @@
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.18"
+        },
         "cis-m365-v6": {
           "controlId": "8.5.1",
           "title": "Ensure anonymous users can't join a meeting",
@@ -108541,6 +111559,9 @@
           "controlId": "CC6.1;CC6.6;CC6.6-POF2;PI1.2-POF1;PI1.2-POF2;PI1.2-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Restriction of Access to System Boundaries"
         },
+        "iso-27002": {
+          "controlId": "5.18"
+        },
         "cis-m365-v6": {
           "controlId": "8.5.5",
           "title": "Ensure meeting chat does not allow anonymous users",
@@ -108764,6 +111785,9 @@
         },
         "soc2": {
           "controlId": "CC2.1-POF6;CC2.1-POF9;CC6.1-POF1"
+        },
+        "iso-27002": {
+          "controlId": "5.9;8.1"
         },
         "cis-m365-v6": {
           "controlId": "5.1.4.2",
@@ -109065,6 +112089,9 @@
         "soc2": {
           "controlId": "CC5.2;PI1.1-POF1;PI1.1-POF2;PI1.1-POF3",
           "title": "COSO Principle 11: Selects and Develops General Controls over Technology"
+        },
+        "iso-27002": {
+          "controlId": "8.25;8.29;8.3"
         }
       },
       "impactRating": {
@@ -109303,6 +112330,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.1-POF11;CC6.6-POF2;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "8.24;8.26"
         }
       },
       "impactRating": {
@@ -109605,6 +112635,9 @@
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
         },
+        "iso-27002": {
+          "controlId": "5.14;8.24;8.26"
+        },
         "cis-m365-v6": {
           "controlId": "2.1.9",
           "title": "Ensure that DKIM is enabled for all Exchange Online Domains",
@@ -109803,6 +112836,9 @@
         "soc2": {
           "controlId": "CC5.2;CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;PI1.1-POF1;PI1.1-POF2;PI1.1-POF3",
           "title": "COSO Principle 11: Selects and Develops General Controls over Technology; Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "5.14;8.24;8.25;8.26;8.29;8.3"
         }
       },
       "impactRating": {
@@ -110113,6 +113149,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110194,6 +113233,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110275,6 +113317,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110356,6 +113401,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110437,6 +113485,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110518,6 +113569,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110599,6 +113653,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110680,6 +113737,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110761,6 +113821,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110843,6 +113906,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -110924,6 +113990,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111005,6 +114074,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111086,6 +114158,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111167,6 +114242,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111248,6 +114326,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111329,6 +114410,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111410,6 +114494,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111491,6 +114578,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111572,6 +114662,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111653,6 +114746,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111734,6 +114830,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111815,6 +114914,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111896,6 +114998,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -111977,6 +115082,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112058,6 +115166,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112139,6 +115250,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112220,6 +115334,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112301,6 +115418,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112382,6 +115502,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112463,6 +115586,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112544,6 +115670,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112625,6 +115754,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112706,6 +115838,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112787,6 +115922,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112870,6 +116008,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -112953,6 +116094,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113036,6 +116180,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113119,6 +116266,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113202,6 +116352,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113285,6 +116438,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113368,6 +116524,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113451,6 +116610,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113533,6 +116695,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113615,6 +116780,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113697,6 +116865,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113779,6 +116950,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113861,6 +117035,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -113943,6 +117120,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114025,6 +117205,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114107,6 +117290,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114189,6 +117375,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114271,6 +117460,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114353,6 +117545,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114435,6 +117630,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114517,6 +117715,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114599,6 +117800,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114681,6 +117885,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114763,6 +117970,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114845,6 +118055,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -114927,6 +118140,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115009,6 +118225,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115091,6 +118310,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115173,6 +118395,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115255,6 +118480,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115337,6 +118565,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115419,6 +118650,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115501,6 +118735,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115583,6 +118820,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115665,6 +118905,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115747,6 +118990,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115829,6 +119075,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115911,6 +119160,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -115993,6 +119245,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -116075,6 +119330,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -117211,6 +120469,9 @@
         "soc2": {
           "controlId": "A1.3;A1.3-POF1;A1.3-POF2;C1.2-POF2;CC6.5;CC6.5-POF2;CC7.4-POF10;CC7.5;CC7.5-POF3;CC7.5-POF6",
           "title": "Identification of Recovery from Identified Security Incidents"
+        },
+        "iso-27002": {
+          "controlId": "5.29;5.3;8.1"
         }
       },
       "impactRating": {
@@ -117283,6 +120544,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117342,6 +120606,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117401,6 +120668,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117460,6 +120730,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117519,6 +120792,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117578,6 +120854,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117639,6 +120918,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117700,6 +120982,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117761,6 +121046,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117822,6 +121110,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117883,6 +121174,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -117944,6 +121238,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -118004,6 +121301,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -118064,6 +121364,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -118124,6 +121427,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -118184,6 +121490,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -118244,6 +121553,9 @@
         },
         "soc2": {
           "controlId": "A1.2;A1.2-POF9"
+        },
+        "iso-27002": {
+          "controlId": "8.14"
         }
       },
       "impactRating": {
@@ -118418,6 +121730,9 @@
         "soc2": {
           "controlId": "A1.2;A1.2-POF7;A1.2-POF8;CC7.5",
           "title": "Identification of Recovery from Identified Security Incidents"
+        },
+        "iso-27002": {
+          "controlId": "8.13"
         }
       },
       "impactRating": {
@@ -118666,6 +121981,9 @@
         "soc2": {
           "controlId": "CC3.2-POF7;CC3.4-POF6;CC7.1;CC7.1-POF5;CC9.2-POF13",
           "title": "Detection and Monitoring of New Vulnerabilities"
+        },
+        "iso-27002": {
+          "controlId": "8.8"
         }
       },
       "impactRating": {
@@ -118844,6 +122162,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -118925,6 +122246,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119006,6 +122330,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119087,6 +122414,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119168,6 +122498,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119248,6 +122581,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119329,6 +122665,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119409,6 +122748,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119490,6 +122832,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119570,6 +122915,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119651,6 +122999,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119731,6 +123082,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119812,6 +123166,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119893,6 +123250,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -119976,6 +123336,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -120059,6 +123422,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -120142,6 +123508,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -120225,6 +123594,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -120308,6 +123680,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -120391,6 +123766,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -120473,6 +123851,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -120555,6 +123936,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.1-POF10;CC6.7;CC6.7-POF2;CC6.7-POF3",
           "title": "Logical Access Security Software, Infrastructure, and Architectures; Data Transmission and Movement Restriction"
+        },
+        "iso-27002": {
+          "controlId": "8.24"
         }
       },
       "impactRating": {
@@ -120934,6 +124318,9 @@
         },
         "soc2": {
           "controlId": "CC1.2-POF1"
+        },
+        "iso-27002": {
+          "controlId": "5.12"
         }
       },
       "impactRating": {
@@ -122465,6 +125852,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -122541,6 +125931,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -122617,6 +126010,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -122693,6 +126089,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -122769,6 +126168,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -122845,6 +126247,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -122922,6 +126327,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -122999,6 +126407,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -123076,6 +126487,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -123153,6 +126567,9 @@
         "soc2": {
           "controlId": "CC6.1;CC6.6-POF2",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -123230,6 +126647,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -123306,6 +126726,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -123383,6 +126806,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.17;5.18"
         }
       },
       "impactRating": {
@@ -123448,6 +126874,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -123512,6 +126941,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -123578,6 +127010,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -123644,6 +127079,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -123709,6 +127147,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -123774,6 +127215,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -123839,6 +127283,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -123904,6 +127351,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -123969,6 +127419,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124034,6 +127487,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124099,6 +127555,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124164,6 +127623,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124229,6 +127691,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124294,6 +127759,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124359,6 +127827,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124424,6 +127895,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124489,6 +127963,9 @@
         "soc2": {
           "controlId": "CC6.1",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.2"
         }
       },
       "impactRating": {
@@ -124575,6 +128052,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -124660,6 +128140,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -124745,6 +128228,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -124830,6 +128316,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -124917,6 +128406,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -125004,6 +128496,9 @@
         "soc2": {
           "controlId": "CC5.2-POF3;CC6.1;CC6.1-POF12;CC6.1-POF13;CC6.1-POF7",
           "title": "Logical Access Security Software, Infrastructure, and Architectures"
+        },
+        "iso-27002": {
+          "controlId": "5.15;5.18;8.12;8.3"
         }
       },
       "impactRating": {
@@ -125086,6 +128581,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125166,6 +128664,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125245,6 +128746,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125324,6 +128828,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125403,6 +128910,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125484,6 +128994,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125564,6 +129077,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125643,6 +129159,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125722,6 +129241,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125801,6 +129323,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125881,6 +129406,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -125961,6 +129489,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -126040,6 +129571,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -126120,6 +129654,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -126200,6 +129737,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -126282,6 +129822,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -126364,6 +129907,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {
@@ -126446,6 +129992,9 @@
         "soc2": {
           "controlId": "CC7.2;CC7.2-POF1;CC7.3",
           "title": "Monitoring System Components for Anomalies; Evaluation of Identified Security Events"
+        },
+        "iso-27002": {
+          "controlId": "6.8;8.15;8.16"
         }
       },
       "impactRating": {

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -6648,6 +6648,93 @@
       ]
     },
     {
+      "checkId": "CA-NAMEDLOC-002",
+      "name": "CA policies reference stale or deleted named locations",
+      "category": "NAMEDLOC",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": "E3",
+      "scfPrimary": "NET-01.1",
+      "scfAdditional": [
+        "CFG-03"
+      ],
+      "impactSeverity": "Medium",
+      "impactRationale": "Failure to treat all users and devices as potential threats by maintaining accurate network location definitions in Conditional Access policies can allow or block access unintentionally, undermining the intended security posture.",
+      "cisM365ControlId": "",
+      "cisM365Profiles": [],
+      "remediation": "Entra admin center > Protection > Conditional Access > Named locations. Identify and remove named location objects that are no longer in use. Review each CA policy that references named locations and remove or replace stale location references.",
+      "rationale": "CA policies that reference named locations no longer present in Entra will silently drop that condition — the 'selected locations' include becomes empty, causing the policy to behave unexpectedly. This is a configuration hygiene issue that can silently widen or break policy scope.",
+      "impact": "A CA policy targeting a now-deleted named location applies to no locations at all, potentially allowing access from locations that should be blocked or applying MFA requirements in unintended ways.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/location-condition",
+          "title": "Microsoft Learn — Location condition in Conditional Access"
+        },
+        {
+          "url": "https://maester.dev/docs/tests/EIDSCA",
+          "title": "Maester — MT.1066 CA policy references valid named locations"
+        }
+      ]
+    },
+    {
+      "checkId": "CA-STALEREF-001",
+      "name": "CA policies reference deleted or invalid groups",
+      "category": "STALEREF",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": "E3",
+      "scfPrimary": "IAC-21.3",
+      "scfAdditional": [
+        "CFG-03"
+      ],
+      "impactSeverity": "Medium",
+      "impactRationale": "Conditional Access policies that reference deleted groups silently lose coverage for those conditions, creating unenforced access control gaps that can go undetected in routine audits.",
+      "cisM365ControlId": "",
+      "cisM365Profiles": [],
+      "remediation": "Entra admin center > Protection > Conditional Access > Policies. For each policy, review the Users > Include and Exclude conditions and remove any group objects that have been deleted from Entra ID. Ensure every group reference resolves to an active group.",
+      "rationale": "When a group referenced in a CA policy condition is deleted, Entra silently removes it from the condition set. A policy scoped to 'selected groups' with all referenced groups deleted becomes effectively unscoped, applying to all users or nobody — depending on whether it was in Include or Exclude.",
+      "impact": "A CA policy with all include groups deleted applies to nobody (MFA requirement silently removed for all users), or a policy with exclude groups deleted begins enforcing on users who were previously exempted.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/troubleshoot-conditional-access",
+          "title": "Microsoft Learn — Troubleshoot Conditional Access policies"
+        },
+        {
+          "url": "https://maester.dev/docs/tests/EIDSCA",
+          "title": "Maester — MT.1038 CA policy references no deleted groups"
+        }
+      ]
+    },
+    {
+      "checkId": "CA-FALLBACK-001",
+      "name": "CA policies have no valid include target (applies to nobody)",
+      "category": "FALLBACK",
+      "collector": "CAEvaluator",
+      "hasAutomatedCheck": true,
+      "licensing": "E3",
+      "scfPrimary": "IAC-21",
+      "scfAdditional": [
+        "CFG-03"
+      ],
+      "impactSeverity": "High",
+      "impactRationale": "A Conditional Access policy with no valid include target is silently disabled — it evaluates to no users and provides no protection, creating a false sense of security in the policy inventory.",
+      "cisM365ControlId": "",
+      "cisM365Profiles": [],
+      "remediation": "Entra admin center > Protection > Conditional Access > Policies. For each enabled policy, verify the Users > Include section contains at least one valid, resolvable user, group, or role. Policies with empty include targets should be disabled or remediated with a valid fallback include (e.g., 'All users').",
+      "rationale": "A CA policy needs at least one valid subject to evaluate against. If all included users or groups have been deleted, the policy applies to an empty set and is effectively disabled. This means controls like MFA, compliant device, or session frequency that the policy was meant to enforce are silently absent.",
+      "impact": "Security controls defined in the policy (MFA, device compliance, session limits) are not enforced for any user — the policy is a no-op. Since the policy still appears in the inventory as 'Enabled', it creates audit evidence that does not reflect actual protection.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-users-groups",
+          "title": "Microsoft Learn — Users and groups in Conditional Access policy"
+        },
+        {
+          "url": "https://maester.dev/docs/tests/EIDSCA",
+          "title": "Maester — MT.1036 CA policy has at least one valid include user"
+        }
+      ]
+    },
+    {
       "checkId": "CA-REPORTONLY-001",
       "name": "Conditional Access policies in report-only mode",
       "category": "REPORTONLY",

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -713,6 +713,11 @@ def derive_frameworks(
         if cmmc_profiles:
             frameworks["cmmc"]["profiles"] = cmmc_profiles
 
+    # iso-27002 mirrors iso-27001 — same Annex A control IDs, different semantic label
+    # (ISO 27001 = ISMS certification requirements; ISO 27002 = implementation guidance)
+    if "iso-27001" in frameworks:
+        frameworks["iso-27002"] = OrderedDict(frameworks["iso-27001"])
+
     return frameworks
 
 

--- a/tests/registry-integrity.Tests.ps1
+++ b/tests/registry-integrity.Tests.ps1
@@ -219,8 +219,8 @@ Describe 'Control Registry Integrity' {
 
     # --- Framework coverage ---
 
-    It 'All 16 frameworks are represented across checks' {
-        $expectedFrameworks = @('cis-m365-v6', 'nist-800-53', 'nist-csf', 'iso-27001', 'stig', 'pci-dss', 'cmmc', 'hipaa', 'cisa-scuba', 'soc2', 'fedramp', 'cis-controls-v8', 'essential-eight', 'mitre-attack', 'gdpr', 'eidsca')
+    It 'All 17 frameworks are represented across checks' {
+        $expectedFrameworks = @('cis-m365-v6', 'nist-800-53', 'nist-csf', 'iso-27001', 'iso-27002', 'stig', 'pci-dss', 'cmmc', 'hipaa', 'cisa-scuba', 'soc2', 'fedramp', 'cis-controls-v8', 'essential-eight', 'mitre-attack', 'gdpr', 'eidsca')
         $allFrameworks = [System.Collections.Generic.HashSet[string]]::new()
         foreach ($check in $checks) {
             foreach ($prop in $check.frameworks.PSObject.Properties) {


### PR DESCRIPTION
## Summary

Closes #235 (Sprint B CA hygiene) and #237 (ISO 27002 framework).

### CA hygiene checks (Sprint B)

Three new `CAEvaluator` checks that surface silent CA policy failures — cases where a policy is enabled but applies to nobody or evaluates against deleted objects:

| CheckId | Name | Maester ref | Impact |
|---------|------|-------------|--------|
| CA-NAMEDLOC-002 | CA policies reference stale/deleted named locations | MT.1066 | Medium |
| CA-STALEREF-001 | CA policies reference deleted or invalid groups | MT.1038 | Medium |
| CA-FALLBACK-001 | CA policy has no valid include target (applies to nobody) | MT.1036 | High |

`CA-DEVICECODE-001` already covered the fourth Sprint B candidate.

### ISO 27002 (closes #237)

Adds `iso-27002` as the 17th framework — same 93 Annex A control IDs as `iso-27001`, separate registry key so consumers can correctly label technical controls as ISO 27002 (implementation guide) rather than ISO 27001 (ISMS certification requirements).

**Implementation:** Single line in `Build-Registry.py` `derive_frameworks()` clones `iso-27001` → `iso-27002` for all 996 mapped checks automatically.

Addresses the concern raised by a certified ISO 27001 Lead Auditor in Galvnyz/M365-Assess#618.

## Changed files

| File | Change |
|------|--------|
| `data/scf-check-mapping.json` | +3 CA hygiene checks |
| `data/frameworks/iso-27002.json` | New — ISO 27002 framework definition |
| `scripts/Build-Registry.py` | Clone iso-27001 → iso-27002 in `derive_frameworks()` |
| `data/registry.json` | Rebuilt — 1,098 checks, 17 frameworks |
| `tests/registry-integrity.Tests.ps1` | 16 → 17 expected frameworks |

## Test plan

- [x] 303/303 Pester tests pass (up from 292 — framework-definitions auto-discovers iso-27002.json)
- [x] `iso-27002` has 996 checks matching `iso-27001` count
- [x] 3 new CA checks appear in registry with correct SCF, collector, and licensing
- [x] Framework definitions schema tests pass for iso-27002.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)