### PR TITLE
chore: ignore *.db files to prevent accidental scf.db commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ Thumbs.db
 desktop.ini
 .DS_Store
 
+# SQLite databases (upstream artifact — belongs in SecFrame, not here)
+*.db
+
 # PowerShell artifacts
 PSScriptAnalyzerResults.*
 testResults.xml


### PR DESCRIPTION
## Summary
- Adds `*.db` to `.gitignore` so SQLite database files can never be accidentally committed
- Follows investigation of a 0-byte `data/scf.db` ghost file that appeared after a botched local script invocation — that file has been deleted

## Test plan
- [ ] `git status` no longer shows `data/scf.db` as an untracked file if it reappears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)