### PR TITLE
chore(gitignore): ignore Python bytecode caches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,10 @@ coverage.xml
 *.clixml
 *_transcript_*.txt
 
+# Python artifacts (Build-Registry.py et al.; py_compile runs in CI)
+__pycache__/
+*.py[cod]
+
 # Module cache (local installs)
 Modules/
 


### PR DESCRIPTION
## Summary

The root `.gitignore` had no Python section, so `python -m py_compile scripts/Build-Registry.py` — run by the CI `validate.yml` workflow and during local registry-build verification — leaves `scripts/__pycache__/*.pyc` **untracked**, where a `git add -A` will stage it. (This happened during the #408 work and the artifact had to be manually unstaged.)

Adds a Python artifacts section after the PowerShell block:

```
# Python artifacts (Build-Registry.py et al.; py_compile runs in CI)
__pycache__/
*.py[cod]
```

## Verification

Reproduced the exact scenario in a clean worktree:

- `python -m py_compile scripts/Build-Registry.py` → creates `scripts/__pycache__/Build-Registry.cpython-313.pyc`
- `git status --short` → shows only ` M .gitignore`; the artifact does **not** appear
- `git status --ignored` → classifies it `!! scripts/__pycache__/`
- `git check-ignore -v` → `.pyc` matches `__pycache__/`, and a stray `foo.pyc` matches `*.py[cod]`

No other files touched.
