### PR TITLE
feat: force-replace override mode + fix #316 SOC 2 retarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **`force-replace` override mode** in `scripts/Build-Registry.py` `apply_fw_overrides()`. Until now, `mode: "replace"` (the default) only filled when the framework key was absent — if SCF had already produced an entry, the override silently became a no-op for the controlId. The new `force-replace` mode fully discards the SCF-derived entry and rebuilds it from override data (controlId, title resolved from `framework-titles.json`, profiles, evidenceType, source, reason). Use it when SCF's mapping is wrong for a framework — e.g., SCF maps SEA-18 to SOC 2 CC2.2 but `soc2-tsc.json` classifies CC2 as `nonAutomatableCriteria`. ([#316](https://github.com/Galvnyz/CheckID/issues/316))
+- **`tests/test_build_registry_overrides.py`** — pytest unit tests covering all three modes (`replace`, `append`, `force-replace`) including the case where `force-replace` has no SCF entry to discard.
+
+### Fixed
+
+- **`ENTRA-TOU-001` SOC 2 mapping** ([#316](https://github.com/Galvnyz/CheckID/issues/316)). Changed from `CC2.2` (Internal Communication, classified as non-automatable per `soc2-tsc.json`) to `CC5` (Control Activities — *"Security policies and procedures are in place and operating effectively"*) using the new `force-replace` mode. Terms of Use enforcement is automatable via Graph and is a textbook control activity, not an internal-communication policy review.
+
+### Changed
+
+- **`tests/migration-3.0.Tests.ps1`** — added a `postMigrationRetargets` exemption list for the framework-overrides round-trip test. Distinguishes intentional `force-replace` re-targets (where the v2.23 controlId is no longer literally present in the registry) from accidental data loss during migration. Each entry documents the reason and references the issue number.
+
 ## [3.0.0] - 2026-04-25
 
 **Theme:** Schema Foundation — provenance + structured remediation. **BREAKING CHANGE.** Consumers must update their renderers; see `docs/SCHEMA-MIGRATION-3.0.md`.

--- a/data/registry.json
+++ b/data/registry.json
@@ -96123,9 +96123,10 @@
           ]
         },
         "soc2": {
-          "controlId": "CC2.2",
-          "title": "COSO Principle 14: Internal Communication",
-          "source": "manual-override"
+          "controlId": "CC5",
+          "title": "Control Activities",
+          "source": "manual-override",
+          "reason": "SCF maps SEA-18 (System Use Notification) to SOC 2 CC2.2 (Internal Communication), but soc2-tsc.json classifies the entire CC2 family as nonAutomatableCriteria — those criteria require policy documentation review, not config-state checks. Terms of Use is a Control Activity (CC5 — 'Security policies and procedures are in place and operating effectively'), which is automatable via Graph. force-replace lands on CC5 instead of carrying both."
         }
       },
       "impactRating": {

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -11451,7 +11451,9 @@
       ],
       "frameworkOverrides": {
         "soc2": {
-          "controlId": "CC2.2"
+          "controlId": "CC5",
+          "mode": "force-replace",
+          "reason": "SCF maps SEA-18 (System Use Notification) to SOC 2 CC2.2 (Internal Communication), but soc2-tsc.json classifies the entire CC2 family as nonAutomatableCriteria — those criteria require policy documentation review, not config-state checks. Terms of Use is a Control Activity (CC5 — 'Security policies and procedures are in place and operating effectively'), which is automatable via Graph. force-replace lands on CC5 instead of carrying both."
         }
       },
       "effortOverride": {

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -685,8 +685,19 @@ def apply_fw_overrides(
     mappings from SCF-derived ones; an optional `reason` field is preserved
     when the override carries one.
 
-    Mode semantics: "replace" (default) fills when the key is absent;
-    "append" merges controlIds into an existing entry.
+    Mode semantics:
+      - "replace" (default): fills when the key is absent; tags an existing
+        SCF-derived entry as manual-override but does NOT overwrite its
+        controlId. Right choice when the curator's mapping agrees with SCF
+        and they only want to assert provenance.
+      - "append": merges the override controlId into an existing entry.
+        Use when both SCF's mapping and the curator's mapping should be
+        expressed (separate criteria, multi-control coverage).
+      - "force-replace": always builds a fresh entry from override data,
+        discarding any SCF-derived controlId / title for this framework.
+        Use when SCF's mapping is wrong for the framework — e.g., SCF maps
+        SEA-18 to SOC 2 CC2.2 but CC2 is non-automatable per soc2-tsc.json,
+        so we need to land on CC5 (Control Activities) instead.
     """
     for fw_key, fw_data in check_overrides.items():
         if not fw_data.get("controlId"):
@@ -698,16 +709,10 @@ def apply_fw_overrides(
             frameworks[fw_key]["source"] = "manual-override"
             if "reason" in fw_data:
                 frameworks[fw_key]["reason"] = fw_data["reason"]
-        elif fw_key in frameworks:
-            # mode == "replace" and key already present (e.g., SCF derivation
-            # produced it). Keep the SCF-supplied controlId and any extras
-            # (title, profiles), but tag the entry with manual-override
-            # provenance — the curator's deliberate decision to assert this
-            # mapping shouldn't be lost just because SCF produced the same.
-            frameworks[fw_key]["source"] = "manual-override"
-            if "reason" in fw_data:
-                frameworks[fw_key]["reason"] = fw_data["reason"]
-        else:
+        elif mode == "force-replace" or fw_key not in frameworks:
+            # force-replace discards any SCF-derived entry; "key not present"
+            # has nothing to discard. Both build a fresh entry from override
+            # data — same code path.
             entry = OrderedDict([("controlId", fw_data["controlId"])])
             title = resolve_title(fw_data["controlId"], fw_key, titles)
             if title:
@@ -719,6 +724,16 @@ def apply_fw_overrides(
             if "reason" in fw_data:
                 entry["reason"] = fw_data["reason"]
             frameworks[fw_key] = entry
+        else:
+            # mode == "replace" (default) and key already present (SCF
+            # derivation produced it). Keep the SCF-supplied controlId and
+            # any extras (title, profiles), but tag the entry with
+            # manual-override provenance — the curator's deliberate decision
+            # to assert this mapping shouldn't be lost just because SCF
+            # produced the same.
+            frameworks[fw_key]["source"] = "manual-override"
+            if "reason" in fw_data:
+                frameworks[fw_key]["reason"] = fw_data["reason"]
 
 
 def derive_frameworks(

--- a/tests/migration-3.0.Tests.ps1
+++ b/tests/migration-3.0.Tests.ps1
@@ -61,6 +61,16 @@ Describe 'Migration v3.0 — framework-overrides round-trip' -Skip:(-not $script
         $registry = Get-Content $registryPath -Raw | ConvertFrom-Json
         $script:checksById = @{}
         foreach ($c in $registry.checks) { $script:checksById[$c.checkId] = $c }
+
+        # Checks intentionally re-targeted post-migration via the `force-replace`
+        # override mode. Each entry documents why the v2.23 override controlId
+        # is no longer literally present in the registry — distinguishes
+        # "deliberate retarget" from "accidental data loss in migration."
+        $script:postMigrationRetargets = @{
+            'ENTRA-TOU-001' = @{
+                soc2 = '#316: CC2 family is non-automatable per soc2-tsc.json; force-replaced from CC2.2 to CC5 (Control Activities)'
+            }
+        }
     }
 
     It 'Every override entry maps to a check that exists in registry.json' {
@@ -82,12 +92,21 @@ Describe 'Migration v3.0 — framework-overrides round-trip' -Skip:(-not $script
                 $actual | Should -Not -BeNullOrEmpty `
                     -Because "$checkId.frameworks.$fwId must exist after migration"
 
-                # Inclusion semantics handles all three cases uniformly:
-                # - Pure addition (key absent): actual.controlId == override.controlId
-                # - Replace with SCF collision: override.controlId is one of actual's IDs
-                # - Append mode: override.controlId is appended to existing IDs
-                $actual.controlId | Should -Match ([regex]::Escape($expected.controlId)) `
-                    -Because "$checkId.frameworks.$fwId.controlId must include the override id (got '$($actual.controlId)', expected to contain '$($expected.controlId)')"
+                # Skip the controlId-inclusion check for entries deliberately
+                # re-targeted via force-replace post-migration. The mapping
+                # still exists with source=manual-override (asserted below);
+                # only the controlId value has changed by design.
+                $isRetarget = $script:postMigrationRetargets.ContainsKey($checkId) `
+                    -and $script:postMigrationRetargets[$checkId].ContainsKey($fwId)
+
+                if (-not $isRetarget) {
+                    # Inclusion semantics handles three cases uniformly:
+                    # - Pure addition (key absent): actual.controlId == override.controlId
+                    # - Replace with SCF collision: override.controlId is one of actual's IDs
+                    # - Append mode: override.controlId is appended to existing IDs
+                    $actual.controlId | Should -Match ([regex]::Escape($expected.controlId)) `
+                        -Because "$checkId.frameworks.$fwId.controlId must include the override id (got '$($actual.controlId)', expected to contain '$($expected.controlId)')"
+                }
 
                 $actual.source | Should -Be 'manual-override' `
                     -Because "$checkId.frameworks.$fwId must carry source=manual-override post-migration"

--- a/tests/test_build_registry_overrides.py
+++ b/tests/test_build_registry_overrides.py
@@ -1,0 +1,98 @@
+"""Tests for apply_fw_overrides in Build-Registry.py — covers all three override modes."""
+import importlib.util
+from collections import OrderedDict
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "Build-Registry.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("build_registry", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def br():
+    return _load_module()
+
+
+@pytest.fixture
+def titles():
+    return {
+        "soc2": {"CC5": "Control Activities", "CC2.2": "COSO Principle 14: Internal Communication"},
+        "nist-csf": {"PR.AA-01": "Identities and credentials are managed"},
+    }
+
+
+def test_replace_default_fills_when_key_absent(br, titles):
+    frameworks = OrderedDict()
+    overrides = {"nist-csf": {"controlId": "PR.AA-01"}}
+    br.apply_fw_overrides(frameworks, overrides, titles)
+    assert frameworks["nist-csf"]["controlId"] == "PR.AA-01"
+    assert frameworks["nist-csf"]["title"] == "Identities and credentials are managed"
+    assert frameworks["nist-csf"]["source"] == "manual-override"
+
+
+def test_replace_default_preserves_scf_controlid_when_present(br, titles):
+    frameworks = OrderedDict({
+        "soc2": OrderedDict([("controlId", "CC2.2"), ("title", "COSO Principle 14: Internal Communication")]),
+    })
+    overrides = {"soc2": {"controlId": "CC5"}}
+    br.apply_fw_overrides(frameworks, overrides, titles)
+    assert frameworks["soc2"]["controlId"] == "CC2.2", \
+        "default 'replace' mode must NOT overwrite SCF-derived controlId"
+    assert frameworks["soc2"]["source"] == "manual-override", \
+        "the override should still tag provenance"
+
+
+def test_append_merges_into_existing(br, titles):
+    frameworks = OrderedDict({
+        "soc2": OrderedDict([("controlId", "CC2.2")]),
+    })
+    overrides = {"soc2": {"controlId": "CC5", "mode": "append"}}
+    br.apply_fw_overrides(frameworks, overrides, titles)
+    assert "CC2.2" in frameworks["soc2"]["controlId"]
+    assert "CC5" in frameworks["soc2"]["controlId"]
+    assert frameworks["soc2"]["source"] == "manual-override"
+
+
+def test_force_replace_discards_scf_entry(br, titles):
+    """The motivating fix for #316: SCF maps SEA-18 to soc2 CC2.2, but
+    CC2 is non-automatable per soc2-tsc.json. force-replace must let the
+    curator land cleanly on CC5 instead."""
+    frameworks = OrderedDict({
+        "soc2": OrderedDict([
+            ("controlId", "CC2.2"),
+            ("title", "COSO Principle 14: Internal Communication"),
+        ]),
+    })
+    overrides = {"soc2": {"controlId": "CC5", "mode": "force-replace", "reason": "CC2 is non-automatable"}}
+    br.apply_fw_overrides(frameworks, overrides, titles)
+    assert frameworks["soc2"]["controlId"] == "CC5"
+    assert frameworks["soc2"]["title"] == "Control Activities", \
+        "force-replace must look up the title for the new controlId, not preserve SCF's"
+    assert frameworks["soc2"]["source"] == "manual-override"
+    assert frameworks["soc2"]["reason"] == "CC2 is non-automatable"
+
+
+def test_force_replace_works_when_key_absent(br, titles):
+    """force-replace should still succeed if SCF didn't produce an entry —
+    the 'discard SCF' part is just a no-op in that case."""
+    frameworks = OrderedDict()
+    overrides = {"soc2": {"controlId": "CC5", "mode": "force-replace"}}
+    br.apply_fw_overrides(frameworks, overrides, titles)
+    assert frameworks["soc2"]["controlId"] == "CC5"
+    assert frameworks["soc2"]["source"] == "manual-override"
+
+
+def test_override_without_controlid_is_skipped(br, titles):
+    frameworks = OrderedDict({"soc2": OrderedDict([("controlId", "CC2.2")])})
+    overrides = {"soc2": {"mode": "force-replace"}}  # no controlId
+    br.apply_fw_overrides(frameworks, overrides, titles)
+    assert frameworks["soc2"]["controlId"] == "CC2.2", \
+        "overrides without a controlId must be skipped, not produce empty entries"


### PR DESCRIPTION
## Summary

- Adds a third override mode `force-replace` to `apply_fw_overrides()` in `scripts/Build-Registry.py`. Until now, the default `replace` mode silently became a no-op when SCF had already produced an entry for that framework — the curator had no way to override an SCF mapping that was wrong for the framework. `force-replace` builds a fresh framework entry from override data, discarding any SCF-derived value.
- Closes #316: re-targets `ENTRA-TOU-001` SOC 2 from `CC2.2` (Internal Communication, classified as `nonAutomatableCriteria` per `soc2-tsc.json`) to `CC5` (Control Activities — *"Security policies and procedures are in place and operating effectively"*) using the new mode.
- Updates the v3.0 migration round-trip test with a `postMigrationRetargets` exemption list so intentional `force-replace` retargets aren't flagged as data loss.

## Why this is needed

The SCF database maps SCF control `SEA-18` (System Use Notification) to SOC 2 `CC2.2`. But `data/frameworks/soc2-tsc.json` declares the entire CC2 family as `nonAutomatableCriteria` — those criteria require policy documentation review, not config-state checks. The registry was internally inconsistent: claiming we automatically score a criterion the framework definition says can't be automatically scored.

A simple `replace` override couldn't fix this because the existing logic preserved the SCF-derived `controlId` whenever the key was already present. Two real options remained: live with the inconsistency, or teach the build a "this SCF mapping is wrong, use mine" mode. This PR is the latter.

## Three override modes after this change

| Mode | Behavior when SCF already produced the key | Use when |
|---|---|---|
| `replace` (default) | Keeps SCF's controlId; tags with `source: manual-override` | The curator's mapping agrees with SCF and they only want to assert provenance |
| `append` | Merges override controlId into existing entry | Both SCF's mapping and the curator's mapping should be expressed |
| `force-replace` *(new)* | Discards SCF's entry entirely; rebuilds from override data | SCF's mapping is wrong for the framework |

## Files

- `scripts/Build-Registry.py` — `apply_fw_overrides()` gains `force-replace` branch; refactored the duplicated entry-builder so `force-replace` and the "key absent" path share one code path. Docstring expanded with all three modes' semantics.
- `data/scf-check-mapping.json` — `ENTRA-TOU-001` SOC 2 override updated: `controlId: "CC5"`, `mode: "force-replace"`, with a `reason` field documenting the SCF-vs-framework conflict.
- `data/registry.json` — `ENTRA-TOU-001` `frameworks.soc2` reflects what Build-Registry would emit (CC5, title "Control Activities", source manual-override, reason). Hand-mirrored since `scf.db` isn't accessible in the dev environment; CI will rebuild and confirm.
- `tests/test_build_registry_overrides.py` — new pytest covering all three modes including the `force-replace` + key-absent corner case and the empty-controlId guard.
- `tests/migration-3.0.Tests.ps1` — `postMigrationRetargets` exemption list lets the framework-overrides round-trip test distinguish intentional retargets from accidental data loss. First entry: `ENTRA-TOU-001.soc2` with the issue reference and the reason.
- `CHANGELOG.md` — `[Unreleased]` entry under Added/Fixed/Changed.

## Test plan

- [x] Pester suite (49/49 real assertions pass on the touched test files; 2 environmental failures from missing local Python — CI has Python and will run them)
- [ ] CI: `validate-data` job (registry JSON schema validation)
- [ ] CI: `data-quality` job (`Test-RegistryData.ps1`)
- [ ] CI: `python-validate` job (Build-Registry.py compiles, new pytest passes)
- [ ] CI: `mapping-count-regression` job — expected delta: SOC 2 mapping count drops by 1 for CC2.2 and gains 1 for CC5 (net zero per-framework, no regression)
- [ ] CI: `enrichment-metrics` job — informational only, no expected change
- [ ] Spot-check `ENTRA-TOU-001` in registry: `frameworks.soc2.controlId == "CC5"`, `title == "Control Activities"`, `source == "manual-override"`, `reason` populated

## Out of scope

- Other potential SCF-disagreement cases. This PR only re-targets the one check called out in #316. If more surface during the v3.4.0 audit (#326), each gets its own `force-replace` override + reason.
- `framework-titles.json` content — already has CC5 as "Control Activities", no change needed.
- The taxonomy spike (#317) — unrelated track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
