### PR TITLE
feat: mapping-count regression CI gate (#255)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -292,3 +292,66 @@ jobs:
               sys.exit(1)
           print(f'All {len(files)} JSON files are valid UTF-8')
           "
+
+  mapping-count-regression:
+    name: Mapping Count Regression
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Fetch main branch for comparison
+        run: git fetch origin main --depth=1
+
+      - name: Extract main registry
+        run: git show origin/main:data/registry.json > /tmp/registry-main.json
+
+      - name: Compare per-framework mapping counts
+        shell: bash
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          allow_drop_args=()
+          IFS=',' read -ra labels <<< "$LABELS"
+          for label in "${labels[@]}"; do
+            case "$label" in
+              ALLOW_MAPPING_DROP=*) allow_drop_args+=("--allow-drop" "${label#ALLOW_MAPPING_DROP=}") ;;
+            esac
+          done
+          python scripts/Compare-MappingCounts.py \
+            /tmp/registry-main.json \
+            data/registry.json \
+            --markdown mapping-delta.md \
+            "${allow_drop_args[@]}"
+
+      - name: Post or update sticky comment with mapping-count delta
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ ! -f mapping-delta.md ]; then
+            echo "No delta markdown generated, skipping comment"
+            exit 0
+          fi
+          marker="<!-- mapping-count-delta -->"
+          existing_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n 1)
+          body_json=$(jq -Rs '{body: .}' < mapping-delta.md)
+          if [ -n "$existing_id" ]; then
+            echo "$body_json" | gh api "repos/$REPO/issues/comments/$existing_id" -X PATCH --input -
+            echo "Updated existing sticky comment $existing_id"
+          else
+            echo "$body_json" | gh api "repos/$REPO/issues/$PR_NUMBER/comments" --input -
+            echo "Posted new sticky comment"
+          fi

--- a/scripts/Compare-MappingCounts.py
+++ b/scripts/Compare-MappingCounts.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Compare per-framework mapping counts between two registry snapshots.
+
+Catches the v2.22.0 AZ-enrichment-class bug where a build path silently
+dropped ~400 framework mappings across 26 AZ-* checks. CI does not have
+to re-run the full build to detect such loss — it just compares the
+committed registry on the PR head against the committed registry on
+main.
+
+Usage:
+    python scripts/Compare-MappingCounts.py <main> <head> [options]
+
+Options:
+    --threshold-pct N    Fail when any framework drops more than N%. Default 2.0.
+    --allow-drop FW      Whitelist a framework that may drop without failing.
+                         Repeatable. Used for intentional removals.
+    --markdown PATH      Write a sticky-comment-friendly markdown table to PATH.
+
+Exit 0 — no regressions (or all regressions whitelisted).
+Exit 1 — at least one un-whitelisted regression beyond the threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+STICKY_MARKER = "<!-- mapping-count-delta -->"
+
+
+def load_registry(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def count_mappings(registry: dict) -> dict[str, int]:
+    """Return {framework_id: count_of_checks_with_that_mapping}."""
+    counts: dict[str, int] = defaultdict(int)
+    for check in registry.get("checks", []):
+        for fw in check.get("frameworks", {}):
+            counts[fw] += 1
+    return dict(counts)
+
+
+def compare(
+    main_counts: dict[str, int],
+    head_counts: dict[str, int],
+    threshold_pct: float,
+    allow_drops: set[str],
+) -> tuple[list[dict], list[dict]]:
+    """Return (regressions, all_rows). Each row has framework, main, head, delta, delta_pct, status."""
+    all_frameworks = sorted(set(main_counts) | set(head_counts))
+    rows: list[dict] = []
+    regressions: list[dict] = []
+
+    for fw in all_frameworks:
+        m = main_counts.get(fw, 0)
+        h = head_counts.get(fw, 0)
+        if m == 0 and h == 0:
+            continue
+        delta = h - m
+        delta_pct = (delta / m * 100.0) if m > 0 else float("inf")
+
+        is_regression = (
+            m > 0
+            and delta < 0
+            and abs(delta_pct) > threshold_pct
+            and fw not in allow_drops
+        )
+        is_waived = (
+            m > 0
+            and delta < 0
+            and abs(delta_pct) > threshold_pct
+            and fw in allow_drops
+        )
+
+        if delta == 0:
+            status = "OK"
+        elif is_regression:
+            status = "FAIL"
+        elif is_waived:
+            status = "WAIVED"
+        elif delta < 0:
+            status = "DROP"  # below threshold, informational
+        elif m == 0:
+            status = "ADDED"
+        else:
+            status = "GROWN"
+
+        row = {
+            "framework": fw,
+            "main": m,
+            "head": h,
+            "delta": delta,
+            "delta_pct": delta_pct,
+            "status": status,
+        }
+        rows.append(row)
+        if is_regression:
+            regressions.append(row)
+
+    return regressions, rows
+
+
+def render_console(rows: list[dict], threshold_pct: float) -> str:
+    if not rows:
+        return "No frameworks with mappings in either snapshot."
+    fw_w = max(len("Framework"), max(len(r["framework"]) for r in rows))
+    out = []
+    out.append(f"{'Framework':<{fw_w}}  {'main':>6}  {'head':>6}  {'diff':>6}  {'diff%':>8}  Status")
+    out.append("-" * (fw_w + 42))
+    for r in rows:
+        pct = "    +inf" if r["delta_pct"] == float("inf") else f"{r['delta_pct']:+7.2f}%"
+        out.append(
+            f"{r['framework']:<{fw_w}}  {r['main']:>6}  {r['head']:>6}  "
+            f"{r['delta']:>+6}  {pct:>8}  {r['status']}"
+        )
+    out.append("")
+    out.append(f"(threshold: drops greater than {threshold_pct}% fail unless waived)")
+    return "\n".join(out)
+
+
+def render_markdown(
+    rows: list[dict],
+    regressions: list[dict],
+    threshold_pct: float,
+    allow_drops: set[str],
+) -> str:
+    lines: list[str] = [STICKY_MARKER, "", "## Framework mapping count delta", ""]
+
+    if not rows:
+        lines.append("_No mapping changes detected._")
+        return "\n".join(lines) + "\n"
+
+    lines.append("| Framework | main | this PR | Δ | Δ% | Status |")
+    lines.append("|---|---:|---:|---:|---:|:--:|")
+    icon = {
+        "OK": "✓",
+        "FAIL": "❌",
+        "WAIVED": "⚠️",
+        "DROP": "⚠️",
+        "ADDED": "✨",
+        "GROWN": "✓",
+    }
+    for r in rows:
+        pct = "—" if r["delta_pct"] == float("inf") else f"{r['delta_pct']:+.2f}%"
+        delta = f"{r['delta']:+d}" if r["delta"] != 0 else "0"
+        lines.append(
+            f"| `{r['framework']}` | {r['main']} | {r['head']} | "
+            f"{delta} | {pct} | {icon.get(r['status'], '?')} {r['status']} |"
+        )
+    lines.append("")
+
+    if regressions:
+        names = ", ".join(f"`{r['framework']}`" for r in regressions)
+        lines.append(
+            f"**Result:** ❌ FAIL — regression in {names} exceeds the {threshold_pct}% threshold."
+        )
+        lines.append("")
+        lines.append(
+            f"Override by adding a label of the form `ALLOW_MAPPING_DROP=<framework>` to this PR."
+        )
+    elif allow_drops:
+        waived = ", ".join(f"`{fw}`" for fw in sorted(allow_drops))
+        lines.append(
+            f"**Result:** ⚠️ PASS — drops in {waived} were waived via `ALLOW_MAPPING_DROP` label(s)."
+        )
+    else:
+        lines.append("**Result:** ✓ PASS — no framework mapping regressions detected.")
+
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("main", type=Path, help="path to main/baseline registry.json")
+    p.add_argument("head", type=Path, help="path to head/PR registry.json")
+    p.add_argument("--threshold-pct", type=float, default=2.0)
+    p.add_argument("--allow-drop", action="append", default=[], metavar="FW")
+    p.add_argument("--markdown", type=Path, default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    main_reg = load_registry(args.main)
+    head_reg = load_registry(args.head)
+
+    main_counts = count_mappings(main_reg)
+    head_counts = count_mappings(head_reg)
+
+    allow_drops = set(args.allow_drop)
+    regressions, rows = compare(main_counts, head_counts, args.threshold_pct, allow_drops)
+
+    print(render_console(rows, args.threshold_pct))
+
+    if args.markdown is not None:
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text(
+            render_markdown(rows, regressions, args.threshold_pct, allow_drops),
+            encoding="utf-8",
+        )
+        print(f"\nMarkdown delta written to {args.markdown}", file=sys.stderr)
+
+    if regressions:
+        for r in regressions:
+            print(
+                f"::error::Framework '{r['framework']}' dropped {abs(r['delta'])} "
+                f"mappings ({r['delta_pct']:+.2f}%, threshold {args.threshold_pct}%). "
+                f"Add label 'ALLOW_MAPPING_DROP={r['framework']}' if intentional.",
+                file=sys.stderr,
+            )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/fixtures/mapping-counts/baseline.json
+++ b/tests/fixtures/mapping-counts/baseline.json
@@ -1,0 +1,2005 @@
+{
+  "schemaVersion": "test-fixture",
+  "checks": [
+    {
+      "checkId": "TEST-001",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-002",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-003",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-004",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-005",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-006",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-007",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-008",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-009",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-010",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-011",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-012",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-013",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-014",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-015",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-016",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-017",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-018",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-019",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-020",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-021",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-022",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-023",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-024",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-025",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-026",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-027",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-028",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-029",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-030",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-031",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-032",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-033",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-034",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-035",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-036",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-037",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-038",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-039",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-040",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-041",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-042",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-043",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-044",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-045",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-046",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-047",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-048",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-049",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-050",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-051",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-052",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-053",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-054",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-055",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-056",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-057",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-058",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-059",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-060",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-061",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-062",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-063",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-064",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-065",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-066",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-067",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-068",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-069",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-070",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-071",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-072",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-073",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-074",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-075",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-076",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-077",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-078",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-079",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-080",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-081",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-082",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-083",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-084",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-085",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-086",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-087",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-088",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-089",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-090",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-091",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-092",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-093",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-094",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-095",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-096",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-097",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-098",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-099",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-100",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/mapping-counts/drop-1pct.json
+++ b/tests/fixtures/mapping-counts/drop-1pct.json
@@ -1,0 +1,2002 @@
+{
+  "schemaVersion": "test-fixture",
+  "checks": [
+    {
+      "checkId": "TEST-001",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-002",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-003",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-004",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-005",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-006",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-007",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-008",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-009",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-010",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-011",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-012",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-013",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-014",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-015",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-016",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-017",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-018",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-019",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-020",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-021",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-022",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-023",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-024",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-025",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-026",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-027",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-028",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-029",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-030",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-031",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-032",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-033",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-034",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-035",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-036",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-037",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-038",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-039",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-040",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-041",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-042",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-043",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-044",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-045",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-046",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-047",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-048",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-049",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-050",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-051",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-052",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-053",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-054",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-055",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-056",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-057",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-058",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-059",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-060",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-061",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-062",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-063",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-064",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-065",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-066",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-067",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-068",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-069",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-070",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-071",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-072",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-073",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-074",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-075",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-076",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-077",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-078",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-079",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-080",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-081",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-082",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-083",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-084",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-085",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-086",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-087",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-088",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-089",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-090",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-091",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-092",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-093",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-094",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-095",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-096",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-097",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-098",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-099",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-100",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/mapping-counts/drop-5pct.json
+++ b/tests/fixtures/mapping-counts/drop-5pct.json
@@ -1,0 +1,1990 @@
+{
+  "schemaVersion": "test-fixture",
+  "checks": [
+    {
+      "checkId": "TEST-001",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-002",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-003",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-004",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-005",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-006",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-007",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-008",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-009",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-010",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-011",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-012",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-013",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-014",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-015",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-016",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-017",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-018",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-019",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-020",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-021",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-022",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-023",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-024",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-025",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-026",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-027",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-028",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-029",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-030",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-031",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-032",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-033",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-034",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-035",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-036",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-037",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-038",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-039",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-040",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-041",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-042",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-043",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-044",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-045",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-046",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-047",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-048",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-049",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-050",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-051",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-052",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-053",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-054",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-055",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-056",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-057",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-058",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-059",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-060",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-061",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-062",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-063",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-064",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-065",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-066",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-067",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-068",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-069",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-070",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-071",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-072",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-073",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-074",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-075",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-076",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-077",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-078",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-079",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-080",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-081",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-082",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-083",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-084",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-085",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-086",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-087",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-088",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-089",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-090",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-091",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-092",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-093",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-094",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-095",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-096",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-097",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-098",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-099",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-100",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/mapping-counts/framework-added.json
+++ b/tests/fixtures/mapping-counts/framework-added.json
@@ -1,0 +1,2305 @@
+{
+  "schemaVersion": "test-fixture",
+  "checks": [
+    {
+      "checkId": "TEST-001",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-002",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-003",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-004",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-005",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-006",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-007",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-008",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-009",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-010",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-011",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-012",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-013",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-014",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-015",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-016",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-017",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-018",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-019",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-020",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-021",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-022",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-023",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-024",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-025",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-026",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-027",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-028",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-029",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-030",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-031",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-032",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-033",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-034",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-035",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-036",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-037",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-038",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-039",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-040",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-041",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-042",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-043",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-044",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-045",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-046",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-047",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-048",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-049",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-050",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-051",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-052",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-053",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-054",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-055",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-056",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-057",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-058",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-059",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-060",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-061",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-062",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-063",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-064",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-065",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-066",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-067",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-068",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-069",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-070",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-071",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-072",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-073",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-074",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-075",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-076",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-077",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-078",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-079",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-080",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-081",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-082",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-083",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-084",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-085",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-086",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-087",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-088",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-089",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-090",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-091",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-092",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-093",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-094",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-095",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-096",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-097",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-098",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-099",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-100",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "X"
+        },
+        "fw-c": {
+          "controlId": "X"
+        },
+        "fw-d": {
+          "controlId": "X"
+        },
+        "fw-e": {
+          "controlId": "X"
+        },
+        "fw-f": {
+          "controlId": "X"
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/mapping-counts/generate.py
+++ b/tests/fixtures/mapping-counts/generate.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Generate fixture registries for mapping-count regression tests.
+
+Run from repo root:
+    python tests/fixtures/mapping-counts/generate.py
+
+Outputs four files in tests/fixtures/mapping-counts/:
+    baseline.json         — 100 checks, each mapped to {fw-a, fw-b, fw-c, fw-d, fw-e}
+    drop-1pct.json        — 1 check loses fw-e (99/100, under 2% threshold)
+    drop-5pct.json        — 5 checks lose fw-e (95/100, over 2% threshold)
+    framework-added.json  — every check gains fw-f (100/100, additive change)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+N = 100
+HERE = Path(__file__).resolve().parent
+
+
+def base() -> dict:
+    return {
+        "schemaVersion": "test-fixture",
+        "checks": [
+            {
+                "checkId": f"TEST-{i:03d}",
+                "frameworks": {
+                    "fw-a": {"controlId": "X"},
+                    "fw-b": {"controlId": "X"},
+                    "fw-c": {"controlId": "X"},
+                    "fw-d": {"controlId": "X"},
+                    "fw-e": {"controlId": "X"},
+                },
+            }
+            for i in range(1, N + 1)
+        ],
+    }
+
+
+def write(name: str, data: dict) -> None:
+    out = HERE / f"{name}.json"
+    out.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {out}")
+
+
+def main() -> None:
+    baseline = base()
+    write("baseline", baseline)
+
+    drop_1pct = base()
+    drop_1pct["checks"][0]["frameworks"].pop("fw-e")
+    write("drop-1pct", drop_1pct)
+
+    drop_5pct = base()
+    for i in range(5):
+        drop_5pct["checks"][i]["frameworks"].pop("fw-e")
+    write("drop-5pct", drop_5pct)
+
+    framework_added = base()
+    for c in framework_added["checks"]:
+        c["frameworks"]["fw-f"] = {"controlId": "X"}
+    write("framework-added", framework_added)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/mapping-counts.Tests.ps1
+++ b/tests/mapping-counts.Tests.ps1
@@ -1,0 +1,78 @@
+Describe 'Mapping-Count Regression Gate' {
+
+    BeforeAll {
+        $script:repoRoot     = (Resolve-Path "$PSScriptRoot/..").Path
+        $script:comparator   = Join-Path $repoRoot 'scripts/Compare-MappingCounts.py'
+        $script:fixturesDir  = Join-Path $repoRoot 'tests/fixtures/mapping-counts'
+        $script:baseline     = Join-Path $fixturesDir 'baseline.json'
+        $script:drop1pct     = Join-Path $fixturesDir 'drop-1pct.json'
+        $script:drop5pct     = Join-Path $fixturesDir 'drop-5pct.json'
+        $script:fwAdded      = Join-Path $fixturesDir 'framework-added.json'
+        $script:registry     = Join-Path $repoRoot 'data/registry.json'
+    }
+
+    It 'Comparator script exists' {
+        Test-Path $comparator | Should -Be $true `
+            -Because "scripts/Compare-MappingCounts.py must exist"
+    }
+
+    It 'All fixtures exist' {
+        @($baseline, $drop1pct, $drop5pct, $fwAdded) | ForEach-Object {
+            Test-Path $_ | Should -Be $true -Because "fixture $_ must exist"
+        }
+    }
+
+    It 'Baseline vs baseline: zero change, exit 0' {
+        $output = python $comparator $baseline $baseline 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "identical registries must produce no regression: $($output -join "`n")"
+    }
+
+    It 'Baseline vs drop-1pct: 1% drop is below 2% threshold, exit 0' {
+        $output = python $comparator $baseline $drop1pct 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "1% drop is under default 2% threshold, must not fail: $($output -join "`n")"
+    }
+
+    It 'Baseline vs drop-5pct: 5% drop exceeds threshold, exit 1' {
+        $output = python $comparator $baseline $drop5pct 2>&1
+        $LASTEXITCODE | Should -Be 1 `
+            -Because "5% drop must fail the 2% gate"
+        ($output -join "`n") | Should -Match 'fw-e' `
+            -Because "error must name the regressed framework"
+    }
+
+    It 'Baseline vs drop-5pct with --allow-drop fw-e: passes with warning' {
+        $output = python $comparator $baseline $drop5pct --allow-drop fw-e 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "explicit --allow-drop must waive the gate: $($output -join "`n")"
+    }
+
+    It 'Baseline vs framework-added: additive change, exit 0' {
+        $output = python $comparator $baseline $fwAdded 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "additive change (fw-f from 0 to 100) is not a regression: $($output -join "`n")"
+    }
+
+    It 'Comparator handles real registry vs itself with exit 0' {
+        $output = python $comparator $registry $registry 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "real registry compared to itself must show zero deltas: $($output -join "`n")"
+    }
+
+    It 'Markdown output flag writes a delta table' {
+        $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "mapping-delta-$(New-Guid).md"
+        try {
+            $null = python $comparator $baseline $drop5pct --markdown $tmp 2>&1
+            Test-Path $tmp | Should -Be $true `
+                -Because "--markdown flag must write the file even when the gate fails"
+            $contents = Get-Content $tmp -Raw
+            $contents | Should -Match 'mapping-count-delta' `
+                -Because "markdown must contain the sticky-comment marker"
+            $contents | Should -Match 'fw-e' `
+                -Because "markdown must show the regressed framework"
+        } finally {
+            if (Test-Path $tmp) { Remove-Item $tmp -Force }
+        }
+    }
+}


### PR DESCRIPTION
Closes #255.

## Summary
- New \`scripts/Compare-MappingCounts.py\` compares per-framework mapping counts between two registry files and exits 1 when any framework drops more than 2% (configurable). Emits a console table + sticky-comment-friendly markdown.
- New PR-only job \`mapping-count-regression\` in \`validate.yml\` that fetches \`origin/main\`'s registry, runs the comparator, posts a marker-based sticky PR comment with the delta table, and fails the build on un-waived regressions.
- 9 Pester tests cover identical inputs, sub-threshold drop, over-threshold drop, \`--allow-drop\` waiver, additive change, real-registry self-comparison, and markdown shape.

## Why
Catches the v2.22.0 AZ-enrichment-class bug where ~400 framework mappings were silently dropped across 26 AZ-* checks. CI doesn't have to re-run the full build to detect such loss — it just compares the committed registry on the PR head against the committed registry on main.

## Override mechanism
Add a label to the PR of the form \`ALLOW_MAPPING_DROP=<framework>\` (e.g., \`ALLOW_MAPPING_DROP=nist-csf\`) for intentional removals (framework deprecation, cohort migration, etc.). The waiver shows up in the sticky comment as ⚠️ \`WAIVED\` so it's visible on the PR.

## Sticky-comment example (from local test)

> <!-- mapping-count-delta -->
>
> ## Framework mapping count delta
>
> | Framework | main | this PR | Δ | Δ% | Status |
> |---|---:|---:|---:|---:|:--:|
> | \`fw-a\` | 100 | 100 | 0 | +0.00% | ✓ OK |
> | \`fw-e\` | 100 | 95 | -5 | -5.00% | ❌ FAIL |
>
> **Result:** ❌ FAIL — regression in \`fw-e\` exceeds the 2.0% threshold.

## Test plan
- [x] Pester suite green locally (327 tests, +9 new)
- [x] Real registry compared to itself shows zero deltas, exit 0
- [ ] On this PR, the new \`mapping-count-regression\` job runs and posts a sticky comment showing zero deltas (since data/registry.json is unchanged)
- [ ] On a future PR that legitimately changes registry mappings, the comment correctly reflects the change

## Notes for review
- TDD discipline: fixtures + 9 Pester tests written first (8 red), then implementation (9 green).
- Fixtures are large (~9k lines of JSON) because they're 4× N=100-check synthetic registries needed to make 1% / 5% / additive scenarios cleanly distinguishable. Generated by \`tests/fixtures/mapping-counts/generate.py\` which is committed alongside for reproducibility.
- The sticky-comment posting uses \`jq\` + \`gh api --input -\` rather than \`gh pr comment\` to enable in-place updates via marker matching, avoiding comment churn.
- Console output uses ASCII (\`diff\`, \`diff%\`) instead of Δ to avoid Windows \`cp1252\` console encoding issues; markdown output keeps the rich Unicode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)