### PR TITLE
feat: enrichment metrics PR comment (#257)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -355,3 +355,55 @@ jobs:
             echo "$body_json" | gh api "repos/$REPO/issues/$PR_NUMBER/comments" --input -
             echo "Posted new sticky comment"
           fi
+
+  enrichment-metrics:
+    name: Enrichment Metrics
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Fetch main branch for comparison
+        run: git fetch origin main --depth=1
+
+      - name: Extract main registry
+        run: git show origin/main:data/registry.json > /tmp/registry-main.json
+
+      - name: Compute enrichment metrics (informational, non-blocking)
+        run: |
+          python scripts/Compute-EnrichmentMetrics.py \
+            /tmp/registry-main.json \
+            data/registry.json \
+            --markdown enrichment-metrics.md
+
+      - name: Post or update sticky comment with enrichment metrics
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ ! -f enrichment-metrics.md ]; then
+            echo "No metrics markdown generated, skipping comment"
+            exit 0
+          fi
+          marker="<!-- enrichment-metrics -->"
+          existing_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -n 1)
+          body_json=$(jq -Rs '{body: .}' < enrichment-metrics.md)
+          if [ -n "$existing_id" ]; then
+            echo "$body_json" | gh api "repos/$REPO/issues/comments/$existing_id" -X PATCH --input -
+            echo "Updated existing sticky comment $existing_id"
+          else
+            echo "$body_json" | gh api "repos/$REPO/issues/$PR_NUMBER/comments" --input -
+            echo "Posted new sticky comment"
+          fi

--- a/scripts/Compute-EnrichmentMetrics.py
+++ b/scripts/Compute-EnrichmentMetrics.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Compute rationale / impact / references population metrics for the registry.
+
+Informational tool. **Always exits 0** — this is a metric, not a gate.
+The hard release-gate for Critical/High enrichment lives in v3.2 (issue
+#281); this script's job is to surface trends on every PR so progress
+is visible without blocking routine work.
+
+Usage:
+    Snapshot:    python scripts/Compute-EnrichmentMetrics.py <registry>
+    Comparison:  python scripts/Compute-EnrichmentMetrics.py <main> <head>
+
+Options:
+    --markdown PATH   Also write a sticky-comment-friendly markdown table.
+
+The markdown output uses a stable HTML marker (`<!-- enrichment-metrics -->`)
+so a CI step can update one comment in place rather than spam new ones.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+STICKY_MARKER = "<!-- enrichment-metrics -->"
+ENRICHMENT_FIELDS = ("rationale", "impact", "references")
+
+
+def load(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _populated(check: dict, field: str) -> bool:
+    val = check.get(field)
+    if field == "references":
+        return bool(val)  # truthy list
+    return bool((val or "").strip())
+
+
+def overall(registry: dict) -> dict[str, int]:
+    out = {"total": 0, "rationale": 0, "impact": 0, "references": 0}
+    for c in registry.get("checks", []):
+        out["total"] += 1
+        for f in ENRICHMENT_FIELDS:
+            if _populated(c, f):
+                out[f] += 1
+    return out
+
+
+def per_framework(registry: dict) -> dict[str, dict[str, int]]:
+    by_fw: dict[str, dict[str, int]] = defaultdict(
+        lambda: {"total": 0, "rationale": 0, "impact": 0, "references": 0}
+    )
+    for c in registry.get("checks", []):
+        flags = {f: _populated(c, f) for f in ENRICHMENT_FIELDS}
+        for fw in c.get("frameworks", {}):
+            row = by_fw[fw]
+            row["total"] += 1
+            for f in ENRICHMENT_FIELDS:
+                if flags[f]:
+                    row[f] += 1
+    return dict(by_fw)
+
+
+def pct(numer: int, denom: int) -> float:
+    return (numer / denom * 100.0) if denom else 0.0
+
+
+def fmt_cell(numer: int, denom: int, delta_pp: float | None) -> str:
+    """Render one table cell: 'X.X% (n/d)' plus optional ' (Δ+P.Pp)'."""
+    p = pct(numer, denom)
+    s = f"{p:.1f}% ({numer}/{denom})"
+    if delta_pp is not None and abs(delta_pp) >= 0.05:
+        sign = "+" if delta_pp > 0 else ""
+        s += f" ({sign}{delta_pp:.1f}pp)"
+    return s
+
+
+def render_console(
+    head_overall: dict,
+    head_per_fw: dict,
+    main_overall: dict | None = None,
+    main_per_fw: dict | None = None,
+) -> str:
+    lines = []
+    lines.append("Enrichment metrics (rationale / impact / references)")
+    lines.append("")
+
+    def row(label: str, numer_key_pairs: list[tuple[int, int]]) -> str:
+        cells = []
+        for n, d in numer_key_pairs:
+            cells.append(f"{pct(n, d):>5.1f}% ({n}/{d})")
+        return f"  {label:<24} " + "  ".join(cells)
+
+    lines.append(f"{'':26}  rationale         impact            references")
+    lines.append(row("(overall)", [
+        (head_overall["rationale"], head_overall["total"]),
+        (head_overall["impact"], head_overall["total"]),
+        (head_overall["references"], head_overall["total"]),
+    ]))
+
+    for fw in sorted(head_per_fw):
+        r = head_per_fw[fw]
+        lines.append(row(fw, [
+            (r["rationale"], r["total"]),
+            (r["impact"], r["total"]),
+            (r["references"], r["total"]),
+        ]))
+
+    if main_overall is not None:
+        lines.append("")
+        lines.append("(comparison vs main: see --markdown output for delta detail)")
+    return "\n".join(lines)
+
+
+def _delta_pp(head: dict, main: dict, field: str) -> float:
+    return pct(head[field], head["total"]) - pct(main.get(field, 0), main.get("total", 0))
+
+
+def render_markdown(
+    head_overall: dict,
+    head_per_fw: dict,
+    main_overall: dict | None = None,
+    main_per_fw: dict | None = None,
+) -> str:
+    has_main = main_overall is not None
+    lines: list[str] = [STICKY_MARKER, "", "## Content enrichment population", ""]
+
+    # Headline row
+    if has_main:
+        d_r = _delta_pp(head_overall, main_overall, "rationale")
+        d_i = _delta_pp(head_overall, main_overall, "impact")
+        d_f = _delta_pp(head_overall, main_overall, "references")
+        lines.append(
+            f"**Overall ({head_overall['total']} checks):** "
+            f"rationale {fmt_cell(head_overall['rationale'], head_overall['total'], d_r)} • "
+            f"impact {fmt_cell(head_overall['impact'], head_overall['total'], d_i)} • "
+            f"references {fmt_cell(head_overall['references'], head_overall['total'], d_f)}"
+        )
+    else:
+        lines.append(
+            f"**Overall ({head_overall['total']} checks):** "
+            f"rationale {fmt_cell(head_overall['rationale'], head_overall['total'], None)} • "
+            f"impact {fmt_cell(head_overall['impact'], head_overall['total'], None)} • "
+            f"references {fmt_cell(head_overall['references'], head_overall['total'], None)}"
+        )
+    lines.append("")
+
+    lines.append("| Framework | n | rationale | impact | references |")
+    lines.append("|---|---:|---:|---:|---:|")
+    for fw in sorted(head_per_fw):
+        head_row = head_per_fw[fw]
+        main_row = (main_per_fw or {}).get(fw)
+        d_r = _delta_pp(head_row, main_row, "rationale") if main_row else None
+        d_i = _delta_pp(head_row, main_row, "impact") if main_row else None
+        d_f = _delta_pp(head_row, main_row, "references") if main_row else None
+        lines.append(
+            f"| `{fw}` | {head_row['total']} | "
+            f"{fmt_cell(head_row['rationale'], head_row['total'], d_r)} | "
+            f"{fmt_cell(head_row['impact'], head_row['total'], d_i)} | "
+            f"{fmt_cell(head_row['references'], head_row['total'], d_f)} |"
+        )
+    lines.append("")
+    lines.append("_Informational only — does not gate the build. The hard release-gate for "
+                 "Critical/High enrichment lives in #281 (v3.2.0)._")
+    return "\n".join(lines) + "\n"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("paths", nargs="+", type=Path, help="<head> for snapshot, or <main> <head> for comparison")
+    p.add_argument("--markdown", type=Path, default=None)
+    return p.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+
+    if len(args.paths) == 1:
+        head = load(args.paths[0])
+        main_reg = None
+    elif len(args.paths) == 2:
+        main_reg = load(args.paths[0])
+        head = load(args.paths[1])
+    else:
+        print("::error::expected 1 (snapshot) or 2 (comparison) registry paths", file=sys.stderr)
+        # Still exit 0 — script is non-blocking by contract.
+        return 0
+
+    head_overall = overall(head)
+    head_per_fw = per_framework(head)
+    main_overall = overall(main_reg) if main_reg is not None else None
+    main_per_fw = per_framework(main_reg) if main_reg is not None else None
+
+    print(render_console(head_overall, head_per_fw, main_overall, main_per_fw))
+
+    if args.markdown is not None:
+        args.markdown.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown.write_text(
+            render_markdown(head_overall, head_per_fw, main_overall, main_per_fw),
+            encoding="utf-8",
+        )
+        print(f"\nMarkdown written to {args.markdown}", file=sys.stderr)
+
+    return 0  # Always 0 — informational only.
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/enrichment-metrics.Tests.ps1
+++ b/tests/enrichment-metrics.Tests.ps1
@@ -1,0 +1,73 @@
+Describe 'Enrichment Metrics' {
+
+    BeforeAll {
+        $script:repoRoot     = (Resolve-Path "$PSScriptRoot/..").Path
+        $script:script       = Join-Path $repoRoot 'scripts/Compute-EnrichmentMetrics.py'
+        $script:fixturesDir  = Join-Path $repoRoot 'tests/fixtures/enrichment-metrics'
+        $script:sparse       = Join-Path $fixturesDir 'sparse.json'
+        $script:enriched     = Join-Path $fixturesDir 'enriched.json'
+        $script:registry     = Join-Path $repoRoot 'data/registry.json'
+    }
+
+    It 'Script exists' {
+        Test-Path $script | Should -Be $true
+    }
+
+    It 'Snapshot mode (single fixture) exits 0 and shows expected percentages' {
+        $output = python $script $sparse 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "metrics script must always exit 0 (informational, non-blocking)"
+        $combined = $output -join "`n"
+        # sparse fixture: 5/10 enriched → 50% on each metric
+        $combined | Should -Match '50' `
+            -Because "sparse fixture should report 50% population: $combined"
+    }
+
+    It 'Comparison mode (same fixture both sides) shows zero delta and exits 0' {
+        $output = python $script $sparse $sparse 2>&1
+        $LASTEXITCODE | Should -Be 0
+        $combined = $output -join "`n"
+        # No specific delta value asserted — zero deltas should appear as +0.00% or similar
+        $combined | Should -Match '50' `
+            -Because "fixture comparison must include the snapshot percentage"
+    }
+
+    It 'Comparison mode with enrichment improvement shows positive deltas' {
+        $output = python $script $sparse $enriched 2>&1
+        $LASTEXITCODE | Should -Be 0
+        $combined = $output -join "`n"
+        # enriched is 100% across the board; main was 50%; delta should be +50pp
+        $combined | Should -Match '\+50|50.0\+|100' `
+            -Because "moving from sparse to enriched must show a visible positive change: $combined"
+    }
+
+    It 'Markdown output flag writes a sticky-comment-friendly file' {
+        $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "enrichment-$(New-Guid).md"
+        try {
+            $null = python $script $sparse $enriched --markdown $tmp 2>&1
+            Test-Path $tmp | Should -Be $true
+            $contents = Get-Content $tmp -Raw
+            $contents | Should -Match 'enrichment-metrics' `
+                -Because "markdown must contain the sticky-comment marker"
+            $contents | Should -Match 'rationale' `
+                -Because "markdown must report the rationale metric"
+            $contents | Should -Match 'fw-a' `
+                -Because "markdown must include per-framework rows"
+        } finally {
+            if (Test-Path $tmp) { Remove-Item $tmp -Force }
+        }
+    }
+
+    It 'Always exits 0 even on regression (non-blocking by design)' {
+        # enriched-as-main vs sparse-as-head simulates a content regression.
+        $output = python $script $enriched $sparse 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "regression must not gate the build — see #281 for the actual release-gate"
+    }
+
+    It 'Handles real registry without erroring' {
+        $output = python $script $registry 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "real registry must produce valid metrics output: $($output -join "`n")"
+    }
+}

--- a/tests/fixtures/enrichment-metrics/enriched.json
+++ b/tests/fixtures/enrichment-metrics/enriched.json
@@ -1,0 +1,220 @@
+{
+  "schemaVersion": "test-fixture",
+  "checks": [
+    {
+      "checkId": "TEST-001",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-002",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-003",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-004",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-005",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-006",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-007",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-008",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-009",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-010",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/enrichment-metrics/generate.py
+++ b/tests/fixtures/enrichment-metrics/generate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Generate fixture registries for enrichment-metrics tests.
+
+Run from repo root:
+    python tests/fixtures/enrichment-metrics/generate.py
+
+Outputs in tests/fixtures/enrichment-metrics/:
+    sparse.json    — N=10 checks; 5 enriched (rationale + impact + 2 refs), 5 empty.
+                     All mapped to fw-a; the 5 enriched also mapped to fw-b.
+    enriched.json  — Same N=10 checks, but ALL have rationale + impact + 2 refs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+
+def make_check(idx: int, enriched: bool, in_fw_b: bool) -> dict:
+    base: dict = {
+        "checkId": f"TEST-{idx:03d}",
+        "frameworks": {"fw-a": {"controlId": "X"}},
+    }
+    if in_fw_b:
+        base["frameworks"]["fw-b"] = {"controlId": "Y"}
+    if enriched:
+        base["rationale"] = "Why this control matters."
+        base["impact"] = "What an attacker sees on failure."
+        base["references"] = [
+            {"url": "https://learn.microsoft.com/example", "title": "Example doc 1"},
+            {"url": "https://learn.microsoft.com/another", "title": "Example doc 2"},
+        ]
+    return base
+
+
+def write(name: str, data: dict) -> None:
+    out = HERE / f"{name}.json"
+    out.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {out}")
+
+
+def main() -> None:
+    # sparse: 5 enriched, 5 empty; the 5 enriched are also in fw-b
+    sparse_checks = [
+        make_check(i, enriched=(i <= 5), in_fw_b=(i <= 5))
+        for i in range(1, 11)
+    ]
+    write(
+        "sparse",
+        {
+            "schemaVersion": "test-fixture",
+            "checks": sparse_checks,
+        },
+    )
+
+    # enriched: ALL 10 enriched; same fw-b membership pattern as sparse so deltas
+    # cleanly attribute to enrichment changes only (not membership changes).
+    enriched_checks = [
+        make_check(i, enriched=True, in_fw_b=(i <= 5))
+        for i in range(1, 11)
+    ]
+    write(
+        "enriched",
+        {
+            "schemaVersion": "test-fixture",
+            "checks": enriched_checks,
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/enrichment-metrics/sparse.json
+++ b/tests/fixtures/enrichment-metrics/sparse.json
@@ -1,0 +1,160 @@
+{
+  "schemaVersion": "test-fixture",
+  "checks": [
+    {
+      "checkId": "TEST-001",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-002",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-003",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-004",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-005",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        },
+        "fw-b": {
+          "controlId": "Y"
+        }
+      },
+      "rationale": "Why this control matters.",
+      "impact": "What an attacker sees on failure.",
+      "references": [
+        {
+          "url": "https://learn.microsoft.com/example",
+          "title": "Example doc 1"
+        },
+        {
+          "url": "https://learn.microsoft.com/another",
+          "title": "Example doc 2"
+        }
+      ]
+    },
+    {
+      "checkId": "TEST-006",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-007",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-008",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-009",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      }
+    },
+    {
+      "checkId": "TEST-010",
+      "frameworks": {
+        "fw-a": {
+          "controlId": "X"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #257.

## Summary
- Adds \`scripts/Compute-EnrichmentMetrics.py\` — counts per-framework rationale/impact/references population, computes Δ vs main, emits sticky-comment markdown.
- Adds new PR-only \`enrichment-metrics\` job in validate.yml that posts a sticky comment using marker \`<!-- enrichment-metrics -->\`, separate from #255's mapping-count comment.
- 7 Pester tests + 2 fixtures (sparse 50%, enriched 100%) prove snapshot, comparison, regression-doesn't-fail, and markdown shape.

## Why
Visibility on enrichment trends without blocking. Pairs with #255 (structural mapping-count delta): structural integrity in one comment, content enrichment in another. Hard gate for Critical/High enrichment is separate (#281, v3.2.0).

## Real-registry snapshot (from local run)
- **Overall:** 26.3% rationale / 26.3% impact / 26.3% references (1,105 checks)
- **100% enriched:** cis-m365-v6, cisa-scuba, eidsca, gdpr, stig
- **Sparsest:** essential-eight (22.2%), nis2 (25.7%)

## Test plan
- [x] Pester suite green locally (342 tests, +7 new)
- [x] Script always exits 0 even on regression
- [x] Snapshot mode + comparison mode both produce valid markdown
- [ ] CI passes on this PR; the new \`enrichment-metrics\` job runs and posts a sticky comment showing zero deltas (since data/registry.json is unchanged)

## Notes for review
- TDD discipline: 7 Pester tests written first, all 7 red, then implementation, all 7 green.
- Reuses the marker-based sticky-comment pattern from #255 — different marker (\`<!-- enrichment-metrics -->\`) so the two comments don't clobber each other.
- Script is **non-blocking by contract**. \`return 0\` is in the always-taken path; the test \"Always exits 0 even on regression\" verifies this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)