### PR TITLE
feat: per-mapping provenance fields in schema (#260)

### DIFF
--- a/data/registry.schema.json
+++ b/data/registry.schema.json
@@ -388,6 +388,22 @@
         },
         "evidenceType": {
           "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "scf-derived",
+            "manual-override",
+            "cis-paraphrased",
+            "stig-manual",
+            "eidsca-crosswalk"
+          ],
+          "description": "Where this mapping came from. Absent means scf-derived (default). 'manual-override' means it was added in framework-overrides.json (or, post-v3.0, inlined on the check). 'cis-paraphrased' / 'eidsca-crosswalk' / 'stig-manual' identify other authored sources."
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Free-text explanation for why this mapping exists. Primarily used on 'manual-override' entries to capture tribal knowledge (e.g. 'SCF lacks PR.AA-05 coverage for sign-in frequency'). Absent on 'scf-derived' entries since the source is self-explanatory."
         }
       }
     }

--- a/tests/fixtures/mapping-provenance/invalid-source-value.json
+++ b/tests/fixtures/mapping-provenance/invalid-source-value.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "2.23.0",
+  "dataVersion": "2026-04-25",
+  "generatedFrom": "fixture",
+  "checks": [
+    {
+      "checkId": "TEST-PROVENANCE-002",
+      "name": "Test check with invalid source value",
+      "category": "TEST",
+      "collector": "Entra",
+      "hasAutomatedCheck": true,
+      "licensing": { "minimum": "E3" },
+      "scf": {
+        "primaryControlId": "IAC-01",
+        "domain": "Identification & Authentication",
+        "controlName": "IA",
+        "controlDescription": "test"
+      },
+      "frameworks": {
+        "fw-bogus": { "controlId": "X", "source": "made-up-source" }
+      },
+      "effort": {
+        "complexity": 1,
+        "isPhased": false,
+        "phaseCount": 1,
+        "disruptionRisk": false
+      },
+      "impactRating": { "severity": "Medium" },
+      "remediation": "Test"
+    }
+  ]
+}

--- a/tests/mapping-provenance.Tests.ps1
+++ b/tests/mapping-provenance.Tests.ps1
@@ -1,0 +1,68 @@
+Describe 'Per-Mapping Provenance (#260)' {
+
+    BeforeAll {
+        $script:repoRoot      = (Resolve-Path "$PSScriptRoot/..").Path
+        $script:schemaPath    = Join-Path $repoRoot 'data/registry.schema.json'
+        $script:registryPath  = Join-Path $repoRoot 'data/registry.json'
+        $script:fixturesDir   = Join-Path $repoRoot 'tests/fixtures/mapping-provenance'
+        $script:validFixture  = Join-Path $fixturesDir 'valid-source-values.json'
+        $script:invalidFixture = Join-Path $fixturesDir 'invalid-source-value.json'
+
+        function script:Test-AgainstSchema {
+            param([string]$Instance)
+            python -c @"
+import json, sys, jsonschema
+try:
+    schema = json.load(open(r'$schemaPath', encoding='utf-8'))
+    instance = json.load(open(r'$Instance', encoding='utf-8'))
+    jsonschema.validate(instance, schema)
+    print('VALID')
+except jsonschema.ValidationError as e:
+    print(f'INVALID: {e.message} at {list(e.absolute_path)}')
+    sys.exit(1)
+"@ 2>&1
+        }
+    }
+
+    It 'Schema declares source as an enum' {
+        $schema = Get-Content $schemaPath -Raw | ConvertFrom-Json
+        $sourceProp = $schema.'$defs'.frameworkMapping.properties.source
+        $sourceProp | Should -Not -BeNullOrEmpty `
+            -Because "frameworkMapping must define a source property"
+        $sourceProp.enum | Should -Contain 'scf-derived'
+        $sourceProp.enum | Should -Contain 'manual-override'
+        $sourceProp.enum | Should -Contain 'cis-paraphrased'
+        $sourceProp.enum | Should -Contain 'stig-manual'
+        $sourceProp.enum | Should -Contain 'eidsca-crosswalk'
+    }
+
+    It 'Schema declares reason as an optional string' {
+        $schema = Get-Content $schemaPath -Raw | ConvertFrom-Json
+        $reasonProp = $schema.'$defs'.frameworkMapping.properties.reason
+        $reasonProp | Should -Not -BeNullOrEmpty
+        $reasonProp.type | Should -Be 'string'
+    }
+
+    It 'Schema does NOT require source or reason' {
+        $schema = Get-Content $schemaPath -Raw | ConvertFrom-Json
+        $required = $schema.'$defs'.frameworkMapping.required
+        $required | Should -Not -Contain 'source' `
+            -Because "source is optional; absence means scf-derived (the default)"
+        $required | Should -Not -Contain 'reason' `
+            -Because "reason is optional; only meaningful on overrides"
+    }
+
+    It 'Current registry.json validates against the schema (no data changes yet)' {
+        $output = Test-AgainstSchema $registryPath
+        $LASTEXITCODE | Should -Be 0 `
+            -Because "v3.0.0 setup must not require data changes from v2.23.0: $output"
+    }
+
+    It 'Schema rejects an unknown source value' {
+        $output = Test-AgainstSchema $invalidFixture
+        $LASTEXITCODE | Should -Be 1 `
+            -Because "unknown source value must fail validation"
+        ($output -join "`n") | Should -Match 'made-up-source|enum' `
+            -Because "validation error must point at the bad value or enum"
+    }
+}


### PR DESCRIPTION
Closes #260. **First v3.0.0 milestone PR.**

## Summary
- Adds two optional fields to \`\$defs/frameworkMapping\` in \`data/registry.schema.json\`:
  - \`source\` — enum of {\`scf-derived\`, \`manual-override\`, \`cis-paraphrased\`, \`stig-manual\`, \`eidsca-crosswalk\`}. Absent means scf-derived (default).
  - \`reason\` — free-text explanation, primarily used on \`manual-override\` entries.
- 5 Pester tests + 1 fixture (rejects unknown source values).

## Why
Lays groundwork for v3.0's main story. Future v3.0 issues populate these:
- #262 dissolves \`framework-overrides.json\` → mappings carry \`source: \"manual-override\"\` + \`reason\` from override annotations
- Other ingest paths set source when known (CIS crosswalk → \`cis-paraphrased\`, EIDSCA → \`eidsca-crosswalk\`, etc.)

## Test plan
- [x] Full Pester suite green locally (354 tests, +5 new)
- [x] Current \`registry.json\` validates against new schema (no data changes — additive only)
- [x] Schema rejects synthetic fixture with \`source: \"made-up-source\"\`
- [ ] CI passes

## Notes for review
- Purely additive. Not a breaking change in itself — the breaking parts of v3.0 (dissolved override files, structured remediation) come in #261/#262/#263/#264.
- Once this lands, downstream consumers can begin reading \`source\` / \`reason\` if they want — though most mappings won't carry the fields until #262 populates them.
- Followed the same TDD pattern as v2.23 PRs: tests written first, schema edited until tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)