### PR TITLE
chore: update Azure AD Connect references to Microsoft Entra branding

### DIFF
--- a/data/registry.json
+++ b/data/registry.json
@@ -9247,7 +9247,7 @@
         "disruptionRisk": true,
         "disruptionScope": "user-facing"
       },
-      "remediation": "Verify Password Hash Sync status in Azure AD Connect. Entra admin center > Identity > Hybrid management > Azure AD Connect.",
+      "remediation": "Verify Password Hash Sync status in Microsoft Entra Connect or Microsoft Entra Cloud Sync. Entra admin center > Identity > Hybrid management > Microsoft Entra Connect.",
       "impact": "On-premises credential compromises are invisible to Entra ID Identity Protection when password hashes are not synced. Stolen on-premises credentials used in cloud authentication generate no risk signal and are not blocked by risk-based CA policies.",
       "rationale": "Password hash sync ensures that Entra ID has a copy of password hashes from on-premises AD. Without it, leaked on-premises credentials cannot be detected by Entra ID's Identity Protection and compromised on-premises accounts can authenticate to cloud services with no cloud-side risk signal.",
       "references": [

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -2221,7 +2221,7 @@
         "E3-L1",
         "E5-L1"
       ],
-      "remediation": "Verify Password Hash Sync status in Azure AD Connect. Entra admin center > Identity > Hybrid management > Azure AD Connect.",
+      "remediation": "Verify Password Hash Sync status in Microsoft Entra Connect or Microsoft Entra Cloud Sync. Entra admin center > Identity > Hybrid management > Microsoft Entra Connect.",
       "rationale": "Password hash sync ensures that Entra ID has a copy of password hashes from on-premises AD. Without it, leaked on-premises credentials cannot be detected by Entra ID's Identity Protection and compromised on-premises accounts can authenticate to cloud services with no cloud-side risk signal.",
       "impact": "On-premises credential compromises are invisible to Entra ID Identity Protection when password hashes are not synced. Stolen on-premises credentials used in cloud authentication generate no risk signal and are not blocked by risk-based CA policies.",
       "references": [


### PR DESCRIPTION
## Summary
- Replaces stale "Azure AD Connect" product name with "Microsoft Entra Connect or Microsoft Entra Cloud Sync" in the `ENTRA-HYBRID-001` remediation text
- Updated in both `data/registry.json` and `data/scf-check-mapping.json`

## References
- Microsoft rebranded Azure AD Connect → Microsoft Entra Connect (July 2023)
- Microsoft Entra Cloud Sync is now the recommended solution for new deployments

## Test plan
- [x] `grep -i "azure ad connect" data/registry.json` returns no matches
- [x] `grep -i "azure ad connect" data/scf-check-mapping.json` returns no matches
- [x] `Invoke-Pester tests/registry-integrity.Tests.ps1` — 31 passed
- [x] `Invoke-Pester tests/scf-mapping.Tests.ps1` — 7 passed

Closes #245

🤖 Generated with [Claude Code](https://claude.ai/claude-code)