### PR TITLE
chore(release): prepare v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-04-30
+
+**Theme:** Authoritative Narrative Audit & Coverage Closure. Fourteen domain pattern catalogs ([#326](https://github.com/Galvnyz/CheckID/issues/326), spikes [#327](https://github.com/Galvnyz/CheckID/issues/327)–[#340](https://github.com/Galvnyz/CheckID/issues/340)) review every existing check against authoritative Microsoft + community sources, surface coverage gaps, and propose canonical reference data files. Plus CIS M365 v6 enrichment infrastructure ([#347](https://github.com/Galvnyz/CheckID/issues/347)) with a consumer-side prose ingestion model that respects CIS SecureSuite licensing while letting members enrich locally. Additive-only release — no schema breakage.
+
 ### Changed
 
 - **CI: skip noisy informational PR comments on doc-only PRs.** The `enrichment-metrics` and `mapping-count-regression` jobs in `.github/workflows/validate.yml` now skip when a PR doesn't touch `data/`, `scripts/`, the module manifest, or the workflows themselves. Both jobs post sticky comments via `github-actions[bot]`; previously they fired on every PR including the v3.4.0 audit-doc series, emitting identical numbers and emailing the PR author for no signal. New `changes` job uses `dorny/paths-filter@v3` to detect source-affecting changes; gating happens via `needs: changes` + `if: needs.changes.outputs.source == 'true'`. PRs that legitimately change registry / build output still get the full sticky comments — only doc-only PRs are silent now.

--- a/CheckID.psd1
+++ b/CheckID.psd1
@@ -1,7 +1,7 @@
 @{
     # Module metadata
     RootModule        = 'CheckID.psm1'
-    ModuleVersion     = '3.0.0'
+    ModuleVersion     = '3.4.0'
     GUID              = 'a3b7c4d5-1e2f-4a5b-8c9d-0e1f2a3b4c5d'
     Author            = 'Galvnyz'
     CompanyName       = 'Galvnyz'

--- a/data/registry.json
+++ b/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "3.0.0",
+  "schemaVersion": "3.4.0",
   "dataVersion": "2026-04-30",
   "generatedFrom": "data/scf-check-mapping.json + SecFrame/SCF/scf.db + data/scf-framework-map.json + data/az-assess-source-checks.json",
   "checks": [

--- a/scripts/Build-Registry.py
+++ b/scripts/Build-Registry.py
@@ -41,7 +41,7 @@ if sys.stdout.encoding != "utf-8":
 SCRIPT_DIR = Path(__file__).parent
 REPO_ROOT = SCRIPT_DIR.parent
 
-SCHEMA_VERSION = "3.0.0"
+SCHEMA_VERSION = "3.4.0"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Reconciles the gap between M#42 (`v3.4.0 — Authoritative Narrative Audit & Coverage Closure`) closing on GitHub last week and no `v3.4.0` tag being cut at the time. All 16 milestone issues plus 4 adjacent fixes shipped to `main` between `v3.0.0` and current HEAD; this PR labels what shipped.

Step 1 of the milestone/release reconciliation plan discussed [here](https://github.com/Galvnyz/CheckID/issues). Subsequent steps (move #295 to v4.0.0, resolve #317 spike, sequence remaining minors) will follow as separate PRs.

## Changes

- Bump `CheckID.psd1` ModuleVersion `3.0.0` → `3.4.0`
- Bump `scripts/Build-Registry.py` SCHEMA_VERSION `3.0.0` → `3.4.0`
- Bump `data/registry.json` schemaVersion `3.0.0` → `3.4.0` (single-line)
- Move `CHANGELOG.md` `[Unreleased]` content into `[3.4.0] - 2026-04-30` with theme summary; new empty `[Unreleased]` section above

## Semver classification

**Additive-only — no breaking changes.** Schema gained optional fields:
- On `frameworks.cis-m365-v6.*`: `sectionNumber`, `assessmentStatus`, `cisSafeguardsByVersion`, `defaultValue`, `references`
- On `frameworkMapping.*`: `cisAuthored` block (consumer-side ingestion path)

Existing v3.0 consumers continue to work unchanged. No removed fields. No type changes. The `ConvertTo-LegacyRemediationString` deprecation shim from v3.0.0 is **still present** — its removal (#295) belongs in v4.0.0, not v3.3.0 as currently scheduled.

## What shipped (per CHANGELOG)

**14 domain pattern catalogs** (#326 umbrella, spikes #327–#340): conditional access, privileged access, MFA enforcement, authentication methods, token + session security, external collaboration, defender for office, sharepoint + onedrive, teams, mail flow, intune, defender for cloud apps, power platform, purview.

**CIS M365 v6 enrichment infrastructure** (#347):
- Phase 1: optional factual metadata fields (sectionNumber, assessmentStatus, cisSafeguardsByVersion, defaultValue, references)
- Phase 2: consumer-side prose ingestion model (`tools/import-cis-prose.py` + `cisAuthored` schema block) respecting CIS SecureSuite licensing
- Architecture refinement: `data/registry.json` always prose-free; `data/registry.local.json` (gitignored) carries merged prose when consumer artifact present

**Force-replace override mode** (#316): new `mode: "force-replace"` in `apply_fw_overrides()` for cases where SCF mapping needs to be discarded rather than appended.

**Adjacent fixes:**
- `ENTRA-TOU-001` SOC 2 mapping retargeted CC2.2 → CC5 (#316)
- `ENTRA-PASSWORD-003/004` missing NIST CSF override added (#253)
- HIPAA framework taxonomy expanded to cover Privacy + Breach Notification subparts (#325)
- `ENTRA-SSPR-001` rebadged to MFA Registration Campaign semantics (#355)
- 24 stale CIS M365 v6.0 recommendation IDs reconciled to v6.0.1 (#352)

## Test plan

- [ ] Verify CHANGELOG diff is structurally clean (`[Unreleased]` empty above, `[3.4.0]` populated)
- [ ] Confirm `Get-Module CheckID -ListAvailable` reports 3.4.0 after merge + repull
- [ ] Re-run `python scripts/Build-Registry.py` and confirm `schemaVersion: "3.4.0"` is emitted
- [ ] CI passes (Pester gates + dup-key + mapping-count regression)

## After merge (deferred to user approval)

Per established release pattern (see #315 for v3.0.0 precedent):

- [ ] `git tag -a v3.4.0 -m "v3.4.0 — Authoritative Narrative Audit & Coverage Closure"`
- [ ] `git push origin v3.4.0`
- [ ] Draft + publish GitHub release with the CHANGELOG `[3.4.0]` body
- [ ] Re-milestone misfiled issues (#316, #325, #253 from v3.2.0 → v3.4.0; #352, #355 from Backlog → v3.4.0)
- [ ] Continue with Step 2 of plan: carve `v4.0.0` milestone for #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)