### PR TITLE
feat(frameworks): own grouping/taxonomy upstream - fix M365-Assess sync regression + v3.5.0 render-taxonomy

### DIFF
--- a/data/frameworks.schema.json
+++ b/data/frameworks.schema.json
@@ -94,9 +94,60 @@
     "colors": {
       "$ref": "#/definitions/colorTheme",
       "description": "Optional top-level light/dark theme colors. Some frameworks (CIS) declare colors per scoring profile instead."
+    },
+    "groupBy": {
+      "type": "string",
+      "enum": [
+        "section-prefix",
+        "dot-prefix",
+        "family-letter-prefix",
+        "soc2-tsc-prefix",
+        "essential-eight-practice",
+        "scuba-service",
+        "hipaa-section",
+        "article-prefix",
+        "nist-800-171-family"
+      ],
+      "description": "Render-taxonomy strategy: names the parser a consumer applies to a controlId to derive its group key. Pairs with 'groups' (or the 'sections'/'controls' variants). Omit when the framework has no native grouping axis and declare 'taxonomyDecision' instead."
+    },
+    "groupLabel": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Singular noun for one group under this framework's axis (e.g. 'section', 'family', 'clause', 'article', 'service')."
+    },
+    "groups": {
+      "$ref": "#/definitions/groupMap",
+      "description": "controlId-prefix -> display label, per the 'groupBy' strategy. Must cover every prefix produced from registry.json controlIds (enforced by tests/framework-grouping-coverage.Tests.ps1)."
+    },
+    "sections": {
+      "$ref": "#/definitions/groupMap",
+      "description": "Variant of 'groups' used by CIS section-numbered frameworks (e.g. cis-m365-v6). Same shape and coverage contract."
+    },
+    "controls": {
+      "$ref": "#/definitions/groupMap",
+      "description": "Variant of 'groups' used by CIS Controls v8 (top-level control families). Same shape and coverage contract."
+    },
+    "taxonomyDecision": {
+      "type": "string",
+      "enum": ["domain-fallback"],
+      "description": "Declared when a framework intentionally has no native grouping axis. 'domain-fallback' tells consumers to group by the M365-Assess product domain instead. Pairs with 'taxonomyReason'."
+    },
+    "taxonomyReason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Human-readable justification for a 'taxonomyDecision' — why no native axis is provided and how to enable one later."
     }
   },
   "definitions": {
+    "groupMap": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      },
+      "description": "Map of controlId-prefix (string key) to human-readable display label."
+    },
     "colorTheme": {
       "type": "object",
       "required": ["light", "dark"],

--- a/data/frameworks/cis-controls-v8.json
+++ b/data/frameworks/cis-controls-v8.json
@@ -42,6 +42,8 @@
       "color": "#60A5FA"
     }
   },
+  "groupBy": "section-prefix",
+  "groupLabel": "control",
   "controls": {
     "1": "Inventory and Control of Enterprise Assets",
     "2": "Inventory and Control of Software Assets",

--- a/data/frameworks/cis-m365-v6.json
+++ b/data/frameworks/cis-m365-v6.json
@@ -69,9 +69,11 @@
     "1": "Identity",
     "2": "Defender",
     "3": "Purview",
+    "4": "Intune",
     "5": "Entra ID",
     "6": "Exchange Online",
     "7": "SharePoint & OneDrive",
-    "8": "Teams"
+    "8": "Teams",
+    "9": "Fabric (Power BI)"
   }
 }

--- a/data/frameworks/cisa-scuba.json
+++ b/data/frameworks/cisa-scuba.json
@@ -42,5 +42,16 @@
       "color": "#FDBA74"
     }
   },
-  "controlIdFormat": "MS.{product}.{number}v{version}"
+  "controlIdFormat": "MS.{product}.{number}v{version}",
+  "groupBy": "scuba-service",
+  "groupLabel": "service",
+  "groups": {
+    "MS.AAD": "Azure AD / Entra ID",
+    "MS.EXO": "Exchange Online",
+    "MS.DEFENDER": "Microsoft Defender",
+    "MS.INTUNE": "Intune",
+    "MS.POWERPLATFORM": "Power Platform",
+    "MS.SHAREPOINT": "SharePoint",
+    "MS.TEAMS": "Teams"
+  }
 }

--- a/data/frameworks/cmmc.json
+++ b/data/frameworks/cmmc.json
@@ -38,5 +38,25 @@
       "background": "#134E4A",
       "color": "#5EEAD4"
     }
+  },
+  "groupBy": "family-letter-prefix",
+  "groupLabel": "family",
+  "groups": {
+    "AC": "Access Control",
+    "AT": "Awareness & Training",
+    "AU": "Audit & Accountability",
+    "CA": "Security Assessment",
+    "CM": "Configuration Management",
+    "CP": "Contingency Planning",
+    "IA": "Identification & Authentication",
+    "IR": "Incident Response",
+    "MA": "Maintenance",
+    "MP": "Media Protection",
+    "PE": "Physical Protection",
+    "PS": "Personnel Security",
+    "RA": "Risk Assessment",
+    "SC": "System & Communications Protection",
+    "SI": "System & Information Integrity",
+    "SR": "Supply Chain Risk Management"
   }
 }

--- a/data/frameworks/essential-eight.json
+++ b/data/frameworks/essential-eight.json
@@ -85,5 +85,17 @@
       "background": "#713F12",
       "color": "#FDE047"
     }
+  },
+  "groupBy": "essential-eight-practice",
+  "groupLabel": "strategy",
+  "groups": {
+    "1": "Application Control",
+    "2": "Patch Applications",
+    "3": "Configure MS Office Macros",
+    "4": "User Application Hardening",
+    "5": "Restrict Administrative Privileges",
+    "6": "Patch Operating Systems",
+    "7": "Multi-Factor Authentication",
+    "8": "Regular Backups"
   }
 }

--- a/data/frameworks/fedramp.json
+++ b/data/frameworks/fedramp.json
@@ -47,5 +47,29 @@
       "background": "#1E3A5F",
       "color": "#93C5FD"
     }
+  },
+  "groupBy": "family-letter-prefix",
+  "groupLabel": "family",
+  "groups": {
+    "AC": "Access Control",
+    "AT": "Awareness & Training",
+    "AU": "Audit & Accountability",
+    "CA": "Assessment, Authorization & Monitoring",
+    "CM": "Configuration Management",
+    "CP": "Contingency Planning",
+    "IA": "Identification & Authentication",
+    "IR": "Incident Response",
+    "MA": "Maintenance",
+    "MP": "Media Protection",
+    "PE": "Physical & Environmental Protection",
+    "PL": "Planning",
+    "PM": "Program Management",
+    "PS": "Personnel Security",
+    "PT": "PII Processing & Transparency",
+    "RA": "Risk Assessment",
+    "SA": "System & Services Acquisition",
+    "SC": "System & Communications Protection",
+    "SI": "System & Information Integrity",
+    "SR": "Supply Chain Risk Management"
   }
 }

--- a/data/frameworks/gdpr.json
+++ b/data/frameworks/gdpr.json
@@ -21,5 +21,13 @@
   },
   "scoring": {
     "method": "control-coverage"
+  },
+  "groupBy": "article-prefix",
+  "groupLabel": "article",
+  "groups": {
+    "5": "Principles Relating to Processing",
+    "32": "Security of Processing",
+    "33": "Breach Notification to Supervisory Authority",
+    "34": "Breach Communication to Data Subject"
   }
 }

--- a/data/frameworks/hipaa.json
+++ b/data/frameworks/hipaa.json
@@ -103,5 +103,25 @@
       "background": "#831843",
       "color": "#F9A8D4"
     }
+  },
+  "groupBy": "hipaa-section",
+  "groupLabel": "safeguard",
+  "groups": {
+    "306": "General Rules",
+    "308": "Administrative Safeguards",
+    "310": "Physical Safeguards",
+    "312": "Technical Safeguards",
+    "314": "Organizational Requirements",
+    "316": "Policies, Procedures & Documentation",
+    "404": "Breach Notification to Individuals",
+    "408": "Breach Notification to the Secretary",
+    "412": "Law Enforcement Delay",
+    "506": "Treatment, Payment & Health Care Operations",
+    "508": "Authorization Requirements",
+    "510": "Opportunity to Agree or Object",
+    "512": "Uses & Disclosures Without Authorization",
+    "514": "Other Privacy Requirements",
+    "530": "Privacy Administrative Requirements",
+    "532": "Transition Provisions"
   }
 }

--- a/data/frameworks/iso-27001.json
+++ b/data/frameworks/iso-27001.json
@@ -39,5 +39,16 @@
       "background": "#064E3B",
       "color": "#6EE7B7"
     }
+  },
+  "groupBy": "section-prefix",
+  "groupLabel": "clause",
+  "groups": {
+    "4": "Context of the Organization",
+    "5": "Organizational Controls (A.5)",
+    "6": "People Controls (A.6)",
+    "7": "Physical Controls (A.7)",
+    "8": "Technological Controls (A.8)",
+    "9": "Performance Evaluation",
+    "10": "Improvement"
   }
 }

--- a/data/frameworks/iso-27017.json
+++ b/data/frameworks/iso-27017.json
@@ -21,5 +21,23 @@
       "background": "#082f49",
       "color": "#7dd3fc"
     }
+  },
+  "groupBy": "section-prefix",
+  "groupLabel": "clause",
+  "groups": {
+    "5": "Information Security Policies",
+    "6": "Organization of Information Security",
+    "7": "Human Resource Security",
+    "8": "Asset Management",
+    "9": "Access Control",
+    "10": "Cryptography",
+    "11": "Physical & Environmental Security",
+    "12": "Operations Security",
+    "13": "Communications Security",
+    "14": "System Acquisition, Development & Maintenance",
+    "15": "Supplier Relationships",
+    "16": "Information Security Incident Management",
+    "17": "Information Security Aspects of Business Continuity Management",
+    "18": "Compliance"
   }
 }

--- a/data/frameworks/mitre-attack.json
+++ b/data/frameworks/mitre-attack.json
@@ -67,5 +67,7 @@
     }
   },
   "controlIdFormat": "T{number}[.{sub}]",
-  "note": "totalControls reflects techniques referenced in CheckID mappings, not the full ATT&CK matrix (356+ techniques)."
+  "note": "totalControls reflects techniques referenced in CheckID mappings, not the full ATT&CK matrix (356+ techniques).",
+  "taxonomyDecision": "domain-fallback",
+  "taxonomyReason": "ATT&CK technique IDs (e.g. T1078.004) do not encode tactics. Many M365-Assess checks map to 100+ techniques each (semicolon-separated), and a single technique can serve multiple tactics — making any per-check tactic grouping ambiguous. Native taxonomy intentionally not provided; report falls back to M365-Assess domain breakdown. To enable: ship a technique → tactic lookup table and decide how to handle multi-tactic techniques. See issue #845 + docs/SCORING.md."
 }

--- a/data/frameworks/nis2.json
+++ b/data/frameworks/nis2.json
@@ -21,5 +21,11 @@
       "background": "#083344",
       "color": "#67e8f9"
     }
+  },
+  "groupBy": "article-prefix",
+  "groupLabel": "article",
+  "groups": {
+    "21": "Cybersecurity Risk-Management Measures",
+    "23": "Reporting Obligations"
   }
 }

--- a/data/frameworks/nist-800-171.json
+++ b/data/frameworks/nist-800-171.json
@@ -21,5 +21,24 @@
       "background": "#431407",
       "color": "#fb923c"
     }
+  },
+  "groupBy": "nist-800-171-family",
+  "groupLabel": "family",
+  "groups": {
+    "3.1": "Access Control",
+    "3.2": "Awareness & Training",
+    "3.3": "Audit & Accountability",
+    "3.4": "Configuration Management",
+    "3.5": "Identification & Authentication",
+    "3.6": "Incident Response",
+    "3.7": "Maintenance",
+    "3.8": "Media Protection",
+    "3.9": "Personnel Security",
+    "3.10": "Physical Protection",
+    "3.11": "Risk Assessment",
+    "3.12": "Security Assessment",
+    "3.13": "System & Communications Protection",
+    "3.14": "System & Information Integrity",
+    "NFO": "Non-Federal Organization Controls"
   }
 }

--- a/data/frameworks/nist-800-53-r5.json
+++ b/data/frameworks/nist-800-53-r5.json
@@ -67,5 +67,29 @@
       "background": "#1E3A5F",
       "color": "#93C5FD"
     }
+  },
+  "groupBy": "family-letter-prefix",
+  "groupLabel": "family",
+  "groups": {
+    "AC": "Access Control",
+    "AT": "Awareness & Training",
+    "AU": "Audit & Accountability",
+    "CA": "Assessment, Authorization & Monitoring",
+    "CM": "Configuration Management",
+    "CP": "Contingency Planning",
+    "IA": "Identification & Authentication",
+    "IR": "Incident Response",
+    "MA": "Maintenance",
+    "MP": "Media Protection",
+    "PE": "Physical & Environmental Protection",
+    "PL": "Planning",
+    "PM": "Program Management",
+    "PS": "Personnel Security",
+    "PT": "PII Processing & Transparency",
+    "RA": "Risk Assessment",
+    "SA": "System & Services Acquisition",
+    "SC": "System & Communications Protection",
+    "SI": "System & Information Integrity",
+    "SR": "Supply Chain Risk Management"
   }
 }

--- a/data/frameworks/nist-csf.json
+++ b/data/frameworks/nist-csf.json
@@ -47,5 +47,15 @@
       "background": "#78350F",
       "color": "#FCD34D"
     }
+  },
+  "groupBy": "dot-prefix",
+  "groupLabel": "function",
+  "groups": {
+    "GV": "Govern",
+    "ID": "Identify",
+    "PR": "Protect",
+    "DE": "Detect",
+    "RS": "Respond",
+    "RC": "Recover"
   }
 }

--- a/data/frameworks/pci-dss-v4.json
+++ b/data/frameworks/pci-dss-v4.json
@@ -59,5 +59,21 @@
       "background": "#7F1D1D",
       "color": "#FCA5A5"
     }
+  },
+  "groupBy": "section-prefix",
+  "groupLabel": "requirement",
+  "groups": {
+    "1": "Network Security Controls",
+    "2": "Secure Configurations",
+    "3": "Protect Stored Account Data",
+    "4": "Protect Cardholder Data in Transit",
+    "5": "Protect Against Malicious Software",
+    "6": "Develop & Maintain Secure Systems",
+    "7": "Restrict Access by Need-to-Know",
+    "8": "Identify Users & Authenticate Access",
+    "9": "Restrict Physical Access",
+    "10": "Log & Monitor All Access",
+    "11": "Test Security Regularly",
+    "12": "Information Security Policy"
   }
 }

--- a/data/frameworks/pci-dss-v4.json
+++ b/data/frameworks/pci-dss-v4.json
@@ -74,6 +74,9 @@
     "9": "Restrict Physical Access",
     "10": "Log & Monitor All Access",
     "11": "Test Security Regularly",
-    "12": "Information Security Policy"
+    "12": "Information Security Policy",
+    "A1": "Additional Requirements for Multi-Tenant Service Providers",
+    "A2": "Additional Requirements for Entities Using SSL/Early TLS",
+    "A3": "Designated Entities Supplemental Validation (DESV)"
   }
 }

--- a/data/frameworks/soc2-tsc.json
+++ b/data/frameworks/soc2-tsc.json
@@ -103,5 +103,14 @@
       "background": "#1E3A5F",
       "color": "#60A5FA"
     }
+  },
+  "groupBy": "soc2-tsc-prefix",
+  "groupLabel": "criteria",
+  "groups": {
+    "CC": "Common Criteria (Security)",
+    "A": "Availability",
+    "C": "Confidentiality",
+    "P": "Privacy",
+    "PI": "Processing Integrity"
   }
 }

--- a/data/frameworks/stig.json
+++ b/data/frameworks/stig.json
@@ -36,5 +36,7 @@
       "color": "#C4B5FD"
     }
   },
-  "controlIdFormat": "V-{number}"
+  "controlIdFormat": "V-{number}",
+  "taxonomyDecision": "domain-fallback",
+  "taxonomyReason": "STIG rule IDs (V-NNNNNN) are opaque — they don't encode product, category, or severity. CAT-I/II/III severity is published in the STIG XCCDF XML but not carried per-check in the registry's framework mapping. Native taxonomy intentionally not provided; report falls back to M365-Assess domain breakdown. To enable: extend the registry to carry per-check STIG severity, or maintain a rule-ID → category lookup. See issue #845 + docs/SCORING.md."
 }

--- a/tests/framework-grouping-coverage.Tests.ps1
+++ b/tests/framework-grouping-coverage.Tests.ps1
@@ -1,0 +1,97 @@
+# Validates the render-taxonomy contract (issue #407 / #318-#323):
+# every framework that declares a `groupBy` strategy must declare a group map
+# (`groups`, `sections`, or `controls`) whose keys cover EVERY group prefix
+# derivable from the controlIds present in data/registry.json. This is what stops
+# registry growth from silently landing in a downstream "Other" bucket.
+
+BeforeDiscovery {
+    $frameworkDir = Join-Path $PSScriptRoot '..' 'data' 'frameworks'
+    $script:groupedFrameworks = foreach ($file in Get-ChildItem -Path $frameworkDir -Filter '*.json') {
+        $json = Get-Content -Path $file.FullName -Raw | ConvertFrom-Json
+        if (-not $json.groupBy) { continue }
+        $map = if ($json.PSObject.Properties.Name -contains 'groups') { $json.groups }
+               elseif ($json.PSObject.Properties.Name -contains 'sections') { $json.sections }
+               elseif ($json.PSObject.Properties.Name -contains 'controls') { $json.controls }
+               else { $null }
+        @{
+            Name        = $file.BaseName
+            RegistryKey = $json.registryKey
+            Strategy    = $json.groupBy
+            GroupKeys   = if ($map) { @($map.PSObject.Properties.Name) } else { @() }
+        }
+    }
+}
+
+Describe 'Framework Group Coverage' {
+
+    BeforeAll {
+        # Parser per groupBy strategy: controlId -> group key. Mirrors the consumer
+        # contract documented on `groupBy` in data/frameworks.schema.json.
+        function Get-GroupKey {
+            param([string]$Strategy, [string]$ControlId)
+            switch ($Strategy) {
+                'section-prefix'           { return ($ControlId -split '\.')[0] }
+                'dot-prefix'               { return ($ControlId -split '\.')[0] }
+                'family-letter-prefix'     { return [regex]::Match($ControlId, '^[A-Za-z]+').Value }
+                'soc2-tsc-prefix'          { return [regex]::Match($ControlId, '^[A-Za-z]+').Value }
+                'essential-eight-practice' { return [regex]::Match($ControlId, 'P(\d+)').Groups[1].Value }
+                'article-prefix'           { return [regex]::Match($ControlId, '^Article\s+(\d+)').Groups[1].Value }
+                'scuba-service' {
+                    $p = $ControlId -split '\.'
+                    return $(if ($p.Count -ge 2) { $p[0..1] -join '.' } else { $ControlId })
+                }
+                'hipaa-section' {
+                    $p = $ControlId -split '\.'
+                    return $(if ($p.Count -gt 1) { $p[1] -replace '\D.*$', '' } else { $ControlId })
+                }
+                'nist-800-171-family' {
+                    if ($ControlId.ToUpper().StartsWith('NFO')) { return 'NFO' }
+                    $p = $ControlId -split '\.'
+                    return $(if ($p.Count -ge 2) { $p[0..1] -join '.' } else { $ControlId })
+                }
+                default { return $ControlId }
+            }
+        }
+
+        # Index registry controlIds by framework key (semicolon-split, trimmed).
+        $registryPath = Join-Path $PSScriptRoot '..' 'data' 'registry.json'
+        $registry = Get-Content -Path $registryPath -Raw | ConvertFrom-Json
+        $script:registryControlIds = @{}
+        foreach ($check in $registry.checks) {
+            foreach ($prop in $check.frameworks.PSObject.Properties) {
+                $val = $prop.Value
+                $cidString = if ($val -is [string]) { $val } else { $val.controlId }
+                if (-not $cidString) { continue }
+                if (-not $script:registryControlIds.ContainsKey($prop.Name)) {
+                    $script:registryControlIds[$prop.Name] = [System.Collections.Generic.HashSet[string]]::new()
+                }
+                foreach ($part in ($cidString -split ';')) {
+                    $t = $part.Trim()
+                    if ($t) { [void]$script:registryControlIds[$prop.Name].Add($t) }
+                }
+            }
+        }
+    }
+
+    Context '<Name>' -ForEach $groupedFrameworks {
+
+        It 'declares a non-empty group map' {
+            $GroupKeys.Count | Should -BeGreaterThan 0 `
+                -Because "framework '$Name' declares groupBy '$Strategy' so it must declare a groups/sections/controls map"
+        }
+
+        It 'every registry controlId resolves to a declared group' {
+            $declared = [System.Collections.Generic.HashSet[string]]::new([string[]]$GroupKeys)
+            $ids = if ($script:registryControlIds.ContainsKey($RegistryKey)) { $script:registryControlIds[$RegistryKey] } else { @() }
+
+            $uncovered = [System.Collections.Generic.HashSet[string]]::new()
+            foreach ($cid in $ids) {
+                $key = Get-GroupKey -Strategy $Strategy -ControlId $cid
+                if (-not $declared.Contains($key)) { [void]$uncovered.Add($key) }
+            }
+
+            ($uncovered | Sort-Object) -join ', ' | Should -BeNullOrEmpty `
+                -Because "every '$RegistryKey' controlId prefix (strategy '$Strategy') must map to a declared group"
+        }
+    }
+}


### PR DESCRIPTION
## Why

M365-Assess consumes CheckID's `data/frameworks/*.json` **verbatim** via its `sync-checkid.yml` workflow (see `REFERENCES.md`: "Fetch `data/registry.json` and `data/frameworks/*.json` from the tagged version"). The grouping/taxonomy presentation metadata that M365-Assess maintainers had hand-added downstream was never present in CheckID's source, so every sync overwrote it.

The v3.4.1 auto-sync PR Galvnyz/M365-Assess#989 dropped, among others:
- `cis-m365-v6` sections **"4": "Intune"** and **"9": "Fabric (Power BI)"**
- the `cisa-scuba` `groups` map including **`MS.INTUNE`**
- grouping/taxonomy metadata across ~12 more framework files

This PR makes CheckID the canonical owner of that metadata so the next sync is a no-op, and delivers the planned v3.5.0 render-taxonomy layer on top of it.

## What

**1. Stop the regression** (`fix(frameworks): carry grouping/taxonomy metadata ...`)
Restore `groupBy` / `groupLabel` / `groups` / `sections` / `taxonomyDecision` / `taxonomyReason` / `note` to the 14 frameworks #989 regressed. Verified byte-idempotent against M365-Assess base, so re-syncing produces zero grouping diff. Relabels 31 previously-orphaned registry checks (5 Intune `4.x`, 26 Power BI `9.x`) under their correct CIS M365 v6 sections.

**2. Backfill + completeness** (`feat(frameworks): backfill native grouping axes ...`)
Declare native axes for the 4 frameworks that had none (#323):

| framework | groupBy strategy | axis |
|---|---|---|
| iso-27017 | `section-prefix` | ISO/IEC 27002:2015 clauses 5-18 |
| nist-800-171 | `nist-800-171-family` (new) | families 3.1-3.14 + NFO bucket |
| gdpr | `article-prefix` (new) | GDPR articles |
| nis2 | `article-prefix` (new) | NIS2 articles |

Also completes **PCI-DSS**: adds appendix groups `A1` / `A2` / `A3`. The registry has appendix controls that the 1-12 requirement map did not cover (a latent "Other" bucket on the M365-Assess side too).

**3. Contract + enforcement** (`feat(frameworks): formalize render-taxonomy schema keys ...`)
Formalize the render-taxonomy keys in `data/frameworks.schema.json` (#407): `groupBy` (enum of 9 strategies), `groupLabel`, `groups` / `sections` / `controls`, `taxonomyDecision`, `taxonomyReason`. `additionalProperties` stays `true`; all 20 framework files validate. Add `tests/framework-grouping-coverage.Tests.ps1` asserting every registry controlId resolves to a declared group for each `groupBy` framework.

## New contract vocabulary (please review)

Two new `groupBy` strategy names join the cross-repo contract; consumers that render native grouping must implement them:
- `article-prefix` -- `^Article\s+(\d+)` -> article number (gdpr, nis2)
- `nist-800-171-family` -- `NFO*` -> `NFO`, else first two dot-segments (`3.12.1` -> `3.12`)

## Testing

- **409 Pester tests pass** (was 377; +32 from the new coverage test), 0 failures.
- All 20 framework files validate against the updated `frameworks.schema.json`.
- Idempotency confirmed: every edited file's grouping/taxonomy keys equal M365-Assess base.
- Group coverage: every `groupBy` framework's map covers 100% of registry controlId prefixes.

## Rollout

- Supersedes the grouping regression in Galvnyz/M365-Assess#989. After this is tagged, M365-Assess should re-run `sync-checkid` -- the framework files then sync clean.
- Release tag deferred to the maintainer.

Closes #318, #319, #320, #321, #322, #323, #407
Refs #317, #324, Galvnyz/M365-Assess#989
