### PR TITLE
chore: pin schemaVersion to ModuleVersion (v2.22.0) and reconcile with release tags

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -98,9 +98,12 @@ jobs:
         shell: pwsh
         run: |
           $reg = Get-Content data/registry.json -Raw | ConvertFrom-Json
+          $manifest = Import-PowerShellDataFile -Path CheckID.psd1
           $errors = @()
 
-          if ($reg.schemaVersion -ne '2.2.0') { $errors += "Expected schemaVersion 2.2.0, got '$($reg.schemaVersion)'" }
+          if ($reg.schemaVersion -ne $manifest.ModuleVersion) {
+            $errors += "schemaVersion '$($reg.schemaVersion)' must equal CheckID.psd1 ModuleVersion '$($manifest.ModuleVersion)' — see VERSIONING.md"
+          }
           if (-not $reg.dataVersion) { $errors += "Missing 'dataVersion' field" }
           if (-not $reg.checks) { $errors += "Missing 'checks' array" }
           if ($reg.checks.Count -lt 160) { $errors += "Expected at least 160 checks, got $($reg.checks.Count)" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the CheckID module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.22.0] - 2026-04-24
+
+### Changed
+
+- **Breaking (data semantics):** `frameworks.cmmc.profiles` now uses identity
+  semantics — it lists only the levels whose tokens appear in `controlId`
+  (e.g. `IA.L2-3.5.5` → `["L2"]`), not the cumulative superset
+  (`["L1","L2"]`). Closes #248. Registry regenerated: 790 previously-uniform
+  `[L1,L2]` entries are now `[L2]`; `[L2,L3]` is now representable (was
+  impossible before). Downstream consumers that filtered by profile should
+  review their logic.
+- **Versioning policy:** `CheckID.psd1` `ModuleVersion` and `registry.json`
+  `schemaVersion` are now pinned to each other, and both track the release
+  tag. CI (Pester test in `tests/registry-integrity.Tests.ps1` and
+  `scripts/Test-RegistryData.ps1`) fails if they diverge. Reconciles
+  historical drift where tags reached v2.21.0 while these fields lagged at
+  2.6.0 / 2.2.0. See VERSIONING.md.
+
 ## [2.6.0] - 2026-04-17
 
 ### Added

--- a/CheckID.psd1
+++ b/CheckID.psd1
@@ -1,7 +1,7 @@
 @{
     # Module metadata
     RootModule        = 'CheckID.psm1'
-    ModuleVersion     = '2.6.0'
+    ModuleVersion     = '2.22.0'
     GUID              = 'a3b7c4d5-1e2f-4a5b-8c9d-0e1f2a3b4c5d'
     Author            = 'Galvnyz'
     CompanyName       = 'Galvnyz'

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Each check in `registry.json` contains:
 }
 ```
 
-Top-level fields: `schemaVersion` (`"2.0.0"`), `dataVersion` (date), `generatedFrom`, `checks[]`.
+Top-level fields: `schemaVersion` (matches `CheckID.psd1` `ModuleVersion` — pinned, see VERSIONING.md), `dataVersion` (date), `generatedFrom`, `checks[]`.
 
 ## Rebuilding the Registry
 

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,12 +1,12 @@
 # CheckID Registry Schema
 
-This document describes the `data/registry.json` schema (v2.1.0, SCF-based).
+This document describes the `data/registry.json` schema (v2.22.0, SCF-based).
 
 ## Top-Level Structure
 
 ```json
 {
-  "schemaVersion": "2.0.0",
+  "schemaVersion": "2.22.0",
   "dataVersion": "YYYY-MM-DD",
   "generatedFrom": "scf-check-mapping.json + SecFrame/SCF/scf.db (SCF 2025.4)",
   "checks": [ ... ]

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -6,50 +6,61 @@ CheckID is a shared library consumed by multiple downstream projects. This docum
 
 | Version | Location | Format | Bumps when |
 |---------|----------|--------|------------|
-| **Schema** | `registry.json` `schemaVersion` | semver | Structure of registry.json changes |
-| **Module** | `CheckID.psd1` `ModuleVersion` | semver | PowerShell module API changes |
-| **Data** | `registry.json` `dataVersion` | YYYY-MM-DD | Every `Build-Registry.ps1` run (informational only) |
+| **App / Module** | `CheckID.psd1` `ModuleVersion` | semver | PowerShell module API changes **or** registry shape/semantic changes |
+| **Schema** | `registry.json` `schemaVersion` | semver | **Always equals ModuleVersion** (enforced by CI) |
+| **Data** | `registry.json` `dataVersion` | YYYY-MM-DD | Every `Build-Registry.py` run (informational only) |
 
-### Schema Version (registry.json `schemaVersion`)
+### Coupling policy
 
-Governs the structure of `registry.json`.
+`schemaVersion` is **pinned** to `ModuleVersion`: both are treated as one release
+version for the CheckID package. Either file's version SHOULD NOT drift; CI fails
+if they diverge (`tests/registry-integrity.Tests.ps1`). Bump both in the same PR.
+
+Why a single version: consumers pin CheckID as a whole (module API + registry
+data shape). Splitting the two added cognitive overhead with no real benefit —
+any schema change forces a module-version review, and vice versa.
+
+**Historical note:** Prior to v2.22.0, git tags and GitHub releases ran ahead of
+`ModuleVersion` and `schemaVersion` (tags reached v2.21.0 while the psd1 still
+said `2.6.0` and the registry said `2.2.0`). As of v2.22.0, **all three
+track the release tag** — bumping the release tag means bumping `ModuleVersion`
+and `schemaVersion` to the same value in the same PR.
+
+### Package Version (`ModuleVersion` == `schemaVersion`)
+
+Governs both the PowerShell module API **and** the `registry.json` shape/semantics.
+Bump the highest category that applies — any major-level trigger forces a major bump
+for both.
 
 | Bump | When |
 |------|------|
-| **Major** | Removed/renamed fields, changed check object shape, changed framework key names |
-| **Minor** | New fields added, new framework mappings, new metadata properties |
-| **Patch** | Data corrections (encoding fixes, title updates, profile corrections) |
+| **Major** | Removed/renamed exported functions; changed parameter signatures; removed/renamed registry fields; changed check-object shape or framework key names; breaking change to the meaning of an existing field (e.g. issue #248: CMMC `profiles` semantics flip) |
+| **Minor** | New exported functions; new optional parameters on existing functions; new registry fields or framework mappings; new metadata properties |
+| **Patch** | Bug fixes in existing functions; performance improvements; data-only corrections (encoding fixes, title updates, non-semantic profile corrections) |
 
-### Module Version (CheckID.psd1 `ModuleVersion`)
+### Data Version (`registry.json` `dataVersion`)
 
-Governs the PowerShell module API.
-
-| Bump | When |
-|------|------|
-| **Major** | Removed/renamed exported functions, changed parameter signatures, removed parameters |
-| **Minor** | New exported functions, new optional parameters on existing functions |
-| **Patch** | Bug fixes in existing functions, performance improvements |
-
-### Data Version (registry.json `dataVersion`)
-
-YYYY-MM-DD date that bumps on every `Build-Registry.ps1` run. Purely informational -- never pin to it.
+YYYY-MM-DD date that bumps on every `Build-Registry.py` run. Purely informational —
+never pin to it.
 
 ## Breaking Change Examples
 
-| Change | Schema | Module | Breaking? |
-|--------|--------|--------|-----------|
-| Rename `checkId` to `id` | Major | -- | Yes |
-| Add `gdpr` framework to checks | Minor | -- | No |
-| Fix HIPAA encoding | Patch | -- | No |
-| Add `Get-FrameworkCoverage` | -- | Minor | No |
-| Remove `Search-Check` | -- | Major | Yes |
-| Add `-Profile` param to `Search-Check` | -- | Minor | No |
+| Change | Bump | Breaking? |
+|--------|------|-----------|
+| Rename `checkId` to `id` | Major | Yes |
+| Remove `Search-Check` cmdlet | Major | Yes |
+| Flip CMMC `profiles` from cumulative to identity semantics (#248) | Major | Yes |
+| Add `gdpr` framework to checks | Minor | No |
+| Add `Get-FrameworkCoverage` cmdlet | Minor | No |
+| Add `-Profile` param to `Search-Check` | Minor | No |
+| Fix HIPAA encoding | Patch | No |
 
 ## Consumer Guidance
 
-- **Pin to major version**: `RequiredModules = @(@{ModuleName='CheckID'; ModuleVersion='1.0.0'})`
-- **Check schema compatibility**: compare `schemaVersion` major digit
-- **Data version is informational only** -- never pin to it
+- **Pin to major version**: `RequiredModules = @(@{ModuleName='CheckID'; ModuleVersion='2.22.0'})`
+- **Schema compatibility**: `registry.json` `schemaVersion` always matches the module
+  `ModuleVersion` — comparing either is equivalent.
+- **Data version is informational only** — never pin to it.
 
 ## Downstream Consumers
 

--- a/data/registry.json
+++ b/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "2.2.0",
+  "schemaVersion": "2.22.0",
   "dataVersion": "2026-04-24",
   "generatedFrom": "data/scf-check-mapping.json + SecFrame/SCF/scf.db + data/scf-framework-map.json + data/az-assess-source-checks.json",
   "checks": [

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -40,7 +40,7 @@ if sys.stdout.encoding != "utf-8":
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 
-SCHEMA_VERSION = "2.2.0"
+SCHEMA_VERSION = "2.22.0"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/Test-RegistryData.ps1
+++ b/scripts/Test-RegistryData.ps1
@@ -94,9 +94,12 @@ Test-Check "registry.json is valid JSON" {
 
 if (-not $reg) { Write-Host "`nRegistry JSON invalid — cannot continue." -ForegroundColor Red; exit 1 }
 
-Test-Check "registry.json has schemaVersion 2.2.0" {
+Test-Check "registry.json schemaVersion matches CheckID.psd1 ModuleVersion" {
     if (-not $reg.schemaVersion) { return "Missing schemaVersion field" }
-    if ($reg.schemaVersion -ne '2.2.0') { return "Expected schemaVersion 2.2.0, got '$($reg.schemaVersion)'" }
+    $manifest = Import-PowerShellDataFile -Path (Join-Path $PSScriptRoot '..' 'CheckID.psd1')
+    if ($reg.schemaVersion -ne $manifest.ModuleVersion) {
+        return "schemaVersion '$($reg.schemaVersion)' must equal ModuleVersion '$($manifest.ModuleVersion)' (see VERSIONING.md)"
+    }
 }
 
 Test-Check "registry.json has dataVersion" {

--- a/tests/registry-integrity.Tests.ps1
+++ b/tests/registry-integrity.Tests.ps1
@@ -1,15 +1,22 @@
 Describe 'Control Registry Integrity' {
     BeforeAll {
         $registryPath = "$PSScriptRoot/../data/registry.json"
+        $manifestPath = "$PSScriptRoot/../CheckID.psd1"
         $raw = Get-Content -Path $registryPath -Raw | ConvertFrom-Json
+        $manifest = Import-PowerShellDataFile -Path $manifestPath
         $checks = $raw.checks
     }
 
     # --- Schema-level tests ---
 
-    It 'Has schemaVersion 2.2.0' {
-        $raw.schemaVersion | Should -Be '2.2.0' `
-            -Because "registry must be schema version 2.2.0 (adds impact, rationale, references, tags fields)"
+    It 'schemaVersion is pinned to CheckID.psd1 ModuleVersion' {
+        $raw.schemaVersion | Should -Be $manifest.ModuleVersion `
+            -Because "schemaVersion and ModuleVersion are coupled per VERSIONING.md — bump both together"
+    }
+
+    It 'schemaVersion is valid semver' {
+        $raw.schemaVersion | Should -Match '^\d+\.\d+\.\d+$' `
+            -Because "schemaVersion must be MAJOR.MINOR.PATCH"
     }
 
     It 'Has dataVersion field with valid date format' {


### PR DESCRIPTION
## Summary

- Couples `CheckID.psd1` `ModuleVersion` and `registry.json` `schemaVersion` to a single package version (**v2.22.0**). CI fails if they diverge.
- Reconciles historical drift: git tags had reached **v2.21.0** while ModuleVersion lagged at 2.6.0 and schemaVersion at 2.2.0. Going forward, bumping the release tag bumps both fields in the same PR.
- Bakes this into documentation (VERSIONING.md rewritten) and changelog (2.22.0 entry covering this + the #248 CMMC profiles fix merged earlier today).

## Why now

M365-Assess needs a new CheckID release to pick up the #248 CMMC `profiles` semantic fix. Tagging v2.22.0 with ModuleVersion still at 2.6.0 and schemaVersion at 2.2.0 would produce a release where consumers can't reliably pin — the package-internal numbers wouldn't match the tag they requested. This PR fixes that before the tag goes out.

## Validator

`tests/registry-integrity.Tests.ps1`:
\`\`\`powershell
It 'schemaVersion is pinned to CheckID.psd1 ModuleVersion' {
    \$raw.schemaVersion | Should -Be \$manifest.ModuleVersion \`
        -Because \"schemaVersion and ModuleVersion are coupled per VERSIONING.md — bump both together\"
}
\`\`\`

Matching check in `scripts/Test-RegistryData.ps1` so both Pester and the standalone data-quality runner enforce it.

## Test plan

- [x] \`python scripts/Build-Registry.py\` rebuilds clean
- [x] \`Invoke-Pester tests/registry-integrity.Tests.ps1\` — 35/35 pass (new coupling + semver-format tests)
- [x] \`scripts/Test-RegistryData.ps1\` — 12/12 pass
- [x] \`Test-ModuleManifest ./CheckID.psd1\` returns Version 2.22.0
- [ ] After merge: tag **v2.22.0** so M365-Assess can pick up the #248 fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)