### PR TITLE
feat: duplicate-key CI gate for data/*.json (#254)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -261,7 +261,11 @@ jobs:
           python -m py_compile scripts/Build-ScfMigration.py
           python -m py_compile scripts/Build-FrameworkTitles.py
           python -m py_compile scripts/Generate-ImpactRationale.py
+          python -m py_compile scripts/Validate-NoDuplicateKeys.py
           echo "All Python scripts compile clean"
+
+      - name: Validate no duplicate JSON keys
+        run: python scripts/Validate-NoDuplicateKeys.py
 
       - name: Install Python test dependencies
         run: pip install pytest

--- a/scripts/Validate-NoDuplicateKeys.py
+++ b/scripts/Validate-NoDuplicateKeys.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate that JSON files contain no duplicate object keys.
+
+Python's json.load silently keeps the last value when an object contains
+duplicate keys. That bug class lost 4 framework overrides in v2.22.0 and
+was caught only by downstream cross-validation (commit 8634df0). This
+script uses object_pairs_hook to reject duplicates at parse time.
+
+Usage:
+    python scripts/Validate-NoDuplicateKeys.py [paths...]
+
+If no paths are given, validates every JSON file under data/.
+
+Exit codes:
+    0 — all files clean
+    1 — at least one duplicate key or parse error
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+class DuplicateKeyError(ValueError):
+    """Raised when a JSON object contains duplicate keys."""
+
+    def __init__(self, file: Path, key: str, detail: str = "") -> None:
+        self.file = file
+        self.key = key
+        self.detail = detail
+        suffix = f" ({detail})" if detail else ""
+        super().__init__(
+            f"{file}: duplicate key '{key}'{suffix}. "
+            "json.load silently keeps the last value — fix by merging the two entries."
+        )
+
+
+def _strict_pairs_hook(file: Path):
+    """Return an object_pairs_hook bound to the file path for error context."""
+
+    def hook(pairs: list[tuple[str, object]]) -> dict:
+        seen: dict[str, object] = {}
+        for k, v in pairs:
+            if k in seen:
+                raise DuplicateKeyError(file, k)
+            seen[k] = v
+        return seen
+
+    return hook
+
+
+def validate_file(path: Path) -> list[str]:
+    """Validate one JSON file. Return list of error messages (empty when clean)."""
+    try:
+        with path.open(encoding="utf-8") as fh:
+            json.load(fh, object_pairs_hook=_strict_pairs_hook(path))
+        return []
+    except DuplicateKeyError as e:
+        return [str(e)]
+    except json.JSONDecodeError as e:
+        return [f"{path}: JSON parse error at line {e.lineno} col {e.colno}: {e.msg}"]
+
+
+def discover(paths: list[str]) -> list[Path]:
+    """Expand CLI args into a sorted, deduplicated list of JSON files."""
+    if not paths:
+        repo_root = Path(__file__).resolve().parent.parent
+        return sorted((repo_root / "data").rglob("*.json"))
+
+    out: list[Path] = []
+    for p in paths:
+        path = Path(p)
+        if path.is_dir():
+            out.extend(path.rglob("*.json"))
+        elif path.is_file():
+            out.append(path)
+        else:
+            out.extend(Path().glob(p))
+    # Dedupe while preserving sort order
+    return sorted(set(out))
+
+
+def main(argv: list[str]) -> int:
+    files = discover(argv)
+    if not files:
+        print("::error::No JSON files found to validate", file=sys.stderr)
+        return 1
+
+    all_errors: list[tuple[Path, str]] = []
+    for f in files:
+        errors = validate_file(f)
+        if errors:
+            for msg in errors:
+                # GitHub Actions error annotation
+                print(f"::error file={f}::{msg}", file=sys.stderr)
+            all_errors.extend((f, msg) for msg in errors)
+        else:
+            print(f"  OK: {f}")
+
+    if all_errors:
+        print(
+            f"\nValidation FAILED: {len(all_errors)} issue(s) across "
+            f"{len({f for f, _ in all_errors})} file(s) "
+            f"(scanned {len(files)} total)",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"\nAll {len(files)} JSON file(s) pass duplicate-key validation")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/duplicate-keys.Tests.ps1
+++ b/tests/duplicate-keys.Tests.ps1
@@ -1,0 +1,52 @@
+Describe 'No Duplicate JSON Keys' {
+
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path "$PSScriptRoot/..").Path
+        $script:validator = Join-Path $repoRoot 'scripts/Validate-NoDuplicateKeys.py'
+        $script:fixturesDir = Join-Path $repoRoot 'tests/fixtures/duplicate-key'
+        $script:brokenFixture = Join-Path $fixturesDir 'broken.json'
+        $script:cleanFixture = Join-Path $fixturesDir 'clean.json'
+    }
+
+    It 'Validator script exists' {
+        Test-Path $validator | Should -Be $true `
+            -Because "scripts/Validate-NoDuplicateKeys.py must exist"
+    }
+
+    It 'Broken fixture exists' {
+        Test-Path $brokenFixture | Should -Be $true `
+            -Because "duplicate-key fixture is required to verify the gate catches the bug class"
+    }
+
+    It 'Clean fixture exists' {
+        Test-Path $cleanFixture | Should -Be $true `
+            -Because "clean fixture is required to verify the validator does not produce false positives"
+    }
+
+    It 'Validator catches a fixture with duplicate keys' {
+        $output = python $validator $brokenFixture 2>&1
+        $LASTEXITCODE | Should -Be 1 `
+            -Because "validator must exit non-zero on duplicate keys: $($output -join "`n")"
+        ($output -join "`n") | Should -Match 'duplicate key' `
+            -Because "error message must mention 'duplicate key' for clarity"
+        ($output -join "`n") | Should -Match 'ENTRA-PASSWORD-002' `
+            -Because "error message must name the offending key"
+    }
+
+    It 'Validator passes against a clean fixture' {
+        $output = python $validator $cleanFixture 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "clean fixture must pass: $($output -join "`n")"
+    }
+
+    It 'Validator passes against current data/ tree' {
+        Push-Location $repoRoot
+        try {
+            $output = python $validator 2>&1
+            $LASTEXITCODE | Should -Be 0 `
+                -Because "data/ tree must currently be clean: $($output -join "`n")"
+        } finally {
+            Pop-Location
+        }
+    }
+}

--- a/tests/fixtures/duplicate-key/broken.json
+++ b/tests/fixtures/duplicate-key/broken.json
@@ -1,0 +1,6 @@
+{
+  "checks": {
+    "ENTRA-PASSWORD-002": { "controlId": "PR.AA-01" },
+    "ENTRA-PASSWORD-002": { "controlId": "PR.AA-02" }
+  }
+}

--- a/tests/fixtures/duplicate-key/clean.json
+++ b/tests/fixtures/duplicate-key/clean.json
@@ -1,0 +1,6 @@
+{
+  "checks": {
+    "ENTRA-PASSWORD-001": { "controlId": "PR.AA-01" },
+    "ENTRA-PASSWORD-002": { "controlId": "PR.AA-02" }
+  }
+}


### PR DESCRIPTION
Closes #254.

## Summary
- Adds \`scripts/Validate-NoDuplicateKeys.py\` — strict JSON parser using \`object_pairs_hook\` that raises on duplicate keys.
- Adds \`tests/duplicate-keys.Tests.ps1\` Pester gate (6 tests).
- Adds \`tests/fixtures/duplicate-key/{broken,clean}.json\` for the test.
- Wires the validator into \`.github/workflows/validate.yml\` under the \`python-validate\` job as a hard-fail gate.

## Why
Python's \`json.load\` silently keeps the last value when an object contains duplicate keys. That bug class lost 4 framework overrides in v2.22.0 (commit 8634df0) and was caught only by downstream cross-validation. This makes that bug class structurally impossible going forward.

## Test plan
- [x] Pester suite green locally (318 tests, including the 6 new ones)
- [x] Validator exits 1 on \`tests/fixtures/duplicate-key/broken.json\` with a clear message naming the offending key (\`ENTRA-PASSWORD-002\`)
- [x] Validator exits 0 on the clean fixture
- [x] Validator exits 0 on the current \`data/\` tree (36 JSON files)
- [ ] CI passes on this PR (the new step appears under \"Validate Python Scripts\")

## Notes for review
- TDD discipline: fixtures + Pester tests committed first, watched to fail (4 red), then implementation landed (6 green). Visible in the diff structure but not in commit history (squashed into one feat commit).
- Error format uses GitHub Actions \`::error file=...::\` annotations so failures surface inline on PRs.
- The script's CLI accepts paths/globs/dirs; with no args, defaults to \`data/**/*.json\` from repo root via \`__file__\` resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)