### PR TITLE
chore(ci): skip enrichment-metrics + mapping-count comments on doc-only PRs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,33 @@ on:
     branches: [main]
 
 jobs:
+  changes:
+    # Detect whether the PR touches files that affect registry / build output.
+    # Doc-only PRs (audit catalogs, CHANGELOG, LICENSES, tools/) skip the noisy
+    # informational jobs (enrichment-metrics, mapping-count-regression) since
+    # they emit identical sticky comments on every run regardless of delta —
+    # which emails the PR author for no signal. See `.github/CONTRIBUTING.md`
+    # if you add a new gating job whose output should differ on doc PRs.
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            source:
+              - 'data/**'
+              - 'scripts/**'
+              - 'CheckID.psd1'
+              - 'CheckID.psm1'
+              - '.github/workflows/**'
+
   lint:
     name: Lint PowerShell
     runs-on: ubuntu-latest
@@ -295,7 +322,8 @@ jobs:
 
   mapping-count-regression:
     name: Mapping Count Regression
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.source == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -358,7 +386,8 @@ jobs:
 
   enrichment-metrics:
     name: Enrichment Metrics
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.source == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: skip noisy informational PR comments on doc-only PRs.** The `enrichment-metrics` and `mapping-count-regression` jobs in `.github/workflows/validate.yml` now skip when a PR doesn't touch `data/`, `scripts/`, the module manifest, or the workflows themselves. Both jobs post sticky comments via `github-actions[bot]`; previously they fired on every PR including the v3.4.0 audit-doc series, emitting identical numbers and emailing the PR author for no signal. New `changes` job uses `dorny/paths-filter@v3` to detect source-affecting changes; gating happens via `needs: changes` + `if: needs.changes.outputs.source == 'true'`. PRs that legitimately change registry / build output still get the full sticky comments — only doc-only PRs are silent now.
+
 ### Documentation
 
 - **`docs/audits/conditional-access.md`** — first domain audit under the v3.4.0 umbrella ([#326](https://github.com/Galvnyz/CheckID/issues/326)). Resolves spike [#327](https://github.com/Galvnyz/CheckID/issues/327). Catalogs **42 canonical CA patterns** across 5 sub-domains (foundational, surface-area, external/guest, anti-pattern, modern 2024-2026), maps them against the registry's 26 existing CA-related checks, identifies **17 coverage gaps** to file as `feat:` issues, **6 narrative-refresh candidates**, and one consolidation opportunity (`ENTRA-CA-001` ↔ `CA-LEGACYAUTH-001`). Includes an AiTM defense matrix mapping CA controls to which adversary-in-the-middle phishing tradecraft they break, and a Graph endpoint detection-method appendix. Sets the methodology template for the remaining 13 v3.4.0 domain spikes.


### PR DESCRIPTION
## Summary

Silences the email-noise source you flagged: `github-actions[bot]` was posting/updating two sticky comments (`enrichment-metrics` + `mapping-count-regression`) on every PR, including the v3.4.0 audit-doc series. Both emitted identical numbers and emailed you for zero signal.

## Root cause

Both jobs in `.github/workflows/validate.yml` were gated only by `if: github.event_name == 'pull_request'`. Doc-only PRs trigger them anyway. Each sticky-comment update is a notification event → email to the PR author.

## Fix

Add a `changes` job using `dorny/paths-filter@v3` that detects source-affecting paths (`data/**`, `scripts/**`, `CheckID.psd1`, `CheckID.psm1`, `.github/workflows/**`). Gate the two noisy jobs via:

```yaml
needs: changes
if: github.event_name == 'pull_request' && needs.changes.outputs.source == 'true'
```

## Behavior matrix

| PR shape | Pester / schema validation | enrichment-metrics comment | mapping-count-regression comment |
|---|---|---|---|
| Source change (data/scripts/module/workflows) | ✅ runs | ✅ posts (current behavior) | ✅ posts (current behavior) |
| Doc-only (audit catalogs, CHANGELOG, LICENSES, tools/) | ✅ runs | **silent** | **silent** |

Other validate.yml jobs (lint, validate-data, data-quality, test, module-test, python-validate) are unchanged.

## Files

- `.github/workflows/validate.yml` — adds `changes` job + 2-line gating on the two noisy jobs (32 lines)
- `CHANGELOG.md` — `[Unreleased]` / Changed entry

## Test plan

- This PR itself touches `.github/workflows/**` so the `changes` job will report `source = true` → full validation runs (correct: workflow changes need to be validated)
- Future doc-only PRs will skip the two noisy jobs
- Future source PRs continue to get the full sticky-comment cycle

## Why now

Email noise from the v3.4.0 audit-doc series (12 PRs in two days, each emitting both comments multiple times during CI) is a real friction. Doing the structural fix now prevents it from continuing on the remaining audits (#335, #336) and any future doc-only work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
