### PR TITLE
feat: framework metadata schema + release channels (#292)

### DIFF
--- a/.github/workflows/notify-downstream-preview.yml
+++ b/.github/workflows/notify-downstream-preview.yml
@@ -1,0 +1,69 @@
+name: Notify Downstream (preview)
+
+# Fires on every push to main (post-merge). Consumers configured for the preview
+# channel pick this up; consumers on the stable channel ignore preview events.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'data/registry.json'
+      - 'data/frameworks/**'
+      - 'data/scf-check-mapping.json'
+      - 'data/scf-framework-map.json'
+
+jobs:
+  notify:
+    name: Notify consumer repos — preview channel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get commit info
+        id: info
+        shell: bash
+        run: |
+          SHA="${GITHUB_SHA}"
+          SHORT="${SHA:0:7}"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short=$SHORT" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch to M365-Assess
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: Galvnyz/M365-Assess
+          event-type: checkid-preview
+          client-payload: '{"sha": "${{ steps.info.outputs.sha }}", "short": "${{ steps.info.outputs.short }}", "channel": "preview"}'
+
+      - name: Dispatch to M365-Remediate
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: Galvnyz/M365-Remediate
+          event-type: checkid-preview
+          client-payload: '{"sha": "${{ steps.info.outputs.sha }}", "short": "${{ steps.info.outputs.short }}", "channel": "preview"}'
+
+      - name: Dispatch to StrykerScan
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: Galvnyz/StrykerScan
+          event-type: checkid-preview
+          client-payload: '{"sha": "${{ steps.info.outputs.sha }}", "short": "${{ steps.info.outputs.short }}", "channel": "preview"}'
+
+      - name: Dispatch to EZ-CMMC
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: Galvnyz/EZ-CMMC
+          event-type: checkid-preview
+          client-payload: '{"sha": "${{ steps.info.outputs.sha }}", "short": "${{ steps.info.outputs.short }}", "channel": "preview"}'
+
+      - name: Summary
+        run: |
+          echo "### Downstream notifications sent — preview channel" >> "$GITHUB_STEP_SUMMARY"
+          echo "Commit: \`${{ steps.info.outputs.short }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Consumers subscribed to the **preview** channel will sync from main HEAD." >> "$GITHUB_STEP_SUMMARY"
+          echo "Consumers on the **stable** channel only respond to tag releases." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/notify-downstream.yml
+++ b/.github/workflows/notify-downstream.yml
@@ -1,4 +1,4 @@
-name: Notify Downstream
+name: Notify Downstream (stable)
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   notify:
-    name: Notify consumer repos
+    name: Notify consumer repos — stable channel
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.CROSS_REPO_TOKEN }}
           repository: Galvnyz/M365-Assess
           event-type: checkid-released
-          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}"}'
+          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}", "channel": "stable"}'
 
       - name: Dispatch to M365-Remediate
         uses: peter-evans/repository-dispatch@v3
@@ -34,7 +34,7 @@ jobs:
           token: ${{ secrets.CROSS_REPO_TOKEN }}
           repository: Galvnyz/M365-Remediate
           event-type: checkid-released
-          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}"}'
+          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}", "channel": "stable"}'
 
       - name: Dispatch to StrykerScan
         uses: peter-evans/repository-dispatch@v3
@@ -42,13 +42,22 @@ jobs:
           token: ${{ secrets.CROSS_REPO_TOKEN }}
           repository: Galvnyz/StrykerScan
           event-type: checkid-released
-          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}"}'
+          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}", "channel": "stable"}'
+
+      - name: Dispatch to EZ-CMMC
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_TOKEN }}
+          repository: Galvnyz/EZ-CMMC
+          event-type: checkid-released
+          client-payload: '{"version": "${{ steps.info.outputs.version }}", "tag": "${{ steps.info.outputs.tag }}", "channel": "stable"}'
 
       - name: Summary
         run: |
-          echo "### Downstream notifications sent" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Downstream notifications sent — stable channel" >> "$GITHUB_STEP_SUMMARY"
           echo "- M365-Assess" >> "$GITHUB_STEP_SUMMARY"
           echo "- M365-Remediate" >> "$GITHUB_STEP_SUMMARY"
           echo "- StrykerScan" >> "$GITHUB_STEP_SUMMARY"
+          echo "- EZ-CMMC" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "CheckID **${{ steps.info.outputs.tag }}** released." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -144,6 +144,30 @@ jobs:
           print(f'Registry validates against schema ({len(registry[\"checks\"])} checks)')
           "
 
+      - name: Validate framework metadata against JSON Schema
+        run: |
+          python <<'PY'
+          import json, sys, jsonschema
+          from pathlib import Path
+          frameworks_dir = Path("data/frameworks")
+          schema = json.loads((frameworks_dir / "_schema.json").read_text())
+          errors = []
+          count = 0
+          for fp in sorted(frameworks_dir.glob("*.json")):
+              if fp.name == "_schema.json":
+                  continue
+              try:
+                  jsonschema.validate(json.loads(fp.read_text()), schema)
+                  count += 1
+              except jsonschema.ValidationError as e:
+                  errors.append(f"{fp.name}: {e.message} at {list(e.absolute_path)}")
+          if errors:
+              for e in errors:
+                  print(f"::error::{e}")
+              sys.exit(1)
+          print(f"{count} framework metadata files validate against schema")
+          PY
+
   data-quality:
     name: Data Quality
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -149,13 +149,10 @@ jobs:
           python <<'PY'
           import json, sys, jsonschema
           from pathlib import Path
-          frameworks_dir = Path("data/frameworks")
-          schema = json.loads((frameworks_dir / "_schema.json").read_text())
+          schema = json.loads(Path("data/frameworks.schema.json").read_text())
           errors = []
           count = 0
-          for fp in sorted(frameworks_dir.glob("*.json")):
-              if fp.name == "_schema.json":
-                  continue
+          for fp in sorted(Path("data/frameworks").glob("*.json")):
               try:
                   jsonschema.validate(json.loads(fp.read_text()), schema)
                   count += 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the CheckID module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Framework metadata JSON Schema** at `data/frameworks/_schema.json`. Validates
+  the 20 framework metadata files in `data/frameworks/` for required fields
+  (frameworkId, label, version, totalControls, registryKey, csvColumn,
+  displayOrder, scoring) and enforces the known scoring methods. Wired into
+  `validate.yml` so PRs touching framework metadata fail on contract drift.
+- **Release channels** for downstream consumers. `notify-downstream.yml` now
+  emits `"channel": "stable"` on tag push (existing behavior, now labeled).
+  New `notify-downstream-preview.yml` emits `"channel": "preview"` on every
+  push to `main` that touches `data/registry.json`, `data/frameworks/**`,
+  `data/scf-check-mapping.json`, or `data/scf-framework-map.json`. Consumers
+  declare their channel; preview-channel consumers track main HEAD, stable-
+  channel consumers track tagged releases.
+- **EZ-CMMC** added to the downstream dispatch list in both stable and preview
+  workflows.
+
 ## [2.22.1] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Framework metadata JSON Schema** at `data/frameworks/_schema.json`. Validates
-  the 20 framework metadata files in `data/frameworks/` for required fields
+- **Framework metadata JSON Schema** at `data/frameworks.schema.json` (mirrors
+  the `data/registry.schema.json` convention). Validates the 20 framework
+  metadata files under `data/frameworks/` for required fields
   (frameworkId, label, version, totalControls, registryKey, csvColumn,
   displayOrder, scoring) and enforces the known scoring methods. Wired into
   `validate.yml` so PRs touching framework metadata fail on contract drift.

--- a/data/frameworks.schema.json
+++ b/data/frameworks.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://github.com/Galvnyz/CheckID/data/frameworks/_schema.json",
+  "$id": "https://github.com/Galvnyz/CheckID/data/frameworks.schema.json",
   "title": "Framework Metadata",
-  "description": "Schema for individual framework metadata files in data/frameworks/. Each *.json file (excluding this _schema.json) describes how a single compliance framework is rendered, scored, and identified in the CheckID registry.",
+  "description": "Schema for framework metadata files under data/frameworks/. Each *.json file in that directory describes how a single compliance framework is rendered, scored, and identified in the CheckID registry. The schema lives outside data/frameworks/ to mirror the data/registry.schema.json convention and to keep the Pester enumerator (Get-ChildItem data/frameworks/*.json) focused on framework files.",
   "type": "object",
   "required": [
     "frameworkId",

--- a/data/frameworks/_schema.json
+++ b/data/frameworks/_schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/Galvnyz/CheckID/data/frameworks/_schema.json",
+  "title": "Framework Metadata",
+  "description": "Schema for individual framework metadata files in data/frameworks/. Each *.json file (excluding this _schema.json) describes how a single compliance framework is rendered, scored, and identified in the CheckID registry.",
+  "type": "object",
+  "required": [
+    "frameworkId",
+    "label",
+    "version",
+    "description",
+    "homepageUrl",
+    "css",
+    "totalControls",
+    "registryKey",
+    "csvColumn",
+    "displayOrder",
+    "scoring"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "frameworkId": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*[a-z0-9]$",
+      "description": "Stable lowercase-kebab identifier. Must match the filename stem."
+    },
+    "label": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable framework name shown in UI."
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Framework version string (e.g., '6.0.1', 'R2', 'v10', '2022')."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 20,
+      "description": "One- or two-sentence description of the framework's purpose."
+    },
+    "homepageUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "Authoritative source URL for the framework."
+    },
+    "css": {
+      "type": "string",
+      "pattern": "^fw-[a-z0-9-]+$",
+      "description": "CSS class prefix used by consumers for framework-specific styling."
+    },
+    "totalControls": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Total count of controls/practices/techniques in the framework."
+    },
+    "registryKey": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Key used in registry.json check entries to reference this framework."
+    },
+    "csvColumn": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Column header in framework-mappings.csv that holds this framework's mapping."
+    },
+    "displayOrder": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Sort order for UI rendering (lower = earlier)."
+    },
+    "scoring": {
+      "type": "object",
+      "required": ["method"],
+      "additionalProperties": true,
+      "properties": {
+        "method": {
+          "type": "string",
+          "enum": [
+            "profile-compliance",
+            "control-coverage",
+            "maturity-level",
+            "criteria-coverage",
+            "technique-coverage",
+            "requirement-compliance",
+            "function-coverage",
+            "policy-compliance",
+            "severity-coverage"
+          ],
+          "description": "Scoring strategy. Method-specific fields (profiles, maturityLevels, criteria, tactics, requirements, functions, policies, severities) are permitted via additionalProperties."
+        }
+      }
+    },
+    "colors": {
+      "$ref": "#/definitions/colorTheme",
+      "description": "Optional top-level light/dark theme colors. Some frameworks (CIS) declare colors per scoring profile instead."
+    }
+  },
+  "definitions": {
+    "colorTheme": {
+      "type": "object",
+      "required": ["light", "dark"],
+      "additionalProperties": false,
+      "properties": {
+        "light": { "$ref": "#/definitions/colorPair" },
+        "dark": { "$ref": "#/definitions/colorPair" }
+      }
+    },
+    "colorPair": {
+      "type": "object",
+      "required": ["background", "color"],
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$"
+        },
+        "color": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Foundation for cross-repo contract automation, parallel to the v2.23–v2.26 internal arc. None of these changes alter `registry.json`'s shape — safe to land before v2.24.0's schema restructure.

- New JSON Schema at `data/frameworks/_schema.json` validates the 20 framework metadata files (required fields, known scoring methods).
- `validate.yml` extended with framework-metadata schema validation as a hard gate.
- `notify-downstream.yml` adds `channel: stable` to dispatch payloads; **EZ-CMMC** added to the consumer list.
- New `notify-downstream-preview.yml` fires on push to main when registry/framework/scf-mapping data changes and emits `channel: preview`. Lets consumers track main HEAD without waiting for tags.
- `CHANGELOG.md` \`[Unreleased]\` section.

Closes #292. Tracked under milestone #40 (Cross-Repo Contracts foundation).

## Test plan
- [x] All 20 framework files validate against \`_schema.json\` locally.
- [ ] CI green: validate.yml's new step passes.
- [ ] Preview workflow's \`paths\` filter validated against a sample data-only commit (no doc-only false positives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)