### PR TITLE
fix: NIST CSF override on ENTRA-PASSWORD-003/004 (closes #253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **`ENTRA-TOU-001` SOC 2 mapping** ([#316](https://github.com/Galvnyz/CheckID/issues/316)). Changed from `CC2.2` (Internal Communication, classified as non-automatable per `soc2-tsc.json`) to `CC5` (Control Activities — *"Security policies and procedures are in place and operating effectively"*) using the new `force-replace` mode. Terms of Use enforcement is automatable via Graph and is a textbook control activity, not an internal-communication policy review.
+- **`ENTRA-PASSWORD-003` and `ENTRA-PASSWORD-004` missing NIST CSF override** ([#253](https://github.com/Galvnyz/CheckID/issues/253)). Their three peers (`-001`, `-002`, `-005`) all carried `nist-csf: PR.AA-01`; the override author got partway through the family and stopped. Added the missing override on both — the password / smart-lockout / banned-password-list controls now consistently map to PR.AA-01 (Identities and credentials are managed). Surfaced during cross-session review with M365-Assess after the v2.22.1 SOC 2 pairing test caught the analogous SOC 2 gap; this is the NIST CSF equivalent.
 
 ### Changed
 

--- a/data/registry.json
+++ b/data/registry.json
@@ -10232,6 +10232,11 @@
         },
         "iso-27002": {
           "controlId": "5.17;5.18"
+        },
+        "nist-csf": {
+          "controlId": "PR.AA-01",
+          "title": "Identities and credentials for authorized users, services, and hardware are managed by the organization",
+          "source": "manual-override"
         }
       },
       "impactRating": {
@@ -41146,6 +41151,11 @@
         },
         "eidsca": {
           "controlId": "EIDSCA.PR01;EIDSCA.PR02",
+          "source": "manual-override"
+        },
+        "nist-csf": {
+          "controlId": "PR.AA-01",
+          "title": "Identities and credentials for authorized users, services, and hardware are managed by the organization",
           "source": "manual-override"
         }
       },

--- a/data/scf-check-mapping.json
+++ b/data/scf-check-mapping.json
@@ -9037,6 +9037,9 @@
         },
         "eidsca": {
           "controlId": "EIDSCA.PR01;EIDSCA.PR02"
+        },
+        "nist-csf": {
+          "controlId": "PR.AA-01"
         }
       }
     },
@@ -9073,7 +9076,12 @@
           "url": "https://learn.microsoft.com/en-us/entra/identity/authentication/concept-password-ban-bad",
           "title": "Microsoft Learn — Eliminate bad passwords using Microsoft Entra Password Protection"
         }
-      ]
+      ],
+      "frameworkOverrides": {
+        "nist-csf": {
+          "controlId": "PR.AA-01"
+        }
+      }
     },
     {
       "checkId": "SPO-SYNC-002",


### PR DESCRIPTION
## Summary

Closes #253. The five `ENTRA-PASSWORD-*` checks form a tight family — all `collector: Entra`, all on password / smart-lockout / banned-password-list policy. Three of them (`-001`, `-002`, `-005`) carry the manual override `nist-csf: PR.AA-01`; `-003` and `-004` didn't, despite addressing the same control surface. Looks like the override author got partway through the family and stopped.

## Before / after

```
                       BEFORE                AFTER
ENTRA-PASSWORD-001     PR.AA-01              PR.AA-01
ENTRA-PASSWORD-002     PR.AA-01              PR.AA-01
ENTRA-PASSWORD-003     MISSING               PR.AA-01
ENTRA-PASSWORD-004     MISSING               PR.AA-01
ENTRA-PASSWORD-005     PR.AA-01              PR.AA-01
```

## Mechanics

Both checks lacked any SCF-derived `nist-csf` mapping, so a default `replace`-mode override hits the "key absent" branch in `apply_fw_overrides()` and creates a fresh entry from override data — no `force-replace` needed (that's reserved for cases like #316 where SCF disagrees).

## Files

- `data/scf-check-mapping.json`:
  - `ENTRA-PASSWORD-003` — appended `nist-csf` to the existing `frameworkOverrides` block alongside `soc2` + `eidsca`
  - `ENTRA-PASSWORD-004` — gains a `frameworkOverrides` block from scratch
- `data/registry.json` — hand-mirrored what Build-Registry would emit (CI's rebuild will confirm)
- `CHANGELOG.md` — `[Unreleased]` / Fixed entry

## Test plan

- [x] Pester `tests/registry-integrity.Tests.ps1` + `tests/migration-3.0.Tests.ps1` — 46/46 pass locally
- [x] Verify family consistency: all 5 PASSWORD checks now resolve to `PR.AA-01`
- [ ] CI: validate-data + python-validate jobs (registry schema, JSON validation, Build-Registry compile)
- [ ] CI: mapping-count-regression job — expected delta: `nist-csf` mapping count gains 2 (additive, no regression)

## Note on PR.AA-01 vs PR.AA-04

The original issue noted:
> Caveat: PR.AA-01 ("Identities and credentials are issued, managed, ...") is what the peers use, but for Smart Lockout (-003) and SSPR (-004) a more precise CSF code might be PR.AA-04 (Authentication and access verification). Worth a quick framework-expert look before applying. The conservative move is to match the peer mapping (PR.AA-01) for consistency.

This PR takes the conservative route — match peer mapping for family consistency. If a follow-up audit (#326) decides PR.AA-04 is more precise for `-003`/`-004`, retargeting all five (or splitting `-001`/`-002` from `-003`/`-004`) is a separate content decision that can use the same override mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
