### PR TITLE
feat: tighten schema — require impactRating + remediation per check (#256)

### DIFF
--- a/data/registry.schema.json
+++ b/data/registry.schema.json
@@ -48,7 +48,9 @@
         "licensing",
         "scf",
         "frameworks",
-        "effort"
+        "effort",
+        "impactRating",
+        "remediation"
       ],
       "additionalProperties": false,
       "properties": {

--- a/tests/fixtures/schema-strict/missing-impactRating.json
+++ b/tests/fixtures/schema-strict/missing-impactRating.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "2.22.1",
+  "dataVersion": "2026-04-24",
+  "generatedFrom": "fixture",
+  "checks": [
+    {
+      "checkId": "TEST-MISSING-001",
+      "name": "Test check missing impactRating",
+      "category": "TEST",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": { "minimum": "E3" },
+      "scf": {
+        "primaryControlId": "IAC-01",
+        "domain": "Identification & Authentication",
+        "controlName": "Identification & Authentication",
+        "controlDescription": "Test description"
+      },
+      "frameworks": {
+        "nist-csf": { "controlId": "PR.AA-01" }
+      },
+      "effort": {
+        "complexity": 1,
+        "isPhased": false,
+        "phaseCount": 1,
+        "disruptionRisk": false
+      },
+      "remediation": "Test remediation"
+    }
+  ]
+}

--- a/tests/fixtures/schema-strict/missing-remediation.json
+++ b/tests/fixtures/schema-strict/missing-remediation.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "2.22.1",
+  "dataVersion": "2026-04-24",
+  "generatedFrom": "fixture",
+  "checks": [
+    {
+      "checkId": "TEST-MISSING-002",
+      "name": "Test check missing remediation",
+      "category": "TEST",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": { "minimum": "E3" },
+      "scf": {
+        "primaryControlId": "IAC-01",
+        "domain": "Identification & Authentication",
+        "controlName": "Identification & Authentication",
+        "controlDescription": "Test description"
+      },
+      "frameworks": {
+        "nist-csf": { "controlId": "PR.AA-01" }
+      },
+      "effort": {
+        "complexity": 1,
+        "isPhased": false,
+        "phaseCount": 1,
+        "disruptionRisk": false
+      },
+      "impactRating": { "severity": "Medium" }
+    }
+  ]
+}

--- a/tests/schema-strict.Tests.ps1
+++ b/tests/schema-strict.Tests.ps1
@@ -1,0 +1,80 @@
+Describe 'Schema-Strict Validation' {
+
+    BeforeAll {
+        $script:repoRoot      = (Resolve-Path "$PSScriptRoot/..").Path
+        $script:schemaPath    = Join-Path $repoRoot 'data/registry.schema.json'
+        $script:registryPath  = Join-Path $repoRoot 'data/registry.json'
+        $script:fixturesDir   = Join-Path $repoRoot 'tests/fixtures/schema-strict'
+        $script:missingImpact = Join-Path $fixturesDir 'missing-impactRating.json'
+        $script:missingRemed  = Join-Path $fixturesDir 'missing-remediation.json'
+
+        # Helper that runs jsonschema and captures exit code
+        function script:Test-AgainstSchema {
+            param([string]$Instance)
+            python -c @"
+import json, sys, jsonschema
+try:
+    schema = json.load(open(r'$schemaPath', encoding='utf-8'))
+    instance = json.load(open(r'$Instance', encoding='utf-8'))
+    jsonschema.validate(instance, schema)
+    print('VALID')
+except jsonschema.ValidationError as e:
+    print(f'INVALID: {e.message} at {list(e.absolute_path)}')
+    sys.exit(1)
+"@ 2>&1
+        }
+    }
+
+    It 'Schema requires impactRating at check level' {
+        $schema = Get-Content $schemaPath -Raw | ConvertFrom-Json
+        $schema.'$defs'.check.required | Should -Contain 'impactRating' `
+            -Because "v2.23 #256 tightened schema must require impactRating"
+    }
+
+    It 'Schema requires remediation at check level' {
+        $schema = Get-Content $schemaPath -Raw | ConvertFrom-Json
+        $schema.'$defs'.check.required | Should -Contain 'remediation' `
+            -Because "v2.23 #256 tightened schema must require remediation"
+    }
+
+    It 'Schema does NOT require rationale (must remain optional)' {
+        $schema = Get-Content $schemaPath -Raw | ConvertFrom-Json
+        $schema.'$defs'.check.required | Should -Not -Contain 'rationale' `
+            -Because "rationale is sparse content (~27%) and must remain optional"
+    }
+
+    It 'Schema does NOT require impact (must remain optional)' {
+        $schema = Get-Content $schemaPath -Raw | ConvertFrom-Json
+        $schema.'$defs'.check.required | Should -Not -Contain 'impact' `
+            -Because "impact is sparse content (~27%) and must remain optional"
+    }
+
+    It 'Schema does NOT require references (must remain optional)' {
+        $schema = Get-Content $schemaPath -Raw | ConvertFrom-Json
+        $schema.'$defs'.check.required | Should -Not -Contain 'references' `
+            -Because "references is sparse content (~27%) and must remain optional"
+    }
+
+    It 'Current registry.json validates against the tightened schema' {
+        $output = Test-AgainstSchema $registryPath
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "all 1105 production checks must pass the tightened schema: $output"
+        ($output -join "`n") | Should -Match 'VALID'
+    }
+
+    It 'Schema rejects a check missing impactRating' {
+        $output = Test-AgainstSchema $missingImpact
+        $LASTEXITCODE | Should -Be 1 `
+            -Because "tightened schema must reject checks missing impactRating"
+        ($output -join "`n") | Should -Match 'impactRating' `
+            -Because "validation error must name the missing field"
+    }
+
+    It 'Schema rejects a check missing remediation' {
+        $output = Test-AgainstSchema $missingRemed
+        $LASTEXITCODE | Should -Be 1 `
+            -Because "tightened schema must reject checks missing remediation"
+        ($output -join "`n") | Should -Match 'remediation' `
+            -Because "validation error must name the missing field"
+    }
+}


### PR DESCRIPTION
Closes #256.

## Summary
- Adds \`impactRating\` and \`remediation\` to the per-check \`required\` array in \`data/registry.schema.json\`.
- 100% of current production checks (1,105/1,105) already have both fields populated, so this is a contract tightening with no production impact today.
- Adds 8 Pester tests + 2 fixtures to prove the gate accepts current registry, rejects fixtures missing either field, and leaves sparse-content fields (\`rationale\`, \`impact\`, \`references\`) optional.

## Why
The CI step \`Validate registry against JSON Schema\` (validate.yml line 136-145) already runs \`jsonschema.validate(registry, schema)\` on every PR — but its strictness is determined by the schema. By adding these two fields to \`required\`, any future PR introducing a check missing either gets blocked at CI time with a precise \`'impactRating' is a required property\` / \`'remediation' is a required property\` error.

## What did NOT change
- \`rationale\`, \`impact\`, \`references\`, \`tags\` remain optional. These are sparse-content fields (~27% populated) governed by the separate enrichment metric (#257) and the v3.2 release-gate (#281) — they are intentionally NOT structurally required.
- The CI YAML — no changes needed; the existing schema-validation step automatically picks up the tightened schema.

## Test plan
- [x] Pester suite green locally (335 tests, +8 new)
- [x] Current \`data/registry.json\` validates against the tightened schema (1,105/1,105 checks)
- [x] Synthetic fixture missing \`impactRating\` is rejected with the field name in the error
- [x] Synthetic fixture missing \`remediation\` is rejected with the field name in the error
- [ ] CI passes on this PR (the \"Validate registry against JSON Schema\" step now enforces the tightened contract)

## Notes for review
- TDD discipline followed: schema edited first, registry-passes test confirmed it didn't break production data, then negative-path fixtures + Pester tests authored.
- Test helper validates against the full registry root (not the \`\$defs/check\` fragment), which is sufficient because the schema's per-check required-fields error fires before the registry-level \`minItems\` constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)