### PR TITLE
feat: defense-in-depth guards in Build-Registry.py (#258)

### DIFF
--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -44,6 +44,34 @@ SCHEMA_VERSION = "2.22.1"
 
 
 # ---------------------------------------------------------------------------
+# Strict JSON loader — defense in depth against the v2.22.0 dup-key bug class
+# ---------------------------------------------------------------------------
+
+def _strict_load_json(path: Path) -> object:
+    """Load JSON, raising ValueError on duplicate keys.
+
+    Python's json.load silently keeps the last value when an object contains
+    duplicate keys. That bug class lost 4 framework overrides in v2.22.0 and
+    was caught only by downstream cross-validation. This helper makes the
+    same bug class structurally impossible at build time (mirrors the CI gate
+    in scripts/Validate-NoDuplicateKeys.py).
+    """
+    def _reject_duplicates(pairs: list[tuple]) -> dict:
+        seen: dict = {}
+        for k, v in pairs:
+            if k in seen:
+                raise ValueError(
+                    f"{path.name}: duplicate key '{k}'. "
+                    "Merge the two entries instead of appending a second one."
+                )
+            seen[k] = v
+        return seen
+
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh, object_pairs_hook=_reject_duplicates)
+
+
+# ---------------------------------------------------------------------------
 # SCF database helpers
 # ---------------------------------------------------------------------------
 
@@ -143,7 +171,7 @@ def load_cis_m365_crosswalk(repo_root: Path) -> dict:
     path = repo_root / "data" / "cis-m365-crosswalk.json"
     if not path.exists():
         return {}
-    data = json.loads(path.read_text(encoding="utf-8"))
+    data = _strict_load_json(path)
     return data.get("controls", {})
 
 
@@ -156,7 +184,7 @@ def load_scuba_nist_mapping(repo_root: Path) -> dict:
     path = repo_root / "data" / "scuba-nist-mapping.json"
     if not path.exists():
         return {}
-    data = json.loads(path.read_text(encoding="utf-8"))
+    data = _strict_load_json(path)
     return data.get("controls", {})
 
 
@@ -219,8 +247,7 @@ def load_framework_titles(path: Path) -> dict[str, dict[str, str]]:
     """Load framework-titles.json as {framework_key: {control_id: title}}."""
     if not path.exists():
         return {}
-    with open(path, "r", encoding="utf-8") as f:
-        data = json.load(f)
+    data = _strict_load_json(path)
     return {k: dict(v.items()) if isinstance(v, dict) else {} for k, v in data.items()}
 
 
@@ -302,12 +329,11 @@ def load_az_assess_source_checks(repo_root: Path) -> list[dict]:
     source_path = repo_root / "data" / "az-assess-source-checks.json"
     if not source_path.exists():
         return []
-    with open(source_path, encoding="utf-8") as f:
-        try:
-            entries = json.load(f)
-        except json.JSONDecodeError as exc:
-            print(f"WARN: az-assess-source-checks.json is invalid JSON — skipping: {exc}")
-            return []
+    try:
+        entries = _strict_load_json(source_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"WARN: az-assess-source-checks.json is invalid — skipping: {exc}")
+        return []
     if not isinstance(entries, list):
         print(f"WARN: az-assess-source-checks.json must be a JSON array, got {type(entries).__name__} — skipping")
         return []
@@ -405,8 +431,7 @@ def load_effort_overrides(repo_root: Path) -> dict[str, dict]:
     path = repo_root / "data" / "effort-overrides.json"
     if not path.exists():
         return {}
-    with open(path, encoding="utf-8") as f:
-        data = json.load(f)
+    data = _strict_load_json(path)
     raw = data.get("overrides", {})
     return {
         cid: {k: v for k, v in entry.items() if not k.startswith("_")}
@@ -774,12 +799,10 @@ def main():
     title_path = REPO_ROOT / "data" / "framework-titles.json"
 
     print(f"Loading check mapping from {mapping_path}")
-    with open(mapping_path, "r", encoding="utf-8") as f:
-        check_mapping = json.load(f)
+    check_mapping = _strict_load_json(mapping_path)
 
     print(f"Loading framework map from {fw_map_path}")
-    with open(fw_map_path, "r", encoding="utf-8") as f:
-        fw_map = json.load(f)
+    fw_map = _strict_load_json(fw_map_path)
 
     print("Loading framework titles...")
     titles = load_framework_titles(title_path)
@@ -791,18 +814,7 @@ def main():
     overrides_path = REPO_ROOT / "data" / "framework-overrides.json"
     fw_overrides: dict[str, dict] = {}
     if overrides_path.exists():
-        def _reject_duplicates(pairs: list[tuple]) -> dict:
-            seen: dict = {}
-            for k, v in pairs:
-                if k in seen:
-                    raise ValueError(
-                        f"framework-overrides.json: duplicate key '{k}'. "
-                        "Merge the two entries instead of appending a second one."
-                    )
-                seen[k] = v
-            return seen
-        with open(overrides_path, "r", encoding="utf-8") as f:
-            overrides_data = json.load(f, object_pairs_hook=_reject_duplicates)
+        overrides_data = _strict_load_json(overrides_path)
         fw_overrides = overrides_data.get("overrides", {})
         print(f"Loaded {len(fw_overrides)} framework overrides")
 
@@ -1037,6 +1049,32 @@ def main():
     registry["generatedFrom"] = sources
     registry["checks"] = checks
 
+    # Pre-write schema validation — defense in depth.
+    # CI runs the same validation, but failing here prevents a malformed
+    # registry from being written to disk (which would then propagate to
+    # consumers who pull this branch locally before CI catches it).
+    schema_validated = False
+    schema_path = REPO_ROOT / "data" / "registry.schema.json"
+    if schema_path.exists():
+        try:
+            import jsonschema  # soft import; skip with warning if missing
+        except ImportError:
+            print(
+                "WARN: jsonschema not installed — skipping pre-write schema validation. "
+                "CI will still validate. Install with: pip install jsonschema"
+            )
+        else:
+            schema = _strict_load_json(schema_path)
+            try:
+                jsonschema.validate(registry, schema)
+                print(f"  Pre-write schema validation: PASS ({len(checks)} checks)")
+                schema_validated = True
+            except jsonschema.ValidationError as exc:
+                raise ValueError(
+                    f"Built registry fails schema validation: {exc.message} "
+                    f"at {list(exc.absolute_path)}. Refusing to write."
+                ) from exc
+
     # Write output
     print(f"\nWriting registry to {args.output}")
     with open(args.output, "w", encoding="utf-8", newline="\n") as f:
@@ -1077,7 +1115,13 @@ def main():
             print(w)
 
     conn.close()
-    print("\nDone.")
+
+    # One-line affirmation that all guards passed (#258).
+    schema_status = "schema validated" if schema_validated else "schema validation SKIPPED"
+    print(
+        f"\n[OK] {len(checks)} checks, {len(fw_counts)} frameworks, "
+        f"0 dup-key violations, {schema_status}. Done."
+    )
 
 
 if __name__ == "__main__":

--- a/tests/build-registry-guards.Tests.ps1
+++ b/tests/build-registry-guards.Tests.ps1
@@ -1,0 +1,90 @@
+Describe 'Build-Registry.py defense-in-depth guards (#258)' {
+
+    BeforeAll {
+        $script:repoRoot   = (Resolve-Path "$PSScriptRoot/..").Path
+        $script:script     = Join-Path $repoRoot 'scripts/Build-Registry.py'
+        $script:source     = Get-Content $script -Raw
+        $script:brokenFix  = Join-Path $repoRoot 'tests/fixtures/duplicate-key/broken.json'
+    }
+
+    It 'Defines _strict_load_json helper at module level' {
+        $source | Should -Match 'def\s+_strict_load_json\s*\(' `
+            -Because "module-level dup-key-rejecting JSON loader is the cornerstone of the guard"
+    }
+
+    It 'Has no unguarded json.load calls outside the helper' {
+        # Allowed: the json.load inside _strict_load_json itself (line ~71).
+        # Disallowed: any other bare json.load(...) or json.loads(file.read_text())
+        # that bypasses the strict helper.
+        $lines = $source -split "`r?`n"
+        $offenders = @()
+        $insideHelper = $false
+        for ($i = 0; $i -lt $lines.Count; $i++) {
+            $line = $lines[$i]
+            if ($line -match '^def\s+_strict_load_json') { $insideHelper = $true; continue }
+            if ($insideHelper -and $line -match '^def\s+\w' -and $line -notmatch '_reject_duplicates') {
+                # Next top-level def — left the helper.
+                $insideHelper = $false
+            }
+            if ($insideHelper) { continue }
+            # Match actual call sites (json.load(...) / json.loads(...)) — not comments.
+            if ($line -match '\bjson\.load\s*\(' -or $line -match '\bjson\.loads\s*\(') {
+                $offenders += "line $($i+1): $($line.Trim())"
+            }
+        }
+        $offenders | Should -BeNullOrEmpty `
+            -Because "every input JSON load must go through _strict_load_json. Found: $($offenders -join '; ')"
+    }
+
+    It 'Calls _strict_load_json multiple times (input file count sanity)' {
+        $matches_ = [regex]::Matches($source, '_strict_load_json\s*\(')
+        # Helper definition + at least 7 call sites (8 input files; framework-titles
+        # goes through load_framework_titles which uses the helper).
+        $matches_.Count | Should -BeGreaterOrEqual 8 `
+            -Because "expect helper used for every input JSON file (~7 call sites + 1 definition)"
+    }
+
+    It 'Includes pre-write schema validation block' {
+        $source | Should -Match 'jsonschema\.validate\s*\(\s*registry\s*,' `
+            -Because "build must validate registry against schema before write"
+        $source | Should -Match 'Refusing to write' `
+            -Because "validation failure must abort write with a clear message"
+    }
+
+    It 'Schema validation is wrapped in soft import (does not hard-require jsonschema)' {
+        $source | Should -Match 'import jsonschema' `
+            -Because "must import jsonschema"
+        # Soft-import pattern: try/except ImportError around the import
+        $source | Should -Match 'except ImportError' `
+            -Because "soft import lets users without jsonschema still build (CI catches violations)"
+    }
+
+    It 'Emits one-line guards-passed summary at the end' {
+        $source | Should -Match 'dup-key violations' `
+            -Because "the final summary affirms the dup-key gate ran"
+        $source | Should -Match 'schema validat' `
+            -Because "the final summary mentions schema validation status"
+    }
+
+    It 'Helper raises ValueError on duplicate keys (functional check)' {
+        $output = python -c @"
+import sys, importlib.util
+from pathlib import Path
+spec = importlib.util.spec_from_file_location('br', r'$script')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+try:
+    mod._strict_load_json(Path(r'$brokenFix'))
+    print('FAIL: did not raise')
+    sys.exit(1)
+except ValueError as e:
+    if 'duplicate key' in str(e):
+        print('PASS')
+    else:
+        print(f'FAIL: wrong message: {e}')
+        sys.exit(1)
+"@ 2>&1
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "helper must reject the duplicate-key fixture: $($output -join "`n")"
+    }
+}


### PR DESCRIPTION
Closes #258.

## Summary
Mirrors the CI gates from #254 (dup-key) and #256 (schema-strict) inside Build-Registry.py itself. Local builds now fail loudly instead of silently producing a malformed registry that only gets caught at PR time.

## What changed
- **\`_strict_load_json\` helper** at module level — single source of truth for dup-key-rejecting JSON loads.
- **All 7 input JSON loads** routed through the helper (cis-m365-crosswalk, scuba-nist-mapping, framework-titles, az-assess-source-checks, effort-overrides, scf-check-mapping, scf-framework-map). framework-overrides was already strict; consolidated to the same helper.
- **Pre-write schema validation** — \`jsonschema.validate(registry, schema)\` runs before \`write_text\`. Refuses to write on violation. Soft-imports jsonschema (warns + skips if not installed); CI still validates.
- **One-line affirmation** at end: \`[OK] N checks, M frameworks, 0 dup-key violations, schema validated. Done.\` Honest reporting — says \"SKIPPED\" if jsonschema missing.

## Why
Defense in depth. Local builds (e.g., during \`Build-Registry.py\` runs while iterating on data) shouldn't be able to write a malformed registry to disk that then propagates to anyone pulling that branch before CI catches it. Same gates, run earlier.

## Test plan
- [x] \`py_compile\` passes
- [x] Full Pester suite green locally (349 tests, +7 new)
- [x] Helper raises \`ValueError\` on \`tests/fixtures/duplicate-key/broken.json\` with the expected message
- [x] Static check: zero unguarded \`json.load(\` / \`json.loads(\` call sites remain in Build-Registry.py outside the helper
- [ ] CI passes on this PR

## Notes for review
- Did NOT extract the helper to a shared module (e.g., \`scripts/_strict_json.py\`). Two reasons: (1) the helper is 15 lines, duplication is mild, and (2) Validate-NoDuplicateKeys.py from #254 has its own subtly-different version (CLI tool with multi-error collection vs. inline raise). If a third caller appears, refactoring to a shared module is cheap.
- Schema validation soft-imports jsonschema deliberately — Build-Registry.py was previously runnable without it. Hard-requiring would break local users without the package installed. CI installs it, so the gate is enforced where it matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)